### PR TITLE
feat: expand mysql db parameters jdbc url DEVOPS-709

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,21 +214,25 @@ helm unittest -u platform/
 
 ### Testing Changes Locally
 
-```bash
-# Render templates to inspect output
-helm template platform ./platform -f platform/values.yaml > output.yaml
+**IMPORTANT FOR AI ASSISTANTS**: Always use unit tests to verify changes. DO NOT use `helm template`
+to test changes during development as it requires multiple values to be set. The unit test suite is
+comprehensive and faster.
 
-# Run unit tests
+```bash
+# PRIMARY: Run unit tests (USE THIS TO VERIFY CHANGES)
 make -C platform test
 
-# Debug specific test
-helm unittest -d -f tests/configmap_test.yaml .
+# Update snapshots after intentional changes
+helm unittest -u platform/
 
-# Lint chart
-helm lint platform/
+# Debug specific test (when a test fails)
+helm unittest -d -f tests/configmap_test.yaml platform/
+```
 
-# Package chart
-make -C platform build
+**For manual inspection only (not for testing):**
+```bash
+# Render templates to inspect output (for human review only, not for automated testing)
+helm template platform ./platform -f platform/values.yaml > output.yaml
 ```
 
 ### Version Bumping

--- a/platform/Chart.yaml
+++ b/platform/Chart.yaml
@@ -20,7 +20,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "0.15.0"
+version: "0.16.0"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/platform/README.md
+++ b/platform/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart to deploy Seqera Platform (formerly known as Tower) on Kubernetes.
 
-![Version: 0.15.0](https://img.shields.io/badge/Version-0.15.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v25.2.3](https://img.shields.io/badge/AppVersion-v25.2.3-informational?style=flat-square)
+![Version: 0.16.0](https://img.shields.io/badge/Version-0.16.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v25.2.3](https://img.shields.io/badge/AppVersion-v25.2.3-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -47,7 +47,7 @@ Values in the `.redis` section take precedence over values in the `.global.redis
 To install the chart with the release name `my-release`:
 
 ```console
-helm install my-release oci://public.cr.seqera.io/charts/platform --version 0.15.0 --namespace my-namespace --create-namespace
+helm install my-release oci://public.cr.seqera.io/charts/platform --version 0.16.0 --namespace my-namespace --create-namespace
 ```
 
 For a list of available chart versions, visit the chart repository: https://public.cr.seqera.io/repo/charts/platform
@@ -76,6 +76,8 @@ For a list of available chart versions, visit the chart repository: https://publ
 | global.platformDatabase.existingSecretName | string | `""` | Name of an existing secret containing credentials for the Platform MySQL db. Note: the secret must already exist in the same namespace at the time of deployment, it can't be created by this chart with e.g. extraDeploy, since this chart will perform a lookup on the Kubernetes API server at install/upgrade time. |
 | global.platformDatabase.existingSecretKey | string | `"TOWER_DB_PASSWORD"` | Key in the existing secret containing the password for the Platform MySQL db. |
 | global.platformDatabase.driver | string | `"mariadb"` | Database driver. Possible options: "mariadb" (or its alias "mysql"). |
+| global.platformDatabase.connectionOptions | object | `{"mariadb":["permitMysqlScheme=true"]}` | Connection options to compose in the driver URL according to the driver used. The only driver that can be set is 'mariadb'. |
+| global.platformDatabase.connectionOptions.mariadb | list | `["permitMysqlScheme=true"]` | Connection options to use with the MariaDB driver. For the full list of supported options see: https://mariadb.com/docs/connectors/mariadb-connector-j/about-mariadb-connector-j |
 | global.platformDatabase.dialect | string | `"mysql-8"` | Hibernate dialect to use, depending on the database version. Possible options: mysql-8 (default), mariadb-10. |
 | global.platformDatabase.minPoolSize | string | `"2"` | Connection pool minimum size. |
 | global.platformDatabase.maxPoolSize | string | `"10"` | Connection pool maximum size. |

--- a/platform/templates/_helpers.tpl
+++ b/platform/templates/_helpers.tpl
@@ -97,6 +97,33 @@ Return the name of the secret containing the Platform database password.
 {{- end -}}
 
 {{/*
+Return the JDBC URL for the database connection, including connection options.
+Constructs URL in format: jdbc:mysql://host:port/database?option1=value1&option2=value2
+
+For now this template is built around the only driver that can be set, 'mariadb'.
+*/}}
+{{- define "platform.database.url" -}}
+  {{- $baseUrl := printf "jdbc:mysql://%s:%d/%s"
+  .Values.global.platformDatabase.host
+  (.Values.global.platformDatabase.port | int)
+  .Values.global.platformDatabase.database -}}
+  {{- $options := list -}}
+  {{/* Evaluate mysql first, so if both are defined we pick mariadb options. */}}
+  {{- if .Values.global.platformDatabase.connectionOptions.mysql -}}
+    {{- $options = .Values.global.platformDatabase.connectionOptions.mysql -}}
+  {{- end -}}
+  {{- if .Values.global.platformDatabase.connectionOptions.mariadb -}}
+    {{- $options = .Values.global.platformDatabase.connectionOptions.mariadb -}}
+  {{- end -}}
+
+  {{- if $options -}}
+    {{- printf "%s?%s" $baseUrl (join "&" $options) -}}
+  {{- else -}}
+    {{- $baseUrl -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
 Return the JDBC driver class name based on the selected database driver.
 */}}
 {{- define "platform.database.driver" -}}

--- a/platform/templates/configmap.yaml
+++ b/platform/templates/configmap.yaml
@@ -43,11 +43,7 @@ data:
 
   WAVE_SERVER_URL: {{ tpl .Values.platform.waveServerUrl $ | quote }}
 
-  TOWER_DB_URL: {{ printf "jdbc:mysql://%s:%d/%s?&usePipelineAuth=false&useBatchMultiSend=false&permitMysqlScheme=true"
-                          .Values.global.platformDatabase.host
-                          (.Values.global.platformDatabase.port | int)
-                          .Values.global.platformDatabase.database
-                              | quote }}
+  TOWER_DB_URL: {{ include "platform.database.url" . | quote }}
   TOWER_DB_USER: {{ tpl .Values.global.platformDatabase.username . | quote }}
   TOWER_DB_DRIVER: {{ include "platform.database.driver" . | quote }}
   TOWER_DB_DIALECT: {{ include "platform.database.dialect" . | quote }}

--- a/platform/tests/__snapshot__/configmap_test.yaml.snap
+++ b/platform/tests/__snapshot__/configmap_test.yaml.snap
@@ -9,7 +9,7 @@ should render shared cm with default values:
       TOWER_DB_MAX_LIFETIME: "180000"
       TOWER_DB_MAX_POOL_SIZE: "10"
       TOWER_DB_MIN_POOL_SIZE: "2"
-      TOWER_DB_URL: jdbc:mysql://:3306/?&usePipelineAuth=false&useBatchMultiSend=false&permitMysqlScheme=true
+      TOWER_DB_URL: jdbc:mysql://:3306/?permitMysqlScheme=true
       TOWER_DB_USER: ""
       TOWER_ENABLE_PLATFORMS: altair-platform,awsbatch-platform,awscloud-platform,azbatch-platform,eks-platform,gke-platform,googlebatch-platform,googlecloud-platform,k8s-platform,local-platform,lsf-platform,moab-platform,slurm-platform
       TOWER_REDIS_URL: redis://:6379

--- a/platform/tests/__snapshot__/deployment-backend_test.yaml.snap
+++ b/platform/tests/__snapshot__/deployment-backend_test.yaml.snap
@@ -27,7 +27,7 @@ should render the backend deployment with the correct checksums, labels and anno
       template:
         metadata:
           annotations:
-            checksum/configmap: 8cee4cfcc8dc75913e9a798b86ad8d692bb11d632b475ed393d8cd56eed0c093
+            checksum/configmap: 380b749392f400fe4829101e8a4fc5f15e4f13cfe8e24c4ba4bd8082b141b596
             checksum/secret: cafb8de952eaf65cd0267d83b2273af42e7c0cb906df95abf490deb0dbb96a70
             common-annotation-key: common-annotation-value
             pod-annotation-key: pod-annotation-value

--- a/platform/tests/__snapshot__/deployment-cron_test.yaml.snap
+++ b/platform/tests/__snapshot__/deployment-cron_test.yaml.snap
@@ -29,7 +29,7 @@ should render the cron deployment with the correct checksums, labels and annotat
       template:
         metadata:
           annotations:
-            checksum/configmap: 8cee4cfcc8dc75913e9a798b86ad8d692bb11d632b475ed393d8cd56eed0c093
+            checksum/configmap: 380b749392f400fe4829101e8a4fc5f15e4f13cfe8e24c4ba4bd8082b141b596
             checksum/secret: cafb8de952eaf65cd0267d83b2273af42e7c0cb906df95abf490deb0dbb96a70
             common-annotation-key: common-annotation-value
             pod-annotation-key: pod-annotation-value

--- a/platform/tests/configmap_test.yaml
+++ b/platform/tests/configmap_test.yaml
@@ -414,3 +414,95 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "Unsupported database dialect: ''. Supported dialects are: 'mysql-8', 'mariadb-10'."
+
+  - it: should render database url correctly for mariadb driver with default list of parameters
+    documentSelector:
+      path: metadata.name
+      value: release-name-platform-shared-backend-cron
+    asserts:
+      - equal:
+          path: data.TOWER_DB_URL
+          value: "jdbc:mysql://:3306/?permitMysqlScheme=true"
+
+  - it: should render database url correctly for mariadb driver with specified parameters
+    documentSelector:
+      path: metadata.name
+      value: release-name-platform-shared-backend-cron
+    set:
+      global:
+        platformDatabase:
+          connectionOptions:
+            mariadb:
+              - "param1=value1"
+              - "param2=value2"
+    asserts:
+      - equal:
+          path: data.TOWER_DB_URL
+          value: "jdbc:mysql://:3306/?param1=value1&param2=value2"
+
+  - it: should render database url correctly for mysql driver (alias for mariadb) with specified parameters
+    documentSelector:
+      path: metadata.name
+      value: release-name-platform-shared-backend-cron
+    set:
+      global:
+        platformDatabase:
+          connectionOptions:
+            mariadb: []
+            mysql:
+              - "param1=value1"
+              - "param2=value2"
+    asserts:
+      - equal:
+          path: data.TOWER_DB_URL
+          value: "jdbc:mysql://:3306/?param1=value1&param2=value2"
+
+  - it: should render database url correctly using mariadb options over mysql if both are provided
+    documentSelector:
+      path: metadata.name
+      value: release-name-platform-shared-backend-cron
+    set:
+      global:
+        platformDatabase:
+          connectionOptions:
+            mariadb:
+              - "param1=value1"
+              - "param2=value2"
+            mysql:
+              - "paramA=value1"
+              - "paramB=value2"
+    asserts:
+      - equal:
+          path: data.TOWER_DB_URL
+          value: "jdbc:mysql://:3306/?param1=value1&param2=value2"
+
+  - it: should render database url correctly using mariadb options when no mysql options are provided
+    documentSelector:
+      path: metadata.name
+      value: release-name-platform-shared-backend-cron
+    set:
+      global:
+        platformDatabase:
+          connectionOptions:
+            mariadb:
+              - "param1=value1"
+              - "param2=value2"
+            mysql: []
+    asserts:
+      - equal:
+          path: data.TOWER_DB_URL
+          value: "jdbc:mysql://:3306/?param1=value1&param2=value2"
+
+  - it: should render database url correctly when no options are provided
+    documentSelector:
+      path: metadata.name
+      value: release-name-platform-shared-backend-cron
+    set:
+      global:
+        platformDatabase:
+          connectionOptions:
+            mariadb: []
+    asserts:
+      - equal:
+          path: data.TOWER_DB_URL
+          value: "jdbc:mysql://:3306/"

--- a/platform/values.yaml
+++ b/platform/values.yaml
@@ -34,11 +34,21 @@ global:
     # -- Key in the existing secret containing the password for the Platform MySQL db.
     # @default -- `"TOWER_DB_PASSWORD"`
     existingSecretKey: ""
-    # Enable encryption in transit when connecting to the external database.
-    # TODO: implement support for this in the templates.
-    #tls: true
     # -- Database driver. Possible options: "mariadb" (or its alias "mysql").
     driver: "mariadb"
+    # -- Connection options to compose in the driver URL according to the driver used. The only
+    # driver that can be set is 'mariadb'.
+    connectionOptions:
+      # -- Connection options to use with the MariaDB driver. For the full list of supported
+      # options see:
+      # https://mariadb.com/docs/connectors/mariadb-connector-j/about-mariadb-connector-j
+      mariadb:
+        # permitMysqlScheme=true allows the MariaDB driver to communicate with MySQL databases.
+        - permitMysqlScheme=true
+        # sslMode enables TLS encryption with varying levels of certificate acceptance criteria.
+        # Other options allow the enabling or disabling of specific TLS ciphers, the path to the
+        # server's CA certificate, etc.
+        # - sslMode=verify-ca
     # -- Hibernate dialect to use, depending on the database version. Possible options: mysql-8
     # (default), mariadb-10.
     dialect: "mysql-8"


### PR DESCRIPTION
This PR allows users to specify different connection options, e.g. whether to enable TLS and how strict should verification be, possibly specify a CA cert, and other options listed in the Mariadb connector: https://mariadb.com/docs/connectors/mariadb-connector-j/about-mariadb-connector-j