### PR TITLE
feat: Make platform cron mount OIDC private key, required from platform v26.1

### DIFF
--- a/charts/platform/CHANGELOG.md
+++ b/charts/platform/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `TOWER_OIDC_PEM_PATH` moved to the shared backend/cron configmap and is now always set (previously backend-only and only when `studios.enabled=true`); required from Platform v26.1 onwards
 - `connect-cert-volume` and `TOWER_OIDC_REGISTRATION_INITIAL_ACCESS_TOKEN` are now always present on the backend deployment (previously only when `studios.enabled=true`); required from Platform v26.1 onwards
+- Bump `mcp` subchart to 0.3.0: rename OAuth environment variables to use `MCP_` prefix (`MCP_OAUTH_INITIAL_ACCESS_TOKEN`, `MCP_OAUTH_JWT_SECRET`, `MCP_OAUTH_ISSUER_URL`, `MCP_OAUTH_AUDIENCE`)
 
 ## [0.29.8] - 2026-04-08
 

--- a/charts/platform/CHANGELOG.md
+++ b/charts/platform/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.30.0] - 2026-04-08
+
+### Added
+
+- Mount OIDC private key secret (`connect-cert-volume` at `/data/certs`) on the cron deployment, matching the backend deployment
+
+### Changed
+
+- `TOWER_OIDC_PEM_PATH` moved to the shared backend/cron configmap and is now always set (previously backend-only and only when `studios.enabled=true`); required from Platform v26.1 onwards
+- `connect-cert-volume` and `TOWER_OIDC_REGISTRATION_INITIAL_ACCESS_TOKEN` are now always present on the backend deployment (previously only when `studios.enabled=true`); required from Platform v26.1 onwards
+
 ## [0.29.8] - 2026-04-08
 
 ### Added

--- a/charts/platform/Chart.lock
+++ b/charts/platform/Chart.lock
@@ -13,12 +13,12 @@ dependencies:
   version: 1.2.9
 - name: mcp
   repository: file://charts/mcp
-  version: 0.2.5
+  version: 0.3.0
 - name: agent-backend
   repository: file://charts/agent-backend
   version: 0.4.5
 - name: portal-web
   repository: file://charts/portal-web
   version: 0.2.3
-digest: sha256:bc9cf1f73d0e2eb3ee1268fc128ed39c1c2e6f1bb127b8cf9dfe4f8dfe0d33a9
-generated: "2026-04-08T12:55:32.552345343+02:00"
+digest: sha256:7a36b28a204e3087d2d25eaa7a3a8d9bce966845c271b406a7e924deba7de2f6
+generated: "2026-04-09T10:15:53.623708429+02:00"

--- a/charts/platform/Chart.yaml
+++ b/charts/platform/Chart.yaml
@@ -37,7 +37,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.29.8
+version: 0.30.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/platform/Chart.yaml
+++ b/charts/platform/Chart.yaml
@@ -69,7 +69,7 @@ dependencies:
       - studios
     condition: studios.enabled
   - name: mcp
-    version: "0.2.x"
+    version: "0.3.x"
     repository: "file://charts/mcp"
     tags:
       - mcp

--- a/charts/platform/README.md
+++ b/charts/platform/README.md
@@ -64,7 +64,7 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 |------------|------|---------|
 | file://../seqera-common | seqera-common | 2.x.x |
 | file://charts/agent-backend | agent-backend | 0.4.x |
-| file://charts/mcp | mcp | 0.2.x |
+| file://charts/mcp | mcp | 0.3.x |
 | file://charts/pipeline-optimization | pipeline-optimization | 2.x.x |
 | file://charts/portal-web | portal-web | 0.2.x |
 | file://charts/studios | studios | 1.x.x |

--- a/charts/platform/README.md
+++ b/charts/platform/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart to deploy Seqera Platform (also referred to as Tower) on Kubernetes.
 
-![Version: 0.29.7](https://img.shields.io/badge/Version-0.29.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v25.3.4](https://img.shields.io/badge/AppVersion-v25.3.4-informational?style=flat-square)
+![Version: 0.30.0](https://img.shields.io/badge/Version-0.30.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v25.3.4](https://img.shields.io/badge/AppVersion-v25.3.4-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -41,7 +41,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/platform \
-  --version 0.29.7 \
+  --version 0.30.0 \
   --namespace my-namespace \
   --create-namespace
 ```

--- a/charts/platform/charts/mcp/CHANGELOG.md
+++ b/charts/platform/charts/mcp/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-04-09
+
+### Changed
+
+- **BREAKING** Rename environment variables to use `MCP_` prefix: `TOWER_OIDC_REGISTRATION_INITIAL_ACCESS_TOKEN` → `MCP_OAUTH_INITIAL_ACCESS_TOKEN`, `OAUTH_JWT_SECRET` → `MCP_OAUTH_JWT_SECRET`, `OAUTH_ISSUER_URL` → `MCP_OAUTH_ISSUER_URL`, `OAUTH_AUDIENCE` → `MCP_OAUTH_AUDIENCE`
+- When upgrading from 0.2.x, you may encounter errors such as `PASSWORDS ERROR: The secret "releasename-mcp" does not contain the key "MCP_OAUTH_JWT_SECRET"`. To resolve this, you can run the following command to update the secret with the new key:
+  ```
+  kubectl -n <namespace> get secret releasename-mcp -o yaml |
+    sed 's/OAUTH_JWT_SECRET/MCP_OAUTH_JWT_SECRET/g' |
+    kubectl apply -f -
+  ```
+- Bump appVersion to 1.1.0
+
 ## [0.2.5] - 2026-04-08
 
 ### Added

--- a/charts/platform/charts/mcp/Chart.yaml
+++ b/charts/platform/charts/mcp/Chart.yaml
@@ -22,8 +22,8 @@ description: |
   Wave container provisioning, bioinformatics data, and nf-core modules through intelligent
   RAG-based natural language interactions.
 type: application
-version: 0.2.5
-appVersion: "1.0.0"
+version: 0.3.0
+appVersion: "1.1.0"
 maintainers:
   - name: Seqera Labs
     email: devops@seqera.io

--- a/charts/platform/charts/mcp/README.md
+++ b/charts/platform/charts/mcp/README.md
@@ -4,7 +4,7 @@ A Model Context Protocol (MCP) server that provides comprehensive access to the 
 Wave container provisioning, bioinformatics data, and nf-core modules through intelligent
 RAG-based natural language interactions.
 
-![Version: 0.2.5](https://img.shields.io/badge/Version-0.2.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -26,7 +26,7 @@ The required values to set in order to have a working installation are:
 
 The Helm chart comes with several requirement checks that will validate the provided configuration before proceeding with the installation.
 
-By default the chart selects the application images defined in the `appVersion` field of the `Chart.yaml` file, currently set as `1.0.0`.
+By default the chart selects the application images defined in the `appVersion` field of the `Chart.yaml` file, currently set as `1.1.0`.
 
 When a sensitive value is required (e.g. the database password), you can either provide it directly in the values file or reference an existing Kubernetes Secret containing the value. The key names to use in the provided Secret are specified in the values file comments.
 Sensitive values provided as plain text by the user are always stored in a Kubernetes Secret created by the chart. When an external Secret is used instead, the chart instructs the components to read the sensitive value from the external Secret directly, without further storing copies of the sensitive value in the chart-created Secret.
@@ -37,7 +37,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/mcp \
-  --version 0.2.5 \
+  --version 0.3.0 \
   --namespace my-namespace \
   --create-namespace
 ```
@@ -76,7 +76,7 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | oauth.audience | string | `"platform"` | OAuth audience for MCP to authenticate with. This is the expected audience claim in the tokens issued by the OAuth provider. When using Seqera Platform as the OAuth provider, this should be set to "platform" to match the audience of the internal client that Platform creates for MCP. When using a custom OAuth provider, this should match the audience configured for the client that MCP uses to authenticate with that provider |
 | oauth.jwtSeedString | string | `""` | JWT seed, defined as string, used to sign authentication tokens. Define the value as a String or a Secret, not both at the same time. If neither is defined, Helm generates a random 35-character string. WARNING: Always explicitly set this value or use an existing secret when using Kustomize. Auto-generated random values are incompatible with Kustomize. When upgrading releases via Kustomize, Helm cannot query the cluster to check if a secret already exists, causing it to regenerate a new random value on each upgrade, which will break authentication |
 | oauth.jwtSeedSecretName | string | `""` | Name of an existing Secret containing the JWT seed, as an alternative to the string field. Note: the Secret must already exist in the same namespace at the time of deployment |
-| oauth.jwtSeedSecretKey | string | `"OAUTH_JWT_SECRET"` | Key in the existing Secret containing the JWT seed |
+| oauth.jwtSeedSecretKey | string | `"MCP_OAUTH_JWT_SECRET"` | Key in the existing Secret containing the JWT seed |
 | image.registry | string | `""` | Container image registry |
 | image.repository | string | `"private/nf-tower-enterprise/mcp"` | Container image repository |
 | image.tag | string | `"{{ .chart.AppVersion }}"` | Container image tag |

--- a/charts/platform/charts/mcp/templates/_helpers.tpl
+++ b/charts/platform/charts/mcp/templates/_helpers.tpl
@@ -49,9 +49,9 @@ Return the name of the secret containing the MCP OAuth JWT seed.
 
 {{- define "mcp.oauth.jwt.existingSecret.secretKey" -}}
   {{- if (include "mcp.oauth.jwt.existingSecret" .) -}}
-    {{- printf "%s" (tpl .Values.oauth.jwtSeedSecretKey .) | default "OAUTH_JWT_SECRET" -}}
+    {{- printf "%s" (tpl .Values.oauth.jwtSeedSecretKey .) | default "MCP_OAUTH_JWT_SECRET" -}}
   {{- else -}}
-    {{- printf "OAUTH_JWT_SECRET" -}}
+    {{- printf "MCP_OAUTH_JWT_SECRET" -}}
   {{- end -}}
 {{- end -}}
 

--- a/charts/platform/charts/mcp/templates/configmap.yaml
+++ b/charts/platform/charts/mcp/templates/configmap.yaml
@@ -39,5 +39,5 @@ data:
   WAVE_API_ENDPOINT: {{ tpl .Values.waveApiEndpoint $ | quote }}
   REGISTRY_API_ENDPOINT: {{ tpl .Values.registryApiEndpoint $ | quote }}
 
-  OAUTH_ISSUER_URL: {{ include "mcp.oauth.issuerUrl" . | quote }}
-  OAUTH_AUDIENCE: {{ tpl .Values.oauth.audience $ | quote }}
+  MCP_OAUTH_ISSUER_URL: {{ include "mcp.oauth.issuerUrl" . | quote }}
+  MCP_OAUTH_AUDIENCE: {{ tpl .Values.oauth.audience $ | quote }}

--- a/charts/platform/charts/mcp/templates/deployment.yaml
+++ b/charts/platform/charts/mcp/templates/deployment.yaml
@@ -80,12 +80,12 @@ spec:
           args: {{- toYaml . | nindent 12 }}
 {{- end }}
           env:
-            - name: TOWER_OIDC_REGISTRATION_INITIAL_ACCESS_TOKEN
+            - name: MCP_OAUTH_INITIAL_ACCESS_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: {{ include "mcp.oidcToken.secretName" . }}
                   key: {{ include "mcp.oidcToken.secretKey" . }}
-            - name: OAUTH_JWT_SECRET
+            - name: MCP_OAUTH_JWT_SECRET
               valueFrom:
                 secretKeyRef:
                   name: {{ include "mcp.oauth.jwt.existingSecret.secretName" . }}

--- a/charts/platform/charts/mcp/templates/secret.yaml
+++ b/charts/platform/charts/mcp/templates/secret.yaml
@@ -36,10 +36,10 @@ metadata:
   annotations: {{- $annotations | nindent 4 }}
 data:
 {{- if not (include "mcp.oidcToken.existingSecret" .) }}
-  TOWER_OIDC_REGISTRATION_INITIAL_ACCESS_TOKEN: {{ include "common.secrets.passwords.manage" (dict "secret" (include "mcp.oidcToken.secretName" .) "key" (include "mcp.oidcToken.secretKey" .) "providedValues" (list "oidcToken.tokenString") "failOnNew" false "length" 32 "context" $ "honorProvidedValues" true) }}
+  MCP_OAUTH_INITIAL_ACCESS_TOKEN: {{ include "common.secrets.passwords.manage" (dict "secret" (include "mcp.oidcToken.secretName" .) "key" (include "mcp.oidcToken.secretKey" .) "providedValues" (list "oidcToken.tokenString") "failOnNew" false "length" 32 "context" $ "honorProvidedValues" true) }}
 {{- end }}
 {{- if not (include "mcp.oauth.jwt.existingSecret" .) }}
-  OAUTH_JWT_SECRET: {{ include "common.secrets.passwords.manage" (dict "secret" (include "mcp.oauth.jwt.existingSecret.secretName" .) "key" (include "mcp.oauth.jwt.existingSecret.secretKey" .) "providedValues" (list "oauth.jwtSeedString") "length" 40 "context" $ "honorProvidedValues" true) }}
+  MCP_OAUTH_JWT_SECRET: {{ include "common.secrets.passwords.manage" (dict "secret" (include "mcp.oauth.jwt.existingSecret.secretName" .) "key" (include "mcp.oauth.jwt.existingSecret.secretKey" .) "providedValues" (list "oauth.jwtSeedString") "length" 40 "context" $ "honorProvidedValues" true) }}
 {{- end }}
 ---
 {{- if .Values.global.imageCredentials }}

--- a/charts/platform/charts/mcp/tests/__snapshot__/configmap_test.yaml.snap
+++ b/charts/platform/charts/mcp/tests/__snapshot__/configmap_test.yaml.snap
@@ -3,11 +3,11 @@ should render a ConfigMap with default values:
     apiVersion: v1
     data:
       HUB_API_ENDPOINT: https://hub.seqera.io
+      MCP_OAUTH_AUDIENCE: platform
+      MCP_OAUTH_ISSUER_URL: https://test.example.com/api
       MCP_SERVER_URL: https://mcp.test.example.com
       MICRONAUT_ENVIRONMENTS: oauth-platform
       MICRONAUT_SERVER_PORT: "6010"
-      OAUTH_AUDIENCE: platform
-      OAUTH_ISSUER_URL: https://test.example.com/api
       REGISTRY_API_ENDPOINT: https://registry.nextflow.io
       TOWER_API_ENDPOINT: https://test.example.com/api
       WAVE_API_ENDPOINT: https://wave.seqera.io

--- a/charts/platform/charts/mcp/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/platform/charts/mcp/tests/__snapshot__/deployment_test.yaml.snap
@@ -21,7 +21,7 @@ should render a Deployment with default values:
       template:
         metadata:
           annotations:
-            checksum/configmap: 595e1244e288fa87e428d959b87d4666a798d74cadd57abec6658a548cf725a0
+            checksum/configmap: 16f769ed028fde925ece3abfcb4bf4d07ef7afa2bfb2516c2f683e336d5af811
             checksum/secret: c02f86a51632209a540a8a0e36bd7bf3aadaf054e628be683b4c60c100b3e3b5
           labels:
             app.kubernetes.io/component: mcp
@@ -33,12 +33,12 @@ should render a Deployment with default values:
         spec:
           containers:
             - env:
-                - name: TOWER_OIDC_REGISTRATION_INITIAL_ACCESS_TOKEN
+                - name: MCP_OAUTH_INITIAL_ACCESS_TOKEN
                   valueFrom:
                     secretKeyRef:
                       key: MY_OIDC_TOKEN
                       name: my-oidc-secret
-                - name: OAUTH_JWT_SECRET
+                - name: MCP_OAUTH_JWT_SECRET
                   valueFrom:
                     secretKeyRef:
                       key: jwt-seed-key

--- a/charts/platform/charts/mcp/tests/__snapshot__/secret_test.yaml.snap
+++ b/charts/platform/charts/mcp/tests/__snapshot__/secret_test.yaml.snap
@@ -2,8 +2,8 @@ should render a Secret with default values:
   1: |
     apiVersion: v1
     data:
-      OAUTH_JWT_SECRET: bXlzZWNyZXRqd3RzZWVk
-      TOWER_OIDC_REGISTRATION_INITIAL_ACCESS_TOKEN: bXktb2lkYy10b2tlbg==
+      MCP_OAUTH_INITIAL_ACCESS_TOKEN: bXktb2lkYy10b2tlbg==
+      MCP_OAUTH_JWT_SECRET: bXlzZWNyZXRqd3RzZWVk
     kind: Secret
     metadata:
       annotations: {}

--- a/charts/platform/charts/mcp/tests/_helpers_test.yaml
+++ b/charts/platform/charts/mcp/tests/_helpers_test.yaml
@@ -35,7 +35,7 @@ tests:
         - oauth-platform
     asserts:
       - equal:
-          path: data.OAUTH_ISSUER_URL
+          path: data.MCP_OAUTH_ISSUER_URL
           value: "https://test.example.com/api"
 
   - it: should use explicit oauth.issuerUrl when set, even with oauth-platform
@@ -47,7 +47,7 @@ tests:
       oauth.issuerUrl: "https://custom-auth.example.com"
     asserts:
       - equal:
-          path: data.OAUTH_ISSUER_URL
+          path: data.MCP_OAUTH_ISSUER_URL
           value: "https://custom-auth.example.com"
 
   - it: should use explicit oauth.issuerUrl when set with oauth environment
@@ -60,7 +60,7 @@ tests:
       oauth.clientSecretString: "my-client-secret"
     asserts:
       - equal:
-          path: data.OAUTH_ISSUER_URL
+          path: data.MCP_OAUTH_ISSUER_URL
           value: "https://custom-auth.example.com"
 
   - it: should template oauth.issuerUrl value
@@ -72,7 +72,7 @@ tests:
       oauth.issuerUrl: "https://auth.{{ .Values.global.platformExternalDomain }}"
     asserts:
       - equal:
-          path: data.OAUTH_ISSUER_URL
+          path: data.MCP_OAUTH_ISSUER_URL
           value: "https://auth.test.example.com"
 
   - it: should use custom image from global registry override

--- a/charts/platform/charts/mcp/tests/configmap_test.yaml
+++ b/charts/platform/charts/mcp/tests/configmap_test.yaml
@@ -65,8 +65,8 @@ tests:
             HUB_API_ENDPOINT: "https://hub.seqera.io"
             WAVE_API_ENDPOINT: "https://wave.seqera.io"
             REGISTRY_API_ENDPOINT: "https://registry.nextflow.io"
-            OAUTH_ISSUER_URL: "https://auth.example.com"
-            OAUTH_AUDIENCE: "mcp"
+            MCP_OAUTH_ISSUER_URL: "https://auth.example.com"
+            MCP_OAUTH_AUDIENCE: "mcp"
 
   - it: should template values in configmap
     set:
@@ -89,5 +89,5 @@ tests:
             HUB_API_ENDPOINT: "https://hub.example.com"
             WAVE_API_ENDPOINT: "https://wave.example.com"
             REGISTRY_API_ENDPOINT: "https://registry.example.com"
-            OAUTH_ISSUER_URL: "https://auth.example.com/auth"
-            OAUTH_AUDIENCE: "RELEASE-NAME-mcp"
+            MCP_OAUTH_ISSUER_URL: "https://auth.example.com/auth"
+            MCP_OAUTH_AUDIENCE: "RELEASE-NAME-mcp"

--- a/charts/platform/charts/mcp/tests/deployment_test.yaml
+++ b/charts/platform/charts/mcp/tests/deployment_test.yaml
@@ -36,7 +36,7 @@ tests:
     asserts:
       - matchSnapshot: {}
 
-  - it: should inject TOWER_OIDC_REGISTRATION_INITIAL_ACCESS_TOKEN from standalone secret by default
+  - it: should inject MCP_OAUTH_INITIAL_ACCESS_TOKEN from standalone secret by default
     template: deployment.yaml
     set:
       oidcToken.existingSecretName: ""
@@ -44,13 +44,13 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].env[0]
           value:
-            name: TOWER_OIDC_REGISTRATION_INITIAL_ACCESS_TOKEN
+            name: MCP_OAUTH_INITIAL_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
                 name: release-name-mcp
                 key: OIDC_CLIENT_REGISTRATION_TOKEN
 
-  - it: should inject TOWER_OIDC_REGISTRATION_INITIAL_ACCESS_TOKEN from existing secret when set
+  - it: should inject MCP_OAUTH_INITIAL_ACCESS_TOKEN from existing secret when set
     template: deployment.yaml
     set:
       oidcToken.existingSecretName: my-platform-backend
@@ -59,7 +59,7 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].env[0]
           value:
-            name: TOWER_OIDC_REGISTRATION_INITIAL_ACCESS_TOKEN
+            name: MCP_OAUTH_INITIAL_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
                 name: my-platform-backend
@@ -202,7 +202,7 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
-            name: OAUTH_JWT_SECRET
+            name: MCP_OAUTH_JWT_SECRET
             valueFrom:
               secretKeyRef:
                 name: my-jwt-secret
@@ -216,11 +216,11 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
-            name: OAUTH_JWT_SECRET
+            name: MCP_OAUTH_JWT_SECRET
             valueFrom:
               secretKeyRef:
                 name: my-jwt-secret
-                key: OAUTH_JWT_SECRET
+                key: MCP_OAUTH_JWT_SECRET
 
   - it: should configure main container with env before envFrom
     template: deployment.yaml
@@ -228,10 +228,10 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
-            name: OAUTH_JWT_SECRET
+            name: MCP_OAUTH_JWT_SECRET
             valueFrom:
               secretKeyRef:
-                key: OAUTH_JWT_SECRET
+                key: MCP_OAUTH_JWT_SECRET
                 name: release-name-mcp
 
   - it: should render extraOptionsSpec under spec

--- a/charts/platform/charts/mcp/tests/secret_test.yaml
+++ b/charts/platform/charts/mcp/tests/secret_test.yaml
@@ -48,28 +48,28 @@ tests:
       - isEmpty:
           path: data
 
-  - it: should include OAUTH_JWT_SECRET when not using external secret
+  - it: should include MCP_OAUTH_JWT_SECRET when not using external secret
     set:
       oauth.jwtSeedString: mysecretpassword
     asserts:
       - equal:
-          path: data.OAUTH_JWT_SECRET
+          path: data.MCP_OAUTH_JWT_SECRET
           value: mysecretpassword
           decodeBase64: true
 
-  - it: should NOT include OAUTH_JWT_SECRET when using external secret
+  - it: should NOT include MCP_OAUTH_JWT_SECRET when using external secret
     set:
       oauth.jwtSeedSecretName: my-external-secret
     asserts:
       - notExists:
-          path: data.OAUTH_JWT_SECRET
+          path: data.MCP_OAUTH_JWT_SECRET
 
-  - it: should generate TOWER_OIDC_REGISTRATION_INITIAL_ACCESS_TOKEN when no existing secret is set
+  - it: should generate MCP_OAUTH_INITIAL_ACCESS_TOKEN when no existing secret is set
     set:
       oidcToken.existingSecretName: ""
     asserts:
       - matchRegex:
-          path: data.TOWER_OIDC_REGISTRATION_INITIAL_ACCESS_TOKEN
+          path: data.MCP_OAUTH_INITIAL_ACCESS_TOKEN
           pattern: "^[A-Za-z0-9@_]{32}$"
           decodeBase64: true
 
@@ -79,16 +79,16 @@ tests:
       oidcToken.tokenString: my-oidc-token-value
     asserts:
       - equal:
-          path: data.TOWER_OIDC_REGISTRATION_INITIAL_ACCESS_TOKEN
+          path: data.MCP_OAUTH_INITIAL_ACCESS_TOKEN
           value: my-oidc-token-value
           decodeBase64: true
 
-  - it: should NOT include TOWER_OIDC_REGISTRATION_INITIAL_ACCESS_TOKEN when using existing secret
+  - it: should NOT include MCP_OAUTH_INITIAL_ACCESS_TOKEN when using existing secret
     set:
       oidcToken.existingSecretName: my-external-oidc-secret
     asserts:
       - notExists:
-          path: data.TOWER_OIDC_REGISTRATION_INITIAL_ACCESS_TOKEN
+          path: data.MCP_OAUTH_INITIAL_ACCESS_TOKEN
 
   - it: should render imagePullSecret when global.imageCredentials is set
     set:

--- a/charts/platform/charts/mcp/values.yaml
+++ b/charts/platform/charts/mcp/values.yaml
@@ -109,7 +109,7 @@ oauth:
   # Note: the Secret must already exist in the same namespace at the time of deployment
   jwtSeedSecretName: ""
   # -- Key in the existing Secret containing the JWT seed
-  # @default -- `"OAUTH_JWT_SECRET"`
+  # @default -- `"MCP_OAUTH_JWT_SECRET"`
   jwtSeedSecretKey: ""
 
 image:

--- a/charts/platform/templates/configmap.yaml
+++ b/charts/platform/templates/configmap.yaml
@@ -38,7 +38,6 @@ data:
 {{- end }}
 {{- if .Values.studios.enabled }}
   TOWER_DATA_STUDIO_CONNECT_URL: {{ tpl .Values.global.studiosConnectionUrl . | quote }}
-  TOWER_OIDC_PEM_PATH: /data/certs/oidc.pem
   TOWER_DATA_STUDIO_WAVE_CUSTOM_IMAGE_REGISTRY: {{ .Values.platform.studios.customImageRegistry | quote }}
   TOWER_DATA_STUDIO_WAVE_CUSTOM_IMAGE_REPOSITORY: {{ .Values.platform.studios.customImageRepository | quote }}
 {{- include "platform.studios.toolsEnvVars" . | nindent 2 }}
@@ -80,6 +79,8 @@ data:
   TOWER_DB_MAX_LIFETIME: {{ .Values.platformDatabase.maxLifetime | toString | quote }}
   TOWER_DB_MAX_POOL_SIZE: {{ .Values.platformDatabase.maxPoolSize | toString | quote }}
   TOWER_DB_MIN_POOL_SIZE: {{ .Values.platformDatabase.minPoolSize | toString | quote }}
+
+  TOWER_OIDC_PEM_PATH: /data/certs/oidc.pem
 
 {{- if .Values.platform.smtp.host }}
   TOWER_SMTP_HOST: {{ .Values.platform.smtp.host | quote }}

--- a/charts/platform/templates/deployment-backend.yaml
+++ b/charts/platform/templates/deployment-backend.yaml
@@ -134,13 +134,11 @@ spec:
                   name: {{ include "platform.smtp.secretName" . }}
                   key: {{ include "platform.smtp.secretKey" . }}
 {{- end }}
-{{- if .Values.studios.enabled }}
             - name: TOWER_OIDC_REGISTRATION_INITIAL_ACCESS_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: {{ include "platform.oidcToken.secretName" . }}
                   key: {{ include "platform.oidcToken.secretKey" . }}
-{{- end }}
             - name: NXF_HOME
               value: "/var/cache/tower/"
             - name: NXF_PLUGINS_DIR
@@ -164,10 +162,8 @@ spec:
               mountPath: /.nextflow/
             - name: plugin-volume
               mountPath: /?/.nextflow/
-{{- if .Values.studios.enabled }}
             - name: connect-cert-volume
               mountPath: /data/certs
-{{- end }}
 {{- with .Values.backend.extraVolumeMounts }}
             {{- include "seqera.tplvalues.render" (dict "value" . "context" $) | nindent 12 }}
 {{- end }}
@@ -193,11 +189,9 @@ spec:
         - name: plugin-volume
           emptyDir:
             sizeLimit: "1Gi"
-{{- if .Values.studios.enabled }}
         - name: connect-cert-volume
           secret:
             secretName: {{ include "studios.oidcPrivateKeySecretName" . }}
-{{- end }}
 {{- with .Values.backend.extraVolumes }}
         {{- include "seqera.tplvalues.render" (dict "value" . "context" $) | nindent 8 }}
 {{- end }}

--- a/charts/platform/templates/deployment-cron.yaml
+++ b/charts/platform/templates/deployment-cron.yaml
@@ -207,6 +207,8 @@ spec:
               mountPath: /.nextflow/
             - name: plugin-volume
               mountPath: /?/.nextflow/
+            - name: connect-cert-volume
+              mountPath: /data/certs
 
 {{- if .Values.cron.containerSecurityContext.enabled }}
           securityContext: {{- omit .Values.cron.containerSecurityContext "enabled" | toYaml | nindent 12 }}
@@ -232,5 +234,8 @@ spec:
         - name: plugin-volume
           emptyDir:
             sizeLimit: "1Gi"
+        - name: connect-cert-volume
+          secret:
+            secretName: {{ include "studios.oidcPrivateKeySecretName" . }}
 
       {{ include "common.images.renderPullSecrets" ( dict "images" (list .Values.cron.image .Values.cron.dbMigrationInitContainer.image) "context" $) | nindent 6 }}

--- a/charts/platform/tests/__snapshot__/configmap_test.yaml.snap
+++ b/charts/platform/tests/__snapshot__/configmap_test.yaml.snap
@@ -40,7 +40,6 @@ should render Studios tools environment variables when studios is enabled with d
       TOWER_DATA_STUDIO_TEMPLATES_XPRA_TOOL: xpra
       TOWER_DATA_STUDIO_WAVE_CUSTOM_IMAGE_REGISTRY: ""
       TOWER_DATA_STUDIO_WAVE_CUSTOM_IMAGE_REPOSITORY: ""
-      TOWER_OIDC_PEM_PATH: /data/certs/oidc.pem
     kind: ConfigMap
     metadata:
       annotations: {}
@@ -98,7 +97,6 @@ should render custom Studios tool when provided:
       TOWER_DATA_STUDIO_TEMPLATES_XPRA_TOOL: xpra
       TOWER_DATA_STUDIO_WAVE_CUSTOM_IMAGE_REGISTRY: ""
       TOWER_DATA_STUDIO_WAVE_CUSTOM_IMAGE_REPOSITORY: ""
-      TOWER_OIDC_PEM_PATH: /data/certs/oidc.pem
     kind: ConfigMap
     metadata:
       annotations: {}
@@ -164,7 +162,6 @@ should render custom Studios tool with deprecated and experimental versions when
       TOWER_DATA_STUDIO_TEMPLATES_XPRA_TOOL: xpra
       TOWER_DATA_STUDIO_WAVE_CUSTOM_IMAGE_REGISTRY: ""
       TOWER_DATA_STUDIO_WAVE_CUSTOM_IMAGE_REPOSITORY: ""
-      TOWER_OIDC_PEM_PATH: /data/certs/oidc.pem
     kind: ConfigMap
     metadata:
       annotations: {}

--- a/charts/platform/tests/__snapshot__/deployment-backend_test.yaml.snap
+++ b/charts/platform/tests/__snapshot__/deployment-backend_test.yaml.snap
@@ -225,7 +225,7 @@ should render the backend deployment with the correct checksums, labels and anno
       template:
         metadata:
           annotations:
-            checksum/configmap: d033ec97fa9bed7b2c101fadd02d9280d309f8cbef93d7fd08363c4050d55d58
+            checksum/configmap: e7c0ce8f1a70f6f66b6154ca92968c09dbf32a11e3a960143e9d2bd91e1525d7
             checksum/secret: d3b5ca20c437b2faa4af1b549c817ee78cc2a992f86741120f01bd93a30d4873
             common-annotation-key: common-annotation-value
             pod-annotation-key: pod-annotation-value

--- a/charts/platform/tests/__snapshot__/deployment-cron_test.yaml.snap
+++ b/charts/platform/tests/__snapshot__/deployment-cron_test.yaml.snap
@@ -69,6 +69,8 @@ should produce a Deployment resource with minimal values:
             name: plugin-volume
           - mountPath: /?/.nextflow/
             name: plugin-volume
+          - mountPath: /data/certs
+            name: connect-cert-volume
     initContainers:
       - command:
           - sh
@@ -185,6 +187,9 @@ should produce a Deployment resource with minimal values:
       - emptyDir:
           sizeLimit: 1Gi
         name: plugin-volume
+      - name: connect-cert-volume
+        secret:
+          secretName: release-name-platform-backend
 should render the cron deployment with the correct checksums, labels and annotations:
   1: |
     apiVersion: apps/v1
@@ -216,7 +221,7 @@ should render the cron deployment with the correct checksums, labels and annotat
       template:
         metadata:
           annotations:
-            checksum/configmap: d033ec97fa9bed7b2c101fadd02d9280d309f8cbef93d7fd08363c4050d55d58
+            checksum/configmap: e7c0ce8f1a70f6f66b6154ca92968c09dbf32a11e3a960143e9d2bd91e1525d7
             checksum/secret: d3b5ca20c437b2faa4af1b549c817ee78cc2a992f86741120f01bd93a30d4873
             common-annotation-key: common-annotation-value
             pod-annotation-key: pod-annotation-value
@@ -301,6 +306,8 @@ should render the cron deployment with the correct checksums, labels and annotat
                   name: plugin-volume
                 - mountPath: /?/.nextflow/
                   name: plugin-volume
+                - mountPath: /data/certs
+                  name: connect-cert-volume
           initContainers:
             - command:
                 - sh
@@ -417,3 +424,6 @@ should render the cron deployment with the correct checksums, labels and annotat
             - emptyDir:
                 sizeLimit: 1Gi
               name: plugin-volume
+            - name: connect-cert-volume
+              secret:
+                secretName: release-name-platform-backend

--- a/charts/platform/tests/configmap_test.yaml
+++ b/charts/platform/tests/configmap_test.yaml
@@ -382,3 +382,21 @@ tests:
         GROUNDSWELL_SERVER_URL: http://RELEASE-NAME-pipeline-optimization:8090
         MICRONAUT_ENVIRONMENTS: prod,redis,ha,wave,groundswell
         TOWER_DATA_EXPLORER_ENABLED: 'false'
+- it: should render TOWER_OIDC_PEM_PATH in the shared-backend-cron configmap regardless of studios.enabled
+  documentSelector:
+    path: metadata.name
+    value: release-name-platform-shared-backend-cron
+  set:
+    studios:
+      enabled: false
+  asserts:
+  - equal:
+      path: data.TOWER_OIDC_PEM_PATH
+      value: /data/certs/oidc.pem
+- it: should not render TOWER_OIDC_PEM_PATH in the backend-only configmap
+  documentSelector:
+    path: metadata.name
+    value: release-name-platform-backend
+  asserts:
+  - notExists:
+      path: data.TOWER_OIDC_PEM_PATH

--- a/charts/platform/tests/deployment-cron_test.yaml
+++ b/charts/platform/tests/deployment-cron_test.yaml
@@ -613,6 +613,26 @@ tests:
         runAsNonRoot: false
         runAsUser: 2000
         asdf: 123
+- it: should include connect-cert-volume in the cron container volumes and volumeMounts
+  template: deployment-cron.yaml
+  asserts:
+  - equal:
+      path: spec.template.spec.volumes
+      value:
+      - configMap:
+          name: release-name-platform-tower-yml
+        name: config-volume
+      - emptyDir:
+          sizeLimit: 1Gi
+        name: plugin-volume
+      - name: connect-cert-volume
+        secret:
+          secretName: release-name-platform-backend
+  - contains:
+      path: spec.template.spec.containers[0].volumeMounts
+      content:
+        name: connect-cert-volume
+        mountPath: /data/certs
 - it: should include extra volumeMounts in the cron container
   template: deployment-cron.yaml
   set:
@@ -635,6 +655,8 @@ tests:
         name: plugin-volume
       - mountPath: /?/.nextflow/
         name: plugin-volume
+      - name: connect-cert-volume
+        mountPath: /data/certs
 - it: should use custom image for the cron deployment
   template: deployment-cron.yaml
   set:


### PR DESCRIPTION
Starting from Platform v26.1, the Platform cron deployment needs the OIDC pem key available.

I tested that it works with a local installation
```
$ k exec deploy/helmrelease-platform-cron -- cat /data/certs/oidc.pem
-----BEGIN RSA PRIVATE KEY-----
...
```