### PR TITLE
docs: Add instructions in main README on how to replicate/vendor chart releases DEVOPS-965

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Kubernetes clusters.
 Currently, it includes charts for:
 - [Platform](./platform/README.md): Seqera Labs Platform for workflow orchestration and management.
 
-More products and services will be added in the future.
+More products will be added in the future.
 
 ## Vendor charts to an internal registry
 
@@ -16,8 +16,9 @@ internal OCI registry.
 
 ### Recommended approach
 
-Use Skopeo to automate and keep your internal registry in sync. Example to synchronize all releases
-of the `platform` chart from the public Seqera registry to your internal registry:
+Use [Skopeo](https://github.com/containers/skopeo) to automate and keep your internal registry in
+sync. For example to synchronize all releases of the `platform` chart from the public Seqera
+registry to your internal registry:
 
 ```console
 skopeo login [...] internal-registry.example.com
@@ -26,6 +27,9 @@ skopeo sync --scoped --src docker --dest docker public.cr.seqera.io/charts/platf
 
 This will copy every version of `public.cr.seqera.io/charts/platform` into the repository
 `internal-registry.example.com/public.cr.seqera.io/charts/platform`.
+
+Note that charts may include dependencies to other charts in the same registry, so make sure to
+vendor all charts you plan to use: refer to the "Requirements" section in each chart's README file.
 
 ### Limit versions with SemVer (Skopeo ≥ 1.15)
 


### PR DESCRIPTION
I preferred adding the instructions in the main README of the repo, since they can apply to any chart.