### PR TITLE
feat: add new env variables to agent-backend deployment 

### DIFF
--- a/charts/platform/CHANGELOG.md
+++ b/charts/platform/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.27.9] - 2026-03-12
+
+### Changed
+
+- Updated agent-backend subchart to version 0.2.6
 
 ## [0.27.8] - 2026-03-12
 

--- a/charts/platform/Chart.yaml
+++ b/charts/platform/Chart.yaml
@@ -37,7 +37,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "0.27.8"
+version: "0.27.9"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/platform/README.md
+++ b/charts/platform/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart to deploy Seqera Platform (also referred to as Tower) on Kubernetes.
 
-![Version: 0.27.8](https://img.shields.io/badge/Version-0.27.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v25.3.3](https://img.shields.io/badge/AppVersion-v25.3.3-informational?style=flat-square)
+![Version: 0.27.9](https://img.shields.io/badge/Version-0.27.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v25.3.3](https://img.shields.io/badge/AppVersion-v25.3.3-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -41,7 +41,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/platform \
-  --version 0.27.8 \
+  --version 0.27.9 \
   --namespace my-namespace \
   --create-namespace
 ```

--- a/charts/platform/charts/agent-backend/CHANGELOG.md
+++ b/charts/platform/charts/agent-backend/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.6] - 2026-03-12
+
+### Changed
+
+- Add new env variables to deployment NEW_PUBLIC_VAR and NEW_SECRET_VAR
 
 ## [0.2.5] - 2026-03-12
 

--- a/charts/platform/charts/agent-backend/Chart.yaml
+++ b/charts/platform/charts/agent-backend/Chart.yaml
@@ -19,7 +19,7 @@ apiVersion: v2
 name: agent-backend
 description: Backend service for Seqera CLI AI capabilities
 type: application
-version: "0.2.5"
+version: "0.2.6"
 appVersion: "2.0.0"
 maintainers:
   - name: Seqera Labs

--- a/charts/platform/charts/agent-backend/README.md
+++ b/charts/platform/charts/agent-backend/README.md
@@ -2,7 +2,7 @@
 
 Backend service for Seqera CLI AI capabilities
 
-![Version: 0.2.5](https://img.shields.io/badge/Version-0.2.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 0.2.6](https://img.shields.io/badge/Version-0.2.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -36,7 +36,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/agent-backend \
-  --version 0.2.5 \
+  --version 0.2.6 \
   --namespace my-namespace \
   --create-namespace
 ```
@@ -82,6 +82,10 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | tokenEncryptionKey | string | `""` | Token encryption key. Define the value as a String or a Secret, not both at the same time |
 | tokenEncryptionKeyExistingSecretName | string | `""` | Name of an existing Secret containing the token encryption key. Note: the Secret must already exist in the same namespace at the time of deployment |
 | tokenEncryptionKeyExistingSecretKey | string | `"AGENT_BACKEND_TOKEN_ENCRYPTION_KEY"` | Key in the existing Secret containing the token encryption key |
+| newPublicVar | string | `""` | New public variable exposed via ConfigMap |
+| newSecretVar | string | `""` | New secret var. Define the value as a String or a Secret, not both at the same time |
+| newSecretVarExistingSecretName | string | `""` | Name of an existing Secret containing the new secret var. Note: the Secret must already exist in the same namespace at the time of deployment |
+| newSecretVarExistingSecretKey | string | `"NEW_SECRET_VAR"` | Key in the existing Secret containing the new secret var |
 | logLevel | string | `"INFO"` | Log level (one of CRITICAL, ERROR, WARNING, INFO, DEBUG) |
 | service | object | `{"extraOptions":{},"extraServices":[],"http":{"name":"http","nodePort":null,"port":80,"targetPort":8002},"type":"ClusterIP"}` | Service configuration |
 | service.type | string | `"ClusterIP"` | Service type. Note: ingresses using AWS ALB require the service to be NodePort |

--- a/charts/platform/charts/agent-backend/templates/NOTES.txt
+++ b/charts/platform/charts/agent-backend/templates/NOTES.txt
@@ -54,6 +54,16 @@
 {{- printf "\nVALUES VALIDATION:\n%s" $message | fail -}}
 {{- end -}}
 
+{{- if and (not .Values.newSecretVar) (not .Values.newSecretVarExistingSecretName) -}}
+{{- $message := "Define the new secret var at 'newSecretVar' or provide an existing secret name at 'newSecretVarExistingSecretName'." -}}
+{{- printf "\nVALUES VALIDATION:\n%s" $message | fail -}}
+{{- end -}}
+
+{{- if and .Values.newSecretVar .Values.newSecretVarExistingSecretName -}}
+{{- $message := "Either provide 'newSecretVar' or an existing secret name in 'newSecretVarExistingSecretName', but not both." -}}
+{{- printf "\nVALUES VALIDATION:\n%s" $message | fail -}}
+{{- end -}}
+
 
 Thank you for installing {{ .Chart.Name | title }}!
 

--- a/charts/platform/charts/agent-backend/templates/_helpers.tpl
+++ b/charts/platform/charts/agent-backend/templates/_helpers.tpl
@@ -77,3 +77,21 @@ Return the name of the secret containing the token encryption key.
     {{- printf "AGENT_BACKEND_TOKEN_ENCRYPTION_KEY" -}}
   {{- end -}}
 {{- end -}}
+
+{{/*
+Return the name of the secret containing the new secret var.
+*/}}
+{{- define "agent-backend.newSecretVar.existingSecret" -}}
+  {{- printf "%s" (tpl .Values.newSecretVarExistingSecretName .) -}}
+{{- end -}}
+{{- define "agent-backend.newSecretVar.existingSecret.secretName" -}}
+  {{- include "agent-backend.newSecretVar.existingSecret" . | default (include "common.names.fullname" .) -}}
+{{- end -}}
+
+{{- define "agent-backend.newSecretVar.existingSecret.secretKey" -}}
+  {{- if (include "agent-backend.newSecretVar.existingSecret" .) -}}
+    {{- printf "%s" (tpl .Values.newSecretVarExistingSecretKey .) | default "NEW_SECRET_VAR" -}}
+  {{- else -}}
+    {{- printf "NEW_SECRET_VAR" -}}
+  {{- end -}}
+{{- end -}}

--- a/charts/platform/charts/agent-backend/templates/configmap.yaml
+++ b/charts/platform/charts/agent-backend/templates/configmap.yaml
@@ -40,4 +40,6 @@ data:
   AGENT_BACKEND_DB_NAME: {{ tpl .Values.database.name . | quote }}
   AGENT_BACKEND_DB_USER: {{ tpl .Values.database.username . | quote }}
 
+  NEW_PUBLIC_VAR: {{ .Values.newPublicVar | quote }}
+
   LOG_LEVEL: {{ .Values.logLevel | default "INFO" | quote }}

--- a/charts/platform/charts/agent-backend/templates/deployment.yaml
+++ b/charts/platform/charts/agent-backend/templates/deployment.yaml
@@ -145,6 +145,11 @@ spec:
                 secretKeyRef:
                   name: {{ include "agent-backend.tokenEncryptionKey.existingSecret.secretName" . }}
                   key: {{ include "agent-backend.tokenEncryptionKey.existingSecret.secretKey" . }}
+            - name: NEW_SECRET_VAR
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "agent-backend.newSecretVar.existingSecret.secretName" . }}
+                  key: {{ include "agent-backend.newSecretVar.existingSecret.secretKey" . }}
 {{- with .Values.extraEnvVars }}
             {{- include "seqera.envVars.render" (dict "value" . "context" $) | nindent 12 }}
 {{- end }}

--- a/charts/platform/charts/agent-backend/templates/secret.yaml
+++ b/charts/platform/charts/agent-backend/templates/secret.yaml
@@ -44,6 +44,9 @@ data:
 {{- if not (include "agent-backend.tokenEncryptionKey.existingSecret" .) }}
   AGENT_BACKEND_TOKEN_ENCRYPTION_KEY: {{ include "common.secrets.passwords.manage" (dict "secret" (include "agent-backend.tokenEncryptionKey.existingSecret.secretName" .) "key" (include "agent-backend.tokenEncryptionKey.existingSecret.secretKey" .) "providedValues" (list "tokenEncryptionKey") "context" $ "honorProvidedValues" true) }}
 {{- end }}
+{{- if not (include "agent-backend.newSecretVar.existingSecret" .) }}
+  NEW_SECRET_VAR: {{ include "common.secrets.passwords.manage" (dict "secret" (include "agent-backend.newSecretVar.existingSecret.secretName" .) "key" (include "agent-backend.newSecretVar.existingSecret.secretKey" .) "providedValues" (list "newSecretVar") "context" $ "honorProvidedValues" true) }}
+{{- end }}
 ---
 {{- if .Values.global.imageCredentials }}
 # Only add the imagePullSecret template if it's defined.

--- a/charts/platform/charts/agent-backend/tests/NOTES_test.yaml
+++ b/charts/platform/charts/agent-backend/tests/NOTES_test.yaml
@@ -131,6 +131,7 @@ tests:
         username: "agent"
         password: "test-password"
       anthropicApiKey: "test-anthropic-key"
+      newSecretVar: "test-new-secret"
     asserts:
       - hasDocuments:
           count: 1
@@ -143,6 +144,7 @@ tests:
         username: "agent"
         existingSecretName: "my-secret"
       anthropicApiKey: "test-anthropic-key"
+      newSecretVar: "test-new-secret"
     asserts:
       - hasDocuments:
           count: 1
@@ -182,6 +184,7 @@ tests:
         username: "agent"
         password: "test-password"
       anthropicApiKey: "test-anthropic-key"
+      newSecretVar: "test-new-secret"
     asserts:
       - hasDocuments:
           count: 1
@@ -194,6 +197,62 @@ tests:
         username: "agent"
         password: "test-password"
       anthropicApiKeyExistingSecretName: "my-anthropic-secret"
+      newSecretVar: "test-new-secret"
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  # newSecretVar validation tests
+  - it: should fail when newSecretVar is not defined and no existingSecretName
+    set:
+      database:
+        host: "database.example.com"
+        name: "agent_backend"
+        username: "agent"
+        password: "test-password"
+      anthropicApiKey: "test-anthropic-key"
+      newSecretVar: ""
+      newSecretVarExistingSecretName: ""
+    asserts:
+      - failedTemplate:
+          errorPattern: "Define the new secret var at 'newSecretVar' or provide an existing secret name at 'newSecretVarExistingSecretName'\\."
+
+  - it: should fail when both newSecretVar and newSecretVarExistingSecretName are defined
+    set:
+      database:
+        host: "database.example.com"
+        name: "agent_backend"
+        username: "agent"
+        password: "test-password"
+      anthropicApiKey: "test-anthropic-key"
+      newSecretVar: "test-new-secret"
+      newSecretVarExistingSecretName: "my-new-secret"
+    asserts:
+      - failedTemplate:
+          errorPattern: "Either provide 'newSecretVar' or an existing secret name in 'newSecretVarExistingSecretName', but not both\\."
+
+  - it: should pass when only newSecretVar is set
+    set:
+      database:
+        host: "database.example.com"
+        name: "agent_backend"
+        username: "agent"
+        password: "test-password"
+      anthropicApiKey: "test-anthropic-key"
+      newSecretVar: "test-new-secret"
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  - it: should pass when only newSecretVarExistingSecretName is set
+    set:
+      database:
+        host: "database.example.com"
+        name: "agent_backend"
+        username: "agent"
+        password: "test-password"
+      anthropicApiKey: "test-anthropic-key"
+      newSecretVarExistingSecretName: "my-new-secret"
     asserts:
       - hasDocuments:
           count: 1
@@ -207,6 +266,7 @@ tests:
         username: "agent"
         password: "test-password"
       anthropicApiKey: "test-anthropic-key"
+      newSecretVar: "test-new-secret"
     asserts:
       - hasDocuments:
           count: 1
@@ -220,6 +280,7 @@ tests:
         username: "agent"
         existingSecretName: "db-secret"
       anthropicApiKeyExistingSecretName: "anthropic-secret"
+      newSecretVarExistingSecretName: "new-secret"
     asserts:
       - hasDocuments:
           count: 1

--- a/charts/platform/charts/agent-backend/tests/__snapshot__/configmap_test.yaml.snap
+++ b/charts/platform/charts/agent-backend/tests/__snapshot__/configmap_test.yaml.snap
@@ -8,6 +8,7 @@ should render a ConfigMap with default values:
       AGENT_BACKEND_DB_USER: agent
       AGENT_BACKEND_PORT: "8002"
       LOG_LEVEL: INFO
+      NEW_PUBLIC_VAR: ""
       SEQERA_MCP_URL: https://mcp.test.example.com/mcp
       SEQERA_PLATFORM_API_URL: https://test.example.com/api
     kind: ConfigMap

--- a/charts/platform/charts/agent-backend/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/platform/charts/agent-backend/tests/__snapshot__/deployment_test.yaml.snap
@@ -21,8 +21,8 @@ should render a Deployment with default values:
       template:
         metadata:
           annotations:
-            checksum/configmap: af1429753c545ff6a2af95ca85fa9849ce880777b0f8137d00063425d53f89d7
-            checksum/secret: ac4ca92760ab83180bef6b3504a9f7b2663f3c2972a4b7e57a8e3173c6092172
+            checksum/configmap: 6483168ec26e8a552869635a29b829b3153a2db7c3a5fa792f6d69b3dc07ac3b
+            checksum/secret: 27609404dd54643eaa6117a334ed921bd7b2546d31a98db9fdeafc9aef6cc187
           labels:
             app.kubernetes.io/component: agent-backend
             app.kubernetes.io/instance: RELEASE-NAME
@@ -47,6 +47,11 @@ should render a Deployment with default values:
                   valueFrom:
                     secretKeyRef:
                       key: AGENT_BACKEND_TOKEN_ENCRYPTION_KEY
+                      name: release-name-agent-backend
+                - name: NEW_SECRET_VAR
+                  valueFrom:
+                    secretKeyRef:
+                      key: NEW_SECRET_VAR
                       name: release-name-agent-backend
               envFrom:
                 - configMapRef:

--- a/charts/platform/charts/agent-backend/tests/__snapshot__/secret_test.yaml.snap
+++ b/charts/platform/charts/agent-backend/tests/__snapshot__/secret_test.yaml.snap
@@ -5,6 +5,7 @@ should render a Secret with default values:
       AGENT_BACKEND_DB_PASSWORD: dGVzdC1kYi1wYXNzd29yZA==
       AGENT_BACKEND_TOKEN_ENCRYPTION_KEY: dGVzdC10b2tlbi1lbmNyeXB0aW9uLWtleQ==
       ANTHROPIC_API_KEY: dGVzdC1hbnRocm9waWMta2V5
+      NEW_SECRET_VAR: dGVzdC1uZXctc2VjcmV0LXZhcg==
     kind: Secret
     metadata:
       annotations: {}

--- a/charts/platform/charts/agent-backend/tests/configmap_test.yaml
+++ b/charts/platform/charts/agent-backend/tests/configmap_test.yaml
@@ -110,3 +110,28 @@ tests:
       - equal:
           path: data.LOG_LEVEL
           value: DEBUG
+
+  - it: should contain new public var
+    set:
+      global.platformExternalDomain: test.example.com
+      global.mcpDomain: mcp.test.example.com
+      database.host: mysql
+      database.name: db
+      database.username: user
+      newPublicVar: my-public-value
+    asserts:
+      - equal:
+          path: data.NEW_PUBLIC_VAR
+          value: "my-public-value"
+
+  - it: should render empty string for new public var when not set
+    set:
+      global.platformExternalDomain: test.example.com
+      global.mcpDomain: mcp.test.example.com
+      database.host: mysql
+      database.name: db
+      database.username: user
+    asserts:
+      - equal:
+          path: data.NEW_PUBLIC_VAR
+          value: ""

--- a/charts/platform/charts/agent-backend/tests/deployment_test.yaml
+++ b/charts/platform/charts/agent-backend/tests/deployment_test.yaml
@@ -32,6 +32,7 @@ tests:
       database.password: test-db-password
       anthropicApiKey: test-anthropic-key
       tokenEncryptionKey: test-token-encryption-key
+      newSecretVar: test-new-secret-var
     asserts:
       - matchSnapshot: {}
 
@@ -280,6 +281,40 @@ tests:
                 secretKeyRef:
                   name: release-name-agent-backend
                   key: AGENT_BACKEND_TOKEN_ENCRYPTION_KEY
+            - name: NEW_SECRET_VAR
+              valueFrom:
+                secretKeyRef:
+                  name: release-name-agent-backend
+                  key: NEW_SECRET_VAR
+
+  - it: should use external secret for new secret var
+    template: deployment.yaml
+    set:
+      newSecretVarExistingSecretName: my-new-secret
+      newSecretVarExistingSecretKey: secret-key
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[3]
+          value:
+            name: NEW_SECRET_VAR
+            valueFrom:
+              secretKeyRef:
+                name: my-new-secret
+                key: secret-key
+
+  - it: should use default key when new secret var external secret is set without custom key
+    template: deployment.yaml
+    set:
+      newSecretVarExistingSecretName: my-new-secret
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[3]
+          value:
+            name: NEW_SECRET_VAR
+            valueFrom:
+              secretKeyRef:
+                name: my-new-secret
+                key: NEW_SECRET_VAR
 
   - it: should configure wait-for-db init container env vars correctly
     template: deployment.yaml

--- a/charts/platform/charts/agent-backend/tests/secret_test.yaml
+++ b/charts/platform/charts/agent-backend/tests/secret_test.yaml
@@ -29,6 +29,7 @@ tests:
       database.password: test-db-password
       anthropicApiKey: test-anthropic-key
       tokenEncryptionKey: test-token-encryption-key
+      newSecretVar: test-new-secret-var
     asserts:
       - hasDocuments:
           count: 1
@@ -63,6 +64,20 @@ tests:
     asserts:
       - isNull:
           path: data.ANTHROPIC_API_KEY
+
+  - it: should include NEW_SECRET_VAR when not using external secret
+    set:
+      newSecretVar: my-secret-value
+    asserts:
+      - isNotNull:
+          path: data.NEW_SECRET_VAR
+
+  - it: should NOT include NEW_SECRET_VAR when using external secret
+    set:
+      newSecretVarExistingSecretName: my-new-secret
+    asserts:
+      - isNull:
+          path: data.NEW_SECRET_VAR
 
   - it: should render imagePullSecret when global.imageCredentials is set
     set:

--- a/charts/platform/charts/agent-backend/values.yaml
+++ b/charts/platform/charts/agent-backend/values.yaml
@@ -105,6 +105,18 @@ tokenEncryptionKeyExistingSecretName: ""
 # @default -- `"AGENT_BACKEND_TOKEN_ENCRYPTION_KEY"`
 tokenEncryptionKeyExistingSecretKey: ""
 
+# -- New public variable exposed via ConfigMap
+newPublicVar: ""
+
+# -- New secret var. Define the value as a String or a Secret, not both at the same time
+newSecretVar: ""
+# -- Name of an existing Secret containing the new secret var.
+# Note: the Secret must already exist in the same namespace at the time of deployment
+newSecretVarExistingSecretName: ""
+# -- Key in the existing Secret containing the new secret var
+# @default -- `"NEW_SECRET_VAR"`
+newSecretVarExistingSecretKey: ""
+
 # -- Log level (one of CRITICAL, ERROR, WARNING, INFO, DEBUG)
 logLevel: INFO
 


### PR DESCRIPTION
Example PR of adding new env variables to agent-backend subchart
- NEW_PUBLIC_VAR - from configmap
- NEW_SECRET_VAR - from secret