### PR TITLE
feat: add SEQERA_PLATFORM_APP_URL support

### DIFF
--- a/charts/platform/CHANGELOG.md
+++ b/charts/platform/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Portal web chart now uses the internal backend service (`global.platformServiceAddress`:`global.platformServicePort`) instead of the public external domain
+- Add `SEQERA_PLATFORM_APP_URL` to the portal-web chart configmap using `global.platformExternalDomain`
 - Bump `portal-web` subchart to 0.2.4
 
 ## [0.30.1] - 2026-04-16

--- a/charts/platform/charts/portal-web/CHANGELOG.md
+++ b/charts/platform/charts/portal-web/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Point `SEQERA_PLATFORM_API_URL` to the internal Platform backend service (`platformServiceAddress`:`platformServicePort`) instead of the external domain
+- Add `SEQERA_PLATFORM_APP_URL` to the portal-web chart configmap using `global.platformExternalDomain`
 - Add `global.platformServiceAddress` and `global.platformServicePort` values
 
 ## [0.2.3] - 2026-04-08

--- a/charts/platform/charts/portal-web/templates/configmap.yaml
+++ b/charts/platform/charts/portal-web/templates/configmap.yaml
@@ -31,6 +31,7 @@ metadata:
   annotations: {{- $annotations | nindent 4 }}
 data:
   SEQERA_PLATFORM_API_URL: {{ printf "http://%s:%s" (tpl .Values.global.platformServiceAddress .) (toString .Values.global.platformServicePort) | quote }}
+  SEQERA_PLATFORM_APP_URL: {{ printf "https://%s" (tpl .Values.global.platformExternalDomain .) | quote }}
   SEQERA_AGENT_BACKEND_URL: {{ printf "https://%s" (tpl .Values.global.agentBackendDomain .) | quote }}
 
   SEQERA_AUTH_DOMAIN: {{ printf "https://%s/api" (tpl .Values.global.platformExternalDomain .) | quote }}

--- a/charts/platform/charts/portal-web/tests/__snapshot__/configmap_test.yaml.snap
+++ b/charts/platform/charts/portal-web/tests/__snapshot__/configmap_test.yaml.snap
@@ -7,6 +7,7 @@ should render a ConfigMap with default values:
       SEQERA_AUTH_DOMAIN: https://example.com/api
       SEQERA_AUTH_WEB_CLIENT_ID: seqera_ai_portal_web
       SEQERA_PLATFORM_API_URL: http://release-name-platform-backend:8080
+      SEQERA_PLATFORM_APP_URL: https://example.com
     kind: ConfigMap
     metadata:
       annotations: {}

--- a/charts/platform/charts/portal-web/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/platform/charts/portal-web/tests/__snapshot__/deployment_test.yaml.snap
@@ -21,7 +21,7 @@ should render a Deployment with default values:
       template:
         metadata:
           annotations:
-            checksum/configmap: 12a3236c4e794f416b8f0622f14b21911535597a6b15e579c5c24f79f3c8e6ed
+            checksum/configmap: 8bf5469b88620cecc2332b46677819a63e63351bdf69851fa2a4fae4dba0a2db
             checksum/secret: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
           labels:
             app.kubernetes.io/component: portal-web

--- a/charts/platform/charts/portal-web/tests/configmap_test.yaml
+++ b/charts/platform/charts/portal-web/tests/configmap_test.yaml
@@ -39,6 +39,14 @@ tests:
           path: data.SEQERA_PLATFORM_API_URL
           value: "http://my-platform-backend:9090"
 
+  - it: should set SEQERA_PLATFORM_APP_URL from platformExternalDomain
+    set:
+      global.platformExternalDomain: prod.example.com
+    asserts:
+      - equal:
+          path: data.SEQERA_PLATFORM_APP_URL
+          value: "https://prod.example.com"
+
   - it: should template platformServiceAddress in SEQERA_PLATFORM_API_URL
     set:
       global.platformServiceAddress: '{{ printf "%s-platform-backend" .Release.Name | lower }}'


### PR DESCRIPTION
## Summary

Related to: https://github.com/seqeralabs/portal/pull/794, on top of #111

- add `SEQERA_PLATFORM_APP_URL` to the `portal-web` chart configmap using `global.platformExternalDomain`
- preserve the split between internal `SEQERA_PLATFORM_API_URL` and external browser-facing Platform URLs
- update chart tests and snapshots to cover the new runtime config and deployment checksum

## Test plan
- [x] Render chart templates with containerized Helm to validate the new configmap value
- [x] Refresh the affected configmap and deployment snapshots
- [ ] Deploy the updated chart and verify portal browser links open the external Platform domain
- [ ] Confirm portal API traffic still flows through the internal Platform backend service