### PR TITLE
feat: Wave lite, first release

### DIFF
--- a/.license-tools-config-helm-tests.json
+++ b/.license-tools-config-helm-tests.json
@@ -8,7 +8,7 @@
   "title": false,
   "custom_title": "yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json",
   "include": [
-    "*/tests/*.yaml",
-    "*/charts/*/tests/*.yaml"
+    "charts/*/tests/*.yaml",
+    "charts/*/charts/*/tests/*.yaml"
   ]
 }

--- a/.license-tools-config-helm.json
+++ b/.license-tools-config-helm.json
@@ -11,11 +11,11 @@
     ".txt": "GO_TEXT_TEMPLATE_STYLE"
   },
   "include": [
-    "*/templates/*.tpl",
-    "*/templates/*.txt",
-    "*/templates/*.yaml",
-    "*/charts/*/templates/*.tpl",
-    "*/charts/*/templates/*.txt",
-    "*/charts/*/templates/*.yaml"
+    "charts/*/templates/*.tpl",
+    "charts/*/templates/*.txt",
+    "charts/*/templates/*.yaml",
+    "charts/*/charts/*/templates/*.tpl",
+    "charts/*/charts/*/templates/*.txt",
+    "charts/*/charts/*/templates/*.yaml"
   ]
 }

--- a/.license-tools-config-other.json
+++ b/.license-tools-config-other.json
@@ -7,9 +7,9 @@
   "force_license": true,
   "title": false,
   "include": [
-    "*/Chart.yaml",
-    "*/values.yaml",
-    "*/charts/*/Chart.yaml",
-    "*/charts/*/values.yaml"
+    "charts/*/Chart.yaml",
+    "charts/*/values.yaml",
+    "charts/*/charts/*/Chart.yaml",
+    "charts/*/charts/*/values.yaml"
   ]
 }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,9 +18,6 @@ repos:
     hooks:
       - id: helmfmt
 
-  # The seqeralabs fork comes with Go text/template support and a fix for relative config files
-  # https://github.com/emzeat/mz-lictools/pull/47
-  # https://github.com/emzeat/mz-lictools/pull/48
   # Use separate calls to the same hook to first decorate helm template files with Go text/template
   # style, then decorate remaining yaml and other files with standard style.
   - repo: https://github.com/emzeat/mz-lictools

--- a/charts/platform/CHANGELOG.md
+++ b/charts/platform/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.31.0] - 2026-04-09
+
+### Added
+
+- Add first version of the `wave` subchart, which deploys the Wave server (https://seqera.io/wave/)
+
 ## [0.30.0] - 2026-04-08
 
 ### Added

--- a/charts/platform/Chart.lock
+++ b/charts/platform/Chart.lock
@@ -4,21 +4,24 @@ dependencies:
   version: 2.38.0
 - name: seqera-common
   repository: file://../seqera-common
-  version: 2.0.2
+  version: 2.1.0
 - name: pipeline-optimization
   repository: file://charts/pipeline-optimization
   version: 2.0.2
 - name: studios
   repository: file://charts/studios
   version: 1.2.9
+- name: wave
+  repository: file://charts/wave
+  version: 0.1.0
 - name: mcp
   repository: file://charts/mcp
   version: 0.3.0
 - name: agent-backend
   repository: file://charts/agent-backend
-  version: 0.4.5
+  version: 0.4.6
 - name: portal-web
   repository: file://charts/portal-web
   version: 0.2.3
-digest: sha256:7a36b28a204e3087d2d25eaa7a3a8d9bce966845c271b406a7e924deba7de2f6
-generated: "2026-04-09T10:15:53.623708429+02:00"
+digest: sha256:f6c360cfb47df70da219a5f98b4831c4a329274d0217096df899004e9325ebf0
+generated: "2026-04-10T15:13:58.09350286+02:00"

--- a/charts/platform/Chart.yaml
+++ b/charts/platform/Chart.yaml
@@ -37,7 +37,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.30.0
+version: 0.31.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -68,6 +68,12 @@ dependencies:
     tags:
       - studios
     condition: studios.enabled
+  - name: wave
+    version: "0.1.x"
+    repository: "file://charts/wave"
+    tags:
+      - wave
+    condition: wave.enabled
   - name: mcp
     version: "0.3.x"
     repository: "file://charts/mcp"

--- a/charts/platform/README.md
+++ b/charts/platform/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart to deploy Seqera Platform (also referred to as Tower) on Kubernetes.
 
-![Version: 0.30.0](https://img.shields.io/badge/Version-0.30.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v25.3.4](https://img.shields.io/badge/AppVersion-v25.3.4-informational?style=flat-square)
+![Version: 0.31.0](https://img.shields.io/badge/Version-0.31.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v25.3.4](https://img.shields.io/badge/AppVersion-v25.3.4-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -41,7 +41,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/platform \
-  --version 0.30.0 \
+  --version 0.31.0 \
   --namespace my-namespace \
   --create-namespace
 ```
@@ -68,6 +68,7 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | file://charts/pipeline-optimization | pipeline-optimization | 2.x.x |
 | file://charts/portal-web | portal-web | 0.2.x |
 | file://charts/studios | studios | 1.x.x |
+| file://charts/wave | wave | 0.1.x |
 | oci://registry-1.docker.io/bitnamicharts | common | 2.x.x |
 
 ## Values
@@ -80,6 +81,7 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | global.platformServicePort | int | `8080` | Seqera Platform Service port |
 | global.studiosDomain | string | `"{{ printf \"studios.%s\" .Values.global.platformExternalDomain }}"` | Domain where the Studios service listens. Make sure the TLS certificate covers this and its wildcard subdomains. Evaluated as a template |
 | global.studiosConnectionUrl | string | `"{{ printf \"https://connect.%s\" (tpl .Values.global.studiosDomain $) }}"` | Base URL for Studios connections: can be any value, since each session will use a unique subdomain under `.global.studiosDomain` anyway to connect. Evaluated as a template |
+| global.waveDomain | string | `"{{ printf \"wave.%s\" .Values.global.platformExternalDomain }}"` | Domain where Wave listens. Evaluated as a template |
 | global.mcpDomain | string | `"{{ printf \"mcp.%s\" .Values.global.platformExternalDomain }}"` | Domain where Seqera MCP listens. Evaluated as a template |
 | global.agentBackendDomain | string | `"{{ printf \"ai-api.%s\" .Values.global.platformExternalDomain }}"` | Domain where the Agent Backend service listens. Evaluated as a template |
 | global.portalWebDomain | string | `"{{ printf \"ai.%s\" .Values.global.platformExternalDomain }}"` | Domain where the Portal Web frontend listens. Evaluated as a template |

--- a/charts/platform/charts/agent-backend/CHANGELOG.md
+++ b/charts/platform/charts/agent-backend/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.6] - 2026-04-10
+
+### Changed
+
+- Reorder `values.yaml` sections to group `redis` alongside `database` for better readability
+- Update README to mention Redis connection details as a required configuration
+- Bump `seqera-common` dependency to 2.1.0
+
 ## [0.4.5] - 2026-04-08
 
 ### Changed

--- a/charts/platform/charts/agent-backend/Chart.lock
+++ b/charts/platform/charts/agent-backend/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 2.38.0
 - name: seqera-common
   repository: file://../../../seqera-common
-  version: 2.0.2
-digest: sha256:c73e43654f07f504de2cee1b5bb0b0263a215a9a0c5694fa86a7b44d0d4fbcef
-generated: "2026-04-08T10:48:40.334335202+02:00"
+  version: 2.1.0
+digest: sha256:e294bedc8101940323bb54df80e22f34220fc591c97a4ea5494ca7172ad318c5
+generated: "2026-04-10T15:14:05.041013846+02:00"

--- a/charts/platform/charts/agent-backend/Chart.yaml
+++ b/charts/platform/charts/agent-backend/Chart.yaml
@@ -19,7 +19,7 @@ apiVersion: v2
 name: agent-backend
 description: Backend service for Seqera CLI AI capabilities
 type: application
-version: 0.4.5
+version: 0.4.6
 appVersion: "2.0.0"
 maintainers:
   - name: Seqera Labs

--- a/charts/platform/charts/agent-backend/README.md
+++ b/charts/platform/charts/agent-backend/README.md
@@ -2,7 +2,7 @@
 
 Backend service for Seqera CLI AI capabilities
 
-![Version: 0.4.5](https://img.shields.io/badge/Version-0.4.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 0.4.6](https://img.shields.io/badge/Version-0.4.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -14,7 +14,8 @@ The chart does not automatically define `cr.seqera.io` as the registry where to 
 
 The required values to set in order to have a working installation are:
 - The `.image` section to point to your container registry.
-- The database connection details for the Agent Backend MySQL database under the `.database` section.
+- The database connection details for the MySQL database under the `.database` section.
+- The redis connection details under the `.redis` section.
 - Anthropic API credentials under `.anthropicApiKey` or `.anthropicApiKeyExistingSecretName`.
 - Container registry credentials under the `.global.imageCredentials` section (can be the credentials for cr.seqera.io or your private registry where you vendored the images to).
   * These credentials will be used by all the subcharts unless overridden in the specific subchart.
@@ -35,7 +36,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/agent-backend \
-  --version 0.4.5 \
+  --version 0.4.6 \
   --namespace my-namespace \
   --create-namespace
 ```
@@ -72,18 +73,6 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | database.enableTls | bool | `false` | Enable TLS for the MySQL database connection |
 | database.tlsCaVerify | bool | `true` | Verify the CA certificate when connecting via TLS (set to false to skip verification, insecure - for development/testing only) |
 | database.sslCa | string | `""` | Path to a CA certificate file for server certificate verification |
-| image.registry | string | `""` | Container image registry |
-| image.repository | string | `"private/nf-tower-enterprise/agent-backend"` | Container image repository |
-| image.tag | string | `"{{ .chart.AppVersion }}"` | Container image tag |
-| image.digest | string | `""` | Container image digest in the format `sha256:1234abcdef` |
-| image.pullPolicy | string | `"IfNotPresent"` | imagePullPolicy for the container Ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images |
-| image.pullSecrets | list | `[]` | List of imagePullSecrets Secrets must be created in the same namespace, for example using the .extraDeploy array Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ |
-| anthropicApiKey | string | `""` | Anthropic API key. Define the value as a String or a Secret, not both at the same time |
-| anthropicApiKeyExistingSecretName | string | `""` | Name of an existing Secret containing the Anthropic API key. Note: the Secret must already exist in the same namespace at the time of deployment |
-| anthropicApiKeyExistingSecretKey | string | `"ANTHROPIC_API_KEY"` | Key in the existing Secret containing the Anthropic API key |
-| tokenEncryptionKey | string | `""` | Token encryption key (must be a valid Fernet key). Define the value as a String or a Secret, not both at the same time. If not defined, a random Fernet key will be auto-generated at each deployment. WARNING: Always explicitly set this value or use an existing secret when using Kustomize. Auto-generated random values are incompatible with Kustomize. When upgrading releases via Kustomize, Helm cannot query the cluster to check if a secret already exists, causing it to regenerate a new random value on each upgrade |
-| tokenEncryptionKeyExistingSecretName | string | `""` | Name of an existing Secret containing the token encryption key. Note: the Secret must already exist in the same namespace at the time of deployment |
-| tokenEncryptionKeyExistingSecretKey | string | `"AGENT_BACKEND_TOKEN_ENCRYPTION_KEY"` | Key in the existing Secret containing the token encryption key |
 | redis.host | string | `""` | Redis hostname |
 | redis.port | int | `6379` | Redis port |
 | redis.db | int | `0` | Redis database index |
@@ -91,6 +80,18 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | redis.password | string | `""` | Redis password |
 | redis.existingSecretName | string | `""` | Name of an existing Secret containing the Redis password, as an alternative to the password field. Note: the Secret must already exist in the same namespace at the time of deployment |
 | redis.existingSecretKey | string | `"AGENT_BACKEND_REDIS_PASSWORD"` | Key in the existing Secret containing the Redis password |
+| anthropicApiKey | string | `""` | Anthropic API key. Define the value as a String or a Secret, not both at the same time |
+| anthropicApiKeyExistingSecretName | string | `""` | Name of an existing Secret containing the Anthropic API key. Note: the Secret must already exist in the same namespace at the time of deployment |
+| anthropicApiKeyExistingSecretKey | string | `"ANTHROPIC_API_KEY"` | Key in the existing Secret containing the Anthropic API key |
+| tokenEncryptionKey | string | `""` | Token encryption key (must be a valid Fernet key). Define the value as a String or a Secret, not both at the same time. If not defined, a random Fernet key will be auto-generated at each deployment. WARNING: Always explicitly set this value or use an existing secret when using Kustomize. Auto-generated random values are incompatible with Kustomize. When upgrading releases via Kustomize, Helm cannot query the cluster to check if a secret already exists, causing it to regenerate a new random value on each upgrade |
+| tokenEncryptionKeyExistingSecretName | string | `""` | Name of an existing Secret containing the token encryption key. Note: the Secret must already exist in the same namespace at the time of deployment |
+| tokenEncryptionKeyExistingSecretKey | string | `"AGENT_BACKEND_TOKEN_ENCRYPTION_KEY"` | Key in the existing Secret containing the token encryption key |
+| image.registry | string | `""` | Container image registry |
+| image.repository | string | `"private/nf-tower-enterprise/agent-backend"` | Container image repository |
+| image.tag | string | `"{{ .chart.AppVersion }}"` | Container image tag |
+| image.digest | string | `""` | Container image digest in the format `sha256:1234abcdef` |
+| image.pullPolicy | string | `"IfNotPresent"` | imagePullPolicy for the container Ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images |
+| image.pullSecrets | list | `[]` | List of imagePullSecrets Secrets must be created in the same namespace, for example using the .extraDeploy array Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ |
 | logLevel | string | `"INFO"` | Log level (one of CRITICAL, ERROR, WARNING, INFO, DEBUG) |
 | service | object | `{"extraOptions":{},"extraServices":[],"http":{"name":"http","nodePort":null,"port":80,"targetPort":8002},"type":"ClusterIP"}` | Service configuration |
 | service.type | string | `"ClusterIP"` | Service type. Note: ingresses using AWS ALB require the service to be NodePort |

--- a/charts/platform/charts/agent-backend/README.md.gotmpl
+++ b/charts/platform/charts/agent-backend/README.md.gotmpl
@@ -13,7 +13,8 @@ The chart does not automatically define `cr.seqera.io` as the registry where to 
 
 The required values to set in order to have a working installation are:
 - The `.image` section to point to your container registry.
-- The database connection details for the Agent Backend MySQL database under the `.database` section.
+- The database connection details for the MySQL database under the `.database` section.
+- The redis connection details under the `.redis` section.
 - Anthropic API credentials under `.anthropicApiKey` or `.anthropicApiKeyExistingSecretName`.
 - Container registry credentials under the `.global.imageCredentials` section (can be the credentials for cr.seqera.io or your private registry where you vendored the images to).
   * These credentials will be used by all the subcharts unless overridden in the specific subchart.

--- a/charts/platform/charts/agent-backend/templates/NOTES.txt
+++ b/charts/platform/charts/agent-backend/templates/NOTES.txt
@@ -64,7 +64,6 @@
 {{- printf "\nVALUES VALIDATION:\n%s" $message | fail -}}
 {{- end -}}
 
-
 Thank you for installing {{ .Chart.Name | title }}!
 
 Your release is named '{{ .Release.Name }}' and was installed in the '{{ include "common.names.namespace" . }}' namespace.

--- a/charts/platform/charts/agent-backend/values.yaml
+++ b/charts/platform/charts/agent-backend/values.yaml
@@ -62,8 +62,7 @@ database:
   # to the password field. Note: the Secret must already exist in the  same namespace at the time of
   # deployment
   existingSecretName: ""
-  # -- Key in the existing Secret containing the password for the MySQL
-  # database
+  # -- Key in the existing Secret containing the password for the MySQL database
   # @default -- `"AGENT_BACKEND_DB_PASSWORD"`
   existingSecretKey: ""
   # -- Enable TLS for the MySQL database connection
@@ -74,25 +73,23 @@ database:
   # -- Path to a CA certificate file for server certificate verification
   sslCa: ""
 
-image:
-  # -- Container image registry
-  registry: ""
-  # -- Container image repository
-  repository: private/nf-tower-enterprise/agent-backend
-  # -- Container image tag
-  # @default -- `"{{ .chart.AppVersion }}"`
-  tag: ""
-  # -- Container image digest in the format `sha256:1234abcdef`
-  digest: ""
-  # -- imagePullPolicy for the container
-  # Ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images
-  pullPolicy: IfNotPresent
-  # -- List of imagePullSecrets
-  # Secrets must be created in the same namespace, for example using the .extraDeploy array
-  # Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-  pullSecrets: []
-  # pullSecrets:
-  #   - myRegistryKeySecretName
+redis:
+  # -- Redis hostname
+  host: ""
+  # -- Redis port
+  port: 6379
+  # -- Redis database index
+  db: 0
+  # -- Enable TLS when connecting to Redis
+  enableTls: false
+  # -- Redis password
+  password: ""
+  # -- Name of an existing Secret containing the Redis password, as an alternative to the password
+  # field. Note: the Secret must already exist in the same namespace at the time of deployment
+  existingSecretName: ""
+  # -- Key in the existing Secret containing the Redis password
+  # @default -- `"AGENT_BACKEND_REDIS_PASSWORD"`
+  existingSecretKey: ""
 
 # -- Anthropic API key. Define the value as a String or a Secret, not both at the same time
 anthropicApiKey: ""
@@ -118,23 +115,25 @@ tokenEncryptionKeyExistingSecretName: ""
 # @default -- `"AGENT_BACKEND_TOKEN_ENCRYPTION_KEY"`
 tokenEncryptionKeyExistingSecretKey: ""
 
-redis:
-  # -- Redis hostname
-  host: ""
-  # -- Redis port
-  port: 6379
-  # -- Redis database index
-  db: 0
-  # -- Enable TLS when connecting to Redis
-  enableTls: false
-  # -- Redis password
-  password: ""
-  # -- Name of an existing Secret containing the Redis password, as an alternative to the password
-  # field. Note: the Secret must already exist in the same namespace at the time of deployment
-  existingSecretName: ""
-  # -- Key in the existing Secret containing the Redis password
-  # @default -- `"AGENT_BACKEND_REDIS_PASSWORD"`
-  existingSecretKey: ""
+image:
+  # -- Container image registry
+  registry: ""
+  # -- Container image repository
+  repository: private/nf-tower-enterprise/agent-backend
+  # -- Container image tag
+  # @default -- `"{{ .chart.AppVersion }}"`
+  tag: ""
+  # -- Container image digest in the format `sha256:1234abcdef`
+  digest: ""
+  # -- imagePullPolicy for the container
+  # Ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images
+  pullPolicy: IfNotPresent
+  # -- List of imagePullSecrets
+  # Secrets must be created in the same namespace, for example using the .extraDeploy array
+  # Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  pullSecrets: []
+  # pullSecrets:
+  #   - myRegistryKeySecretName
 
 # -- Log level (one of CRITICAL, ERROR, WARNING, INFO, DEBUG)
 logLevel: INFO

--- a/charts/platform/charts/mcp/CHANGELOG.md
+++ b/charts/platform/charts/mcp/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2026-04-10
+
+### Changed
+
+- Bump `seqera-common` dependency to 2.1.0
+
 ## [0.3.0] - 2026-04-09
 
 ### Changed

--- a/charts/platform/charts/mcp/Chart.lock
+++ b/charts/platform/charts/mcp/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 2.38.0
 - name: seqera-common
   repository: file://../../../seqera-common
-  version: 2.0.2
-digest: sha256:7b111521a34004487a6f8885db9475d1bbd8bd4d92cfc49cb2e6cca80b1571e2
-generated: "2026-04-08T10:48:46.366378367+02:00"
+  version: 2.1.0
+digest: sha256:437d502e6939f2fb10e3ea778fbfb9dd2642106392d290cc9ba24ffa91b07d7c
+generated: "2026-04-10T15:14:10.495361241+02:00"

--- a/charts/platform/charts/mcp/Chart.yaml
+++ b/charts/platform/charts/mcp/Chart.yaml
@@ -22,7 +22,7 @@ description: |
   Wave container provisioning, bioinformatics data, and nf-core modules through intelligent
   RAG-based natural language interactions.
 type: application
-version: 0.3.0
+version: 0.3.1
 appVersion: "1.1.0"
 maintainers:
   - name: Seqera Labs

--- a/charts/platform/charts/mcp/README.md
+++ b/charts/platform/charts/mcp/README.md
@@ -4,7 +4,7 @@ A Model Context Protocol (MCP) server that provides comprehensive access to the 
 Wave container provisioning, bioinformatics data, and nf-core modules through intelligent
 RAG-based natural language interactions.
 
-![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
+![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -37,7 +37,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/mcp \
-  --version 0.3.0 \
+  --version 0.3.1 \
   --namespace my-namespace \
   --create-namespace
 ```

--- a/charts/platform/charts/pipeline-optimization/CHANGELOG.md
+++ b/charts/platform/charts/pipeline-optimization/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.3] - 2026-04-10
+
+### Changed
+
+- Bump `seqera-common` dependency to 2.1.0
+
 ## [2.0.2] - 2026-04-08
 
 ### Changed

--- a/charts/platform/charts/pipeline-optimization/Chart.lock
+++ b/charts/platform/charts/pipeline-optimization/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 2.38.0
 - name: seqera-common
   repository: file://../../../seqera-common
-  version: 2.0.2
-digest: sha256:c73e43654f07f504de2cee1b5bb0b0263a215a9a0c5694fa86a7b44d0d4fbcef
-generated: "2026-04-08T10:48:51.937417226+02:00"
+  version: 2.1.0
+digest: sha256:e294bedc8101940323bb54df80e22f34220fc591c97a4ea5494ca7172ad318c5
+generated: "2026-04-10T15:14:16.368662517+02:00"

--- a/charts/platform/charts/pipeline-optimization/Chart.yaml
+++ b/charts/platform/charts/pipeline-optimization/Chart.yaml
@@ -23,7 +23,7 @@ maintainers:
     email: devops@seqera.io
     url: https://seqera.io
 type: application
-version: 2.0.2
+version: 2.0.3
 appVersion: "0.4.13"
 dependencies:
   - name: common

--- a/charts/platform/charts/pipeline-optimization/README.md
+++ b/charts/platform/charts/pipeline-optimization/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart to deploy the Seqera Pipeline Optimization service (referred to as Groundswell in Platform configuration files).
 
-![Version: 2.0.2](https://img.shields.io/badge/Version-2.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.13](https://img.shields.io/badge/AppVersion-0.4.13-informational?style=flat-square)
+![Version: 2.0.3](https://img.shields.io/badge/Version-2.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.13](https://img.shields.io/badge/AppVersion-0.4.13-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -37,7 +37,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/pipeline-optimization \
-  --version 2.0.2 \
+  --version 2.0.3 \
   --namespace my-namespace \
   --create-namespace
 ```

--- a/charts/platform/charts/portal-web/CHANGELOG.md
+++ b/charts/platform/charts/portal-web/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this chart will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.2.4] - 2026-04-10
+
+### Changed
+
+- Bump `seqera-common` dependency to 2.1.0
+
 ## [0.2.3] - 2026-04-08
 
 ### Changed

--- a/charts/platform/charts/portal-web/Chart.lock
+++ b/charts/platform/charts/portal-web/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 2.38.0
 - name: seqera-common
   repository: file://../../../seqera-common
-  version: 2.0.2
-digest: sha256:7b111521a34004487a6f8885db9475d1bbd8bd4d92cfc49cb2e6cca80b1571e2
-generated: "2026-04-08T10:48:57.63185887+02:00"
+  version: 2.1.0
+digest: sha256:437d502e6939f2fb10e3ea778fbfb9dd2642106392d290cc9ba24ffa91b07d7c
+generated: "2026-04-10T15:14:22.044647641+02:00"

--- a/charts/platform/charts/portal-web/Chart.yaml
+++ b/charts/platform/charts/portal-web/Chart.yaml
@@ -19,7 +19,7 @@ apiVersion: v2
 name: portal-web
 description: Portal web frontend for Seqera Platform
 type: application
-version: 0.2.3
+version: 0.2.4
 appVersion: "0.1.0"
 maintainers:
   - name: Seqera Labs

--- a/charts/platform/charts/portal-web/README.md
+++ b/charts/platform/charts/portal-web/README.md
@@ -2,7 +2,7 @@
 
 Portal web frontend for Seqera Platform
 
-![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.2.4](https://img.shields.io/badge/Version-0.2.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -31,7 +31,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/portal-web \
-  --version 0.2.3 \
+  --version 0.2.4 \
   --namespace my-namespace \
   --create-namespace
 ```

--- a/charts/platform/charts/studios/CHANGELOG.md
+++ b/charts/platform/charts/studios/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.10] - 2026-04-10
+
+### Changed
+
+- Bump `seqera-common` dependency to 2.1.0
+
 ## [1.2.9] - 2026-04-08
 
 ### Changed

--- a/charts/platform/charts/studios/Chart.lock
+++ b/charts/platform/charts/studios/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 2.38.0
 - name: seqera-common
   repository: file://../../../seqera-common
-  version: 2.0.2
-digest: sha256:c73e43654f07f504de2cee1b5bb0b0263a215a9a0c5694fa86a7b44d0d4fbcef
-generated: "2026-04-08T10:49:03.17231521+02:00"
+  version: 2.1.0
+digest: sha256:e294bedc8101940323bb54df80e22f34220fc591c97a4ea5494ca7172ad318c5
+generated: "2026-04-10T15:14:27.575325333+02:00"

--- a/charts/platform/charts/studios/Chart.yaml
+++ b/charts/platform/charts/studios/Chart.yaml
@@ -21,7 +21,7 @@ name: studios
 description: Studios is a unified platform for interactive analysis
 sources:
   - https://github.com/seqeralabs/helm-charts/tree/main/seqera/charts/studios
-version: 1.2.9
+version: 1.2.10
 appVersion: "0.11.0"
 maintainers:
   - name: Seqera Labs

--- a/charts/platform/charts/studios/README.md
+++ b/charts/platform/charts/studios/README.md
@@ -2,7 +2,7 @@
 
 Studios is a unified platform for interactive analysis
 
-![Version: 1.2.9](https://img.shields.io/badge/Version-1.2.9-informational?style=flat-square) ![AppVersion: 0.11.0](https://img.shields.io/badge/AppVersion-0.11.0-informational?style=flat-square)
+![Version: 1.2.10](https://img.shields.io/badge/Version-1.2.10-informational?style=flat-square) ![AppVersion: 0.11.0](https://img.shields.io/badge/AppVersion-0.11.0-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -41,7 +41,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/studios \
-  --version 1.2.9 \
+  --version 1.2.10 \
   --namespace my-namespace \
   --create-namespace
 ```

--- a/charts/platform/charts/wave/.helmignore
+++ b/charts/platform/charts/wave/.helmignore
@@ -1,0 +1,1 @@
+../../.helmignore

--- a/charts/platform/charts/wave/CHANGELOG.md
+++ b/charts/platform/charts/wave/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this chart will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2026-04-09
+
+### Added
+
+- Initial release of Wave chart

--- a/charts/platform/charts/wave/Chart.lock
+++ b/charts/platform/charts/wave/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: common
+  repository: oci://registry-1.docker.io/bitnamicharts
+  version: 2.38.0
+- name: seqera-common
+  repository: file://../../../seqera-common
+  version: 2.1.0
+digest: sha256:e294bedc8101940323bb54df80e22f34220fc591c97a4ea5494ca7172ad318c5
+generated: "2026-04-10T15:14:33.610749814+02:00"

--- a/charts/platform/charts/wave/Chart.yaml
+++ b/charts/platform/charts/wave/Chart.yaml
@@ -1,0 +1,38 @@
+# Copyright (c) 2026 Seqera Labs
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v2
+name: wave
+description: Wave
+type: application
+version: 0.1.0
+appVersion: "v1.32.4"
+maintainers:
+  - name: Seqera Labs
+    email: devops@seqera.io
+    url: https://seqera.io
+dependencies:
+  - name: common
+    repository: oci://registry-1.docker.io/bitnamicharts
+    tags:
+      - bitnami-common
+    version: "2.x.x"
+  - name: seqera-common
+    version: "2.x.x"
+    repository: file://../../../seqera-common
+    tags:
+      - seqera-common

--- a/charts/platform/charts/wave/README.md
+++ b/charts/platform/charts/wave/README.md
@@ -129,7 +129,7 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | initContainerDependencies.waitForPostgres.enabled | bool | `true` | Enable wait for PostgreSQL init container before starting the main container |
 | initContainerDependencies.waitForPostgres.image.registry | string | `""` | Override default wait for PostgreSQL init container image |
 | initContainerDependencies.waitForPostgres.image.repository | string | `"postgres"` |  |
-| initContainerDependencies.waitForPostgres.image.tag | string | `"12"` |  |
+| initContainerDependencies.waitForPostgres.image.tag | string | `"16-alpine"` |  |
 | initContainerDependencies.waitForPostgres.image.digest | string | `""` |  |
 | initContainerDependencies.waitForPostgres.image.pullPolicy | string | `"IfNotPresent"` |  |
 | initContainerDependencies.waitForPostgres.securityContext.runAsUser | int | `101` | UID the container processes run as (overrides container image default) |

--- a/charts/platform/charts/wave/README.md
+++ b/charts/platform/charts/wave/README.md
@@ -61,6 +61,7 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | global.waveDomain | string | `"{{ printf \"wave.%s\" .Values.global.platformExternalDomain }}"` | Domain where Wave listens. Evaluated as a template |
 | global.imageCredentials | list | `[]` | Optional credentials to log in and fetch images from a private registry. These credentials are shared with all the subcharts automatically |
 | global.imageCredentialsSecrets | list | `[]` | Optional list of existing Secrets containing image pull credentials to use for pulling images from private registries. These Secrets are shared with all the subcharts automatically |
+| micronautEnvironments | list | `["postgres","redis","lite"]` | List of Micronaut environments to enable |
 | database.host | string | `""` | PostgreSQL database hostname |
 | database.port | int | `5432` | PostgreSQL database port |
 | database.name | string | `""` | PostgreSQL database name |

--- a/charts/platform/charts/wave/README.md
+++ b/charts/platform/charts/wave/README.md
@@ -1,0 +1,195 @@
+# wave
+
+Wave
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.32.4](https://img.shields.io/badge/AppVersion-v1.32.4-informational?style=flat-square)
+
+> [!WARNING]
+> This chart is currently still in development and breaking changes are expected.
+> The public API SHOULD NOT be considered stable.
+
+## Requirements and configuration
+
+The chart does not automatically define `cr.seqera.io` as the registry where to take the images from: instructions are available to [vendor the Seqera container images to your private registry](https://docs.seqera.io/platform-enterprise/enterprise/prerequisites/common#vendoring-seqera-container-images-to-your-own-registry).
+
+The required values to set in order to have a working installation are:
+- The `.image` section to point to your container registry.
+- The database connection details for the PostgreSQL database under the `.database` section.
+- The redis connection details under the `.redis` section.
+- Container registry credentials under the `.global.imageCredentials` section (can be the credentials for cr.seqera.io or your private registry where you vendored the images to).
+  * These credentials will be used by all the subcharts unless overridden in the specific subchart.
+  * Multiple credentials can be specified to cover different registries.
+  * Specific pull secrets can be defined in each `.image` section to extend the global credentials.
+  * Image pull secrets defined in the specific `.image` section will be added to the global ones, not replacing them.
+
+The Helm chart comes with several requirement checks that will validate the provided configuration before proceeding with the installation.
+
+By default the chart selects the application images defined in the `appVersion` field of the `Chart.yaml` file, currently set as `v1.32.4`.
+
+When a sensitive value is required (e.g. the database password), you can either provide it directly in the values file or reference an existing Kubernetes Secret containing the value. The key names to use in the provided Secret are specified in the values file comments.
+Sensitive values provided as plain text by the user are always stored in a Kubernetes Secret created by the chart. When an external Secret is used instead, the chart instructs the components to read the sensitive value from the external Secret directly, without further storing copies of the sensitive value in the chart-created Secret.
+
+## Installing the chart
+
+To install the chart with the release name `my-release`:
+
+```console
+helm install my-release oci://public.cr.seqera.io/charts/wave \
+  --version 0.1.0 \
+  --namespace my-namespace \
+  --create-namespace
+```
+
+For a list of available chart versions, see the chart repository: https://public.cr.seqera.io/repo/charts/wave
+
+## Upgrading the chart
+
+When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md) for breaking changes and migration instructions.
+
+## Requirements
+
+| Repository | Name | Version |
+|------------|------|---------|
+| file://../../../seqera-common | seqera-common | 2.x.x |
+| oci://registry-1.docker.io/bitnamicharts | common | 2.x.x |
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| global.platformExternalDomain | string | `"example.com"` | Domain where Seqera Platform listens |
+| global.waveDomain | string | `"{{ printf \"wave.%s\" .Values.global.platformExternalDomain }}"` | Domain where Wave listens. Evaluated as a template |
+| global.imageCredentials | list | `[]` | Optional credentials to log in and fetch images from a private registry. These credentials are shared with all the subcharts automatically |
+| global.imageCredentialsSecrets | list | `[]` | Optional list of existing Secrets containing image pull credentials to use for pulling images from private registries. These Secrets are shared with all the subcharts automatically |
+| database.host | string | `""` | PostgreSQL database hostname |
+| database.port | int | `5432` | PostgreSQL database port |
+| database.name | string | `""` | PostgreSQL database name |
+| database.username | string | `""` | PostgreSQL database username |
+| database.password | string | `""` | PostgreSQL database password |
+| database.existingSecretName | string | `""` | Name of an existing Secret containing credentials for the PostgreSQL database, as an alternative to the password field. Note: the Secret must already exist in the  same namespace at the time of deployment |
+| database.existingSecretKey | string | `"WAVE_DB_PASSWORD"` | Key in the existing Secret containing the password for the PostgreSQL database |
+| database.enableTls | bool | `false` | Enable TLS for the PostgreSQL database connection |
+| redis.host | string | `""` | Redis hostname |
+| redis.port | int | `6379` | Redis port |
+| redis.db | int | `0` | Redis database index |
+| redis.enableTls | bool | `false` | Enable TLS when connecting to Redis |
+| redis.password | string | `""` | Redis password |
+| redis.existingSecretName | string | `""` | Name of an existing Secret containing the Redis password, as an alternative to the password field. Note: the Secret must already exist in the same namespace at the time of deployment |
+| redis.existingSecretKey | string | `"REDIS_PASSWORD"` | Key in the existing Secret containing the Redis password |
+| image.registry | string | `""` | Container image registry |
+| image.repository | string | `"private/nf-tower-enterprise/wave"` | Container image repository |
+| image.tag | string | `"{{ .chart.AppVersion }}"` | Container image tag |
+| image.digest | string | `""` | Container image digest in the format `sha256:1234abcdef` |
+| image.pullPolicy | string | `"IfNotPresent"` | imagePullPolicy for the container Ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images |
+| image.pullSecrets | list | `[]` | List of imagePullSecrets Secrets must be created in the same namespace, for example using the .extraDeploy array Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ |
+| service | object | `{"extraOptions":{},"extraServices":[],"http":{"name":"http","nodePort":null,"port":9090,"targetPort":9090},"type":"ClusterIP"}` | Service configuration |
+| service.type | string | `"ClusterIP"` | Service type. Note: ingresses using AWS ALB require the service to be NodePort |
+| service.http.name | string | `"http"` | Service name to use |
+| service.http.port | int | `9090` | Service port |
+| service.http.targetPort | int | `9090` | Port on the pod/container that the Service forwards traffic to (can be a number or named port, distinct from the Service's external port) |
+| service.http.nodePort | string | `nil` | Service node port, only used when service.type is Nodeport or LoadBalancer Choose port between 30000-32767, unless the cluster was configured differently than default |
+| service.extraServices | list | `[]` | Other services that should live in the Service object https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service |
+| service.extraOptions | object | `{}` | Extra Service options to place under .spec (for example, clusterIP, loadBalancerIP, externalTrafficPolicy, externalIPs). Evaluated as a template |
+| initContainers | list | `[]` | Additional init containers for the pod. Evaluated as a template |
+| command | list | `[]` | Override default container command (useful when using custom images) |
+| args | list | `[]` | Override default container args (useful when using custom images) |
+| workingDir | string | `"/work"` | Working directory for the main container process. Evaluated as a template |
+| podLabels | object | `{}` | Additional labels for the pod. Evaluated as a template |
+| podAnnotations | object | `{}` | Additional annotations for the pod. Evaluated as a template |
+| extraOptionsSpec | object | `{}` | Extra options to place under .spec (e.g. replicas, strategy, revisionHistoryLimit, etc). Evaluated as a template |
+| extraOptionsTemplateSpec | object | `{}` | Extra options to place under .spec.template.spec (e.g. nodeSelector, affinity, restartPolicy, etc). Evaluated as a template |
+| extraEnvVars | list | `[]` | Extra environment variables |
+| extraEnvVarsCMs | list | `[]` | List of ConfigMaps containing extra env vars |
+| extraEnvVarsSecrets | list | `[]` | List of Secrets containing extra env vars |
+| extraVolumes | list | `[]` | List of volumes to add to the deployment (evaluated as template). Requires setting `extraVolumeMounts` |
+| extraVolumeMounts | list | `[]` | List of volume mounts to add to the container (evaluated as template). Normally used with `extraVolumes` |
+| podSecurityContext.enabled | bool | `true` | Enable pod Security Context |
+| podSecurityContext.fsGroup | int | `101` | Sets the GID that Kubernetes will apply to mounted volumes and created files so processes in the pod can share group-owned access |
+| containerSecurityContext.enabled | bool | `true` | Enable container Security Context |
+| containerSecurityContext.runAsUser | int | `101` | UID the container processes run as (overrides container image default) |
+| containerSecurityContext.runAsNonRoot | bool | `true` | Boolean that requires the container to run as a non-root UID (prevents starting if UID 0) |
+| containerSecurityContext.readOnlyRootFilesystem | bool | `true` | Mounts the container root filesystem read-only to prevent in-place writes or tampering |
+| containerSecurityContext.capabilities | object | `{"drop":["ALL"]}` | Fine-grained Linux kernel privileges to add or drop for the container |
+| resources | object | `{}` | Container requests and limits for different resources like CPU or memory |
+| initContainerDependencies.enabled | bool | `true` | Enable init containers that coordinate startup dependencies |
+| initContainerDependencies.waitForRedis.enabled | bool | `true` | Enable wait for Redis init container before starting the main container |
+| initContainerDependencies.waitForRedis.image.registry | string | `""` | Override default wait for Redis init container image |
+| initContainerDependencies.waitForRedis.image.repository | string | `"redis"` |  |
+| initContainerDependencies.waitForRedis.image.tag | string | `"7-alpine"` |  |
+| initContainerDependencies.waitForRedis.image.digest | string | `""` |  |
+| initContainerDependencies.waitForRedis.image.pullPolicy | string | `"IfNotPresent"` |  |
+| initContainerDependencies.waitForRedis.securityContext.runAsUser | int | `101` | UID the container processes run as (overrides container image default) |
+| initContainerDependencies.waitForRedis.securityContext.runAsNonRoot | bool | `true` | Require the container to run as a non-root UID (prevents starting if UID is 0) |
+| initContainerDependencies.waitForRedis.securityContext.readOnlyRootFilesystem | bool | `true` | Mount the container root filesystem read-only to prevent in-place writes or tampering |
+| initContainerDependencies.waitForRedis.securityContext.capabilities | object | `{"drop":["ALL"]}` | Fine-grained Linux kernel privileges to add or drop for the container |
+| initContainerDependencies.waitForRedis.resources | object | `{"limits":{"memory":"100Mi"},"requests":{"cpu":"0.5","memory":"50Mi"}}` | Container requests and limits for different resources like CPU or memory |
+| initContainerDependencies.waitForRedis.extraEnvVars | list | `[]` | Additional environment variables for the init container |
+| initContainerDependencies.waitForRedis.extraVolumeMounts | list | `[]` | Additional volume mounts for the init container (e.g. to mount a CA certificate) |
+| initContainerDependencies.waitForPostgres.enabled | bool | `true` | Enable wait for PostgreSQL init container before starting the main container |
+| initContainerDependencies.waitForPostgres.image.registry | string | `""` | Override default wait for PostgreSQL init container image |
+| initContainerDependencies.waitForPostgres.image.repository | string | `"postgres"` |  |
+| initContainerDependencies.waitForPostgres.image.tag | string | `"12"` |  |
+| initContainerDependencies.waitForPostgres.image.digest | string | `""` |  |
+| initContainerDependencies.waitForPostgres.image.pullPolicy | string | `"IfNotPresent"` |  |
+| initContainerDependencies.waitForPostgres.securityContext.runAsUser | int | `101` | UID the container processes run as (overrides container image default) |
+| initContainerDependencies.waitForPostgres.securityContext.runAsNonRoot | bool | `true` | Require the container to run as a non-root UID (prevents starting if UID is 0) |
+| initContainerDependencies.waitForPostgres.securityContext.readOnlyRootFilesystem | bool | `true` | Mount the container root filesystem read-only to prevent in-place writes or tampering |
+| initContainerDependencies.waitForPostgres.securityContext.capabilities | object | `{"drop":["ALL"]}` | Fine-grained Linux kernel privileges to add or drop for the container |
+| initContainerDependencies.waitForPostgres.resources | object | `{"limits":{"memory":"100Mi"},"requests":{"cpu":"0.5","memory":"50Mi"}}` | Container requests and limits for different resources like CPU or memory |
+| initContainerDependencies.waitForPostgres.extraEnvVars | list | `[]` | Additional environment variables for the init container. The special variable `MYSQL_EXTRA_ARGS` is appended verbatim to the `mysql` readiness check command, and can be used to pass TLS flags when connecting to managed MySQL services such as AWS RDS or Azure Database for MySQL that require certificate verification. Pair with `extraVolumeMounts` to mount the CA certificate into the container. Example (TLS with CA certificate mounted from a volume): extraEnvVars:   - name: MYSQL_EXTRA_ARGS     value: "--ssl-ca=/certs/ca.pem --ssl-mode=VERIFY_IDENTITY" |
+| initContainerDependencies.waitForPostgres.extraVolumeMounts | list | `[]` | Additional volume mounts for the init container. Use this to mount CA certificates (e.g. from a Secret or ConfigMap populated by an extraInitContainer) so that `MYSQL_EXTRA_ARGS` can reference them. |
+| startupProbe.enabled | bool | `false` | Enable startup probe |
+| startupProbe.httpGet.path | string | `"/health"` | HTTP GET path for startup probe |
+| startupProbe.httpGet.port | string | `"{{ .Values.service.http.targetPort }}"` | HTTP GET port for startup probe. Evaluated as a template |
+| startupProbe.initialDelaySeconds | int | `5` | Longer initial wait to accommodate slow-starting apps |
+| startupProbe.periodSeconds | int | `10` | Often set longer to avoid frequent checks while starting |
+| startupProbe.timeoutSeconds | int | `3` | Can be longer to allow slow initialization responses |
+| startupProbe.failureThreshold | int | `5` | Consecutive failures during startup before killing the container (instead of immediate restarts) |
+| startupProbe.successThreshold | int | `1` | Number of consecutive successes required to consider startup complete and enable liveness/readiness |
+| readinessProbe.enabled | bool | `true` | Enable readiness probe |
+| readinessProbe.httpGet.path | string | `"/health"` | HTTP GET path for readiness probe |
+| readinessProbe.httpGet.port | string | `"{{ .Values.service.http.targetPort }}"` | HTTP GET port for readiness probe. Evaluated as a template |
+| readinessProbe.initialDelaySeconds | int | `5` | Delay before first check (normal start timing) |
+| readinessProbe.periodSeconds | int | `5` | Regular check interval during normal operation |
+| readinessProbe.timeoutSeconds | int | `3` | Short timeout to detect unresponsive containers for readiness |
+| readinessProbe.failureThreshold | int | `5` | Consecutive failures before marking the container Unready (no restart) |
+| readinessProbe.successThreshold | int | `1` | Number of consecutive successes required to mark the container Ready after failures |
+| livenessProbe.enabled | bool | `true` | Enable liveness probe |
+| livenessProbe.httpGet.path | string | `"/health"` | HTTP GET path for liveness probe |
+| livenessProbe.httpGet.port | string | `"{{ .Values.service.http.targetPort }}"` | HTTP GET port for liveness probe. Evaluated as a template |
+| livenessProbe.initialDelaySeconds | int | `5` | Delay before first check (normal start timing) |
+| livenessProbe.periodSeconds | int | `10` | Regular check interval during normal operation |
+| livenessProbe.timeoutSeconds | int | `3` | Short timeout to detect hung containers quickly |
+| livenessProbe.failureThreshold | int | `10` | Consecutive failures before restarting the container |
+| livenessProbe.successThreshold | int | `1` | Typically 1 (usually ignored) |
+| serviceAccount | object | `{"annotations":{},"automountServiceAccountToken":true,"imagePullSecretNames":[],"name":""}` | Service account configuration |
+| serviceAccount.name | string | `""` | Service account name |
+| serviceAccount.annotations | object | `{}` | Service account annotations |
+| serviceAccount.imagePullSecretNames | list | `[]` | Names of Secrets containing credentials to pull images from registries |
+| serviceAccount.automountServiceAccountToken | bool | `true` | Automatically mount service account token |
+| ingress.enabled | bool | `false` | Enable ingress for Wave |
+| ingress.path | string | `"/"` | Path for the main ingress rule Note: this needs to be set to '/*' to be used with AWS ALB ingress controller |
+| ingress.defaultPathType | string | `"ImplementationSpecific"` | Default path type for the Ingress |
+| ingress.defaultBackend | object | `{}` | Configure the default service for the ingress (evaluated as template) Important: make sure only one defaultBackend is defined across the k8s cluster: if the ingress doesn't reconcile successfully, 'describe ingress <name>' will report problems |
+| ingress.extraHosts | list | `[]` | Additional hosts you want to include. Evaluated as a template |
+| ingress.annotations | object | `{}` | Ingress annotations specific to your load balancer. Evaluated as a template |
+| ingress.extraLabels | object | `{}` | Additional labels for the ingress object. Evaluated as a template |
+| ingress.ingressClassName | string | `""` | Name of the ingress class (replaces the deprecated annotation `kubernetes.io/ingress.class`) |
+| ingress.tls | list | `[]` | TLS configuration. Evaluated as a template |
+| extraDeploy | list | `[]` | Array of extra objects to deploy with the release |
+| commonAnnotations | object | `{}` | Annotations to add to all deployed objects |
+| commonLabels | object | `{}` | Labels to add to all deployed objects |
+| secretLabels | object | `{}` | Additional labels for the Secret objects. Evaluated as a template |
+| secretAnnotations | object | `{}` | Additional annotations for the Secret objects. Evaluated as a template |
+| configMapLabels | object | `{}` | Additional labels for the ConfigMap objects. Evaluated as a template |
+| configMapAnnotations | object | `{}` | Additional annotations for the ConfigMap objects. Evaluated as a template |
+
+## Licensing
+
+Seqera® and Nextflow® are registered trademarks of Seqera Labs.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.

--- a/charts/platform/charts/wave/README.md.gotmpl
+++ b/charts/platform/charts/wave/README.md.gotmpl
@@ -1,0 +1,60 @@
+{{ template "chart.header" . }}
+{{ template "chart.description" . }}
+
+{{ template "chart.versionBadge" . }}{{ template "chart.typeBadge" . }}{{ template "chart.appVersionBadge" . }}
+
+> [!WARNING]
+> This chart is currently still in development and breaking changes are expected.
+> The public API SHOULD NOT be considered stable.
+
+## Requirements and configuration
+
+The chart does not automatically define `cr.seqera.io` as the registry where to take the images from: instructions are available to [vendor the Seqera container images to your private registry](https://docs.seqera.io/platform-enterprise/enterprise/prerequisites/common#vendoring-seqera-container-images-to-your-own-registry).
+
+The required values to set in order to have a working installation are:
+- The `.image` section to point to your container registry.
+- The database connection details for the PostgreSQL database under the `.database` section.
+- The redis connection details under the `.redis` section.
+- Container registry credentials under the `.global.imageCredentials` section (can be the credentials for cr.seqera.io or your private registry where you vendored the images to).
+  * These credentials will be used by all the subcharts unless overridden in the specific subchart.
+  * Multiple credentials can be specified to cover different registries.
+  * Specific pull secrets can be defined in each `.image` section to extend the global credentials.
+  * Image pull secrets defined in the specific `.image` section will be added to the global ones, not replacing them.
+
+The Helm chart comes with several requirement checks that will validate the provided configuration before proceeding with the installation.
+
+By default the chart selects the application images defined in the `appVersion` field of the `Chart.yaml` file, currently set as `{{ template "chart.appVersion" . }}`.
+
+When a sensitive value is required (e.g. the database password), you can either provide it directly in the values file or reference an existing Kubernetes Secret containing the value. The key names to use in the provided Secret are specified in the values file comments.
+Sensitive values provided as plain text by the user are always stored in a Kubernetes Secret created by the chart. When an external Secret is used instead, the chart instructs the components to read the sensitive value from the external Secret directly, without further storing copies of the sensitive value in the chart-created Secret.
+
+## Installing the chart
+
+To install the chart with the release name `my-release`:
+
+```console
+helm install my-release oci://public.cr.seqera.io/charts/{{ template "chart.name" . }} \
+  --version {{ template "chart.version" . }} \
+  --namespace my-namespace \
+  --create-namespace
+```
+
+For a list of available chart versions, see the chart repository: https://public.cr.seqera.io/repo/charts/{{ template "chart.name" . }}
+
+## Upgrading the chart
+
+When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md) for breaking changes and migration instructions.
+
+{{ template "chart.requirementsSection" . }}
+
+{{ template "chart.valuesSection" . }}
+
+## Licensing
+
+Seqera® and Nextflow® are registered trademarks of Seqera Labs.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.

--- a/charts/platform/charts/wave/templates/NOTES.txt
+++ b/charts/platform/charts/wave/templates/NOTES.txt
@@ -1,0 +1,64 @@
+{{/*
+ Copyright (c) 2026 Seqera Labs
+ All rights reserved.
+
+ SPDX-License-Identifier: Apache-2.0
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/}}
+
+{{/* We can't put checks in _helpers.tpl, it doesn't make installation fail. */}}
+
+{{- if not .Values.database.host -}}
+{{- $message := "Define the Wave database host at 'database.host'." -}}
+{{- printf "\nVALUES VALIDATION:\n%s" $message | fail -}}
+{{- end -}}
+
+{{- if not .Values.database.name -}}
+{{- $message := "Define the Wave database name at 'database.name'." -}}
+{{- printf "\nVALUES VALIDATION:\n%s" $message | fail -}}
+{{- end -}}
+
+{{- if not .Values.database.username -}}
+{{- $message := "Define the Wave database username at 'database.username'." -}}
+{{- printf "\nVALUES VALIDATION:\n%s" $message | fail -}}
+{{- end -}}
+
+{{- if and (not .Values.database.password) (not .Values.database.existingSecretName) -}}
+{{- $message := "Define the Wave database password at 'database.password' or provide an existing secret name at 'database.existingSecretName'." -}}
+{{- printf "\nVALUES VALIDATION:\n%s" $message | fail -}}
+{{- end -}}
+
+{{- if and .Values.database.password .Values.database.existingSecretName -}}
+{{- $message := "Either provide 'database.password' or an existing secret name in 'database.existingSecretName', but not both." -}}
+{{- printf "\nVALUES VALIDATION:\n%s" $message | fail -}}
+{{- end -}}
+
+{{- if not .Values.redis.host -}}
+{{- $message := "Define the Wave Redis host at 'redis.host'." -}}
+{{- printf "\nVALUES VALIDATION:\n%s" $message | fail -}}
+{{- end -}}
+
+{{- if and .Values.redis.password .Values.redis.existingSecretName -}}
+{{- $message := "Either provide 'redis.password' or an existing secret name in 'redis.existingSecretName', but not both." -}}
+{{- printf "\nVALUES VALIDATION:\n%s" $message | fail -}}
+{{- end -}}
+
+Thank you for installing {{ .Chart.Name | title }}!
+
+Your release is named '{{ .Release.Name }}' and was installed in the '{{ include "common.names.namespace" . }}' namespace.
+
+To check the status of your release, try:
+
+  $ helm --namespace {{ include "common.names.namespace" . }} status {{ .Release.Name }}
+  $ helm --namespace {{ include "common.names.namespace" . }} get all {{ .Release.Name }}

--- a/charts/platform/charts/wave/templates/_helpers.tpl
+++ b/charts/platform/charts/wave/templates/_helpers.tpl
@@ -74,6 +74,17 @@ Return the name of the secret containing the Redis password.
   {{- include "wave.redis.existingSecret" . | default (include "common.names.fullname" .) -}}
 {{- end -}}
 
+{{/*
+Build the Wave micronaut envs list: always ensure required environments are present.
+*/}}
+{{- define "wave.micronautEnvs" -}}
+  {{- $list := .Values.micronautEnvironments -}}
+  {{/* Always make sure the required micronaut environments are added to the list */}}
+  {{- $list = append $list "postgres" -}}
+  {{- $list = append $list "redis" -}}
+  {{- uniq $list | join "," | quote -}}
+{{- end -}}
+
 {{- define "wave.redis.existingSecret.secretKey" -}}
   {{- if (include "wave.redis.existingSecret" .) -}}
     {{- printf "%s" (tpl .Values.redis.existingSecretKey .) | default "WAVE_REDIS_PASSWORD" -}}

--- a/charts/platform/charts/wave/templates/_helpers.tpl
+++ b/charts/platform/charts/wave/templates/_helpers.tpl
@@ -1,0 +1,83 @@
+{{/*
+ Copyright (c) 2026 Seqera Labs
+ All rights reserved.
+
+ SPDX-License-Identifier: Apache-2.0
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "wave.serviceAccountName" -}}
+{{- default (printf "%s-sa" (include "common.names.fullname" .)) .Values.serviceAccount.name -}}
+{{- end }}
+
+{{/*
+Return the name of the secret containing the database password.
+*/}}
+{{- define "wave.database.existingSecret" -}}
+  {{- printf "%s" (tpl .Values.database.existingSecretName .) -}}
+{{- end -}}
+{{- define "wave.database.existingSecret.secretName" -}}
+  {{- include "wave.database.existingSecret" . | default (include "common.names.fullname" .) -}}
+{{- end -}}
+
+{{- define "wave.database.existingSecret.secretKey" -}}
+  {{- if (include "wave.database.existingSecret" .) -}}
+    {{- printf "%s" (tpl .Values.database.existingSecretKey .) | default "WAVE_DB_PASSWORD" -}}
+  {{- else -}}
+    {{- printf "WAVE_DB_PASSWORD" -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Return the PostgreSQL URI.
+*/}}
+{{- define "wave.database.uri" -}}
+  {{- printf "jdbc:postgresql://%s:%d/%s"
+  (tpl .Values.database.host .)
+  (.Values.database.port | int)
+  (tpl .Values.database.name .)
+  -}}
+{{- end -}}
+
+{{/*
+Return the Redis URI for the wait-for-redis init container.
+*/}}
+{{- define "wave.redis.uri" -}}
+  {{- printf "%s://%s:%d"
+  (ternary "rediss" "redis" (.Values.redis.enableTls | toString | eq "true"))
+  (tpl .Values.redis.host .)
+  (.Values.redis.port | int)
+  -}}
+{{- end -}}
+
+{{/*
+Return the name of the secret containing the Redis password.
+*/}}
+{{- define "wave.redis.existingSecret" -}}
+  {{- printf "%s" (tpl .Values.redis.existingSecretName .) -}}
+{{- end -}}
+{{- define "wave.redis.existingSecret.secretName" -}}
+  {{- include "wave.redis.existingSecret" . | default (include "common.names.fullname" .) -}}
+{{- end -}}
+
+{{- define "wave.redis.existingSecret.secretKey" -}}
+  {{- if (include "wave.redis.existingSecret" .) -}}
+    {{- printf "%s" (tpl .Values.redis.existingSecretKey .) | default "WAVE_REDIS_PASSWORD" -}}
+  {{- else -}}
+    {{- printf "WAVE_REDIS_PASSWORD" -}}
+  {{- end -}}
+{{- end -}}

--- a/charts/platform/charts/wave/templates/configmap.yaml
+++ b/charts/platform/charts/wave/templates/configmap.yaml
@@ -1,0 +1,40 @@
+{{/*
+ Copyright (c) 2026 Seqera Labs
+ All rights reserved.
+
+ SPDX-License-Identifier: Apache-2.0
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/}}
+
+{{- $commonLabels := include "common.labels.standard" (dict "customLabels" .Values.commonLabels "context" $) | fromYaml -}}
+{{- $mergedlabels := include "common.tplvalues.merge" (dict "values" (list .Values.configMapLabels $commonLabels) "context" .) -}}
+{{- $labels := include "common.tplvalues.render" (dict "value" $mergedlabels "context" $) -}}
+{{- $mergedAnnotations := include "common.tplvalues.merge" (dict "values" (list .Values.configMapAnnotations .Values.commonAnnotations) "context" .) -}}
+{{- $annotations := include "common.tplvalues.render" (dict "value" $mergedAnnotations "context" $) -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "common.names.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- $labels | nindent 4 }}
+  annotations: {{- $annotations | nindent 4 }}
+data:
+  MICRONAUT_ENVIRONMENTS: "postgres,redis,lite" # TODO
+  MICRONAUT_SERVER_PORT: {{ .Values.service.http.targetPort | quote }}
+  TOWER_ENDPOINT_URL: '{{ printf "https://%s/api" .Values.global.platformExternalDomain | quote }}'
+  WAVE_SERVER_URL: {{ printf "https://%s" (tpl .Values.global.platformExternalDomain $) | quote }}
+
+  REDIS_URI: {{ include "wave.redis.uri" . | quote }}
+  WAVE_DB_USER: {{ .Values.database.username | quote }}
+  WAVE_DB_URI: {{ include "wave.database.uri" . | quote }}

--- a/charts/platform/charts/wave/templates/configmap.yaml
+++ b/charts/platform/charts/wave/templates/configmap.yaml
@@ -30,7 +30,7 @@ metadata:
   labels: {{- $labels | nindent 4 }}
   annotations: {{- $annotations | nindent 4 }}
 data:
-  MICRONAUT_ENVIRONMENTS: "postgres,redis,lite" # TODO
+  MICRONAUT_ENVIRONMENTS: {{ include "wave.micronautEnvs" . }}
   MICRONAUT_SERVER_PORT: {{ .Values.service.http.targetPort | quote }}
   TOWER_ENDPOINT_URL: '{{ printf "https://%s/api" .Values.global.platformExternalDomain | quote }}'
   WAVE_SERVER_URL: {{ printf "https://%s" (tpl .Values.global.platformExternalDomain $) | quote }}

--- a/charts/platform/charts/wave/templates/deployment.yaml
+++ b/charts/platform/charts/wave/templates/deployment.yaml
@@ -63,8 +63,9 @@ spec:
 {{- end }}
 
       initContainers:
-        - name: busybox
-          image: busybox:latest
+        - name: touch-config-file
+          image: {{ include "seqera.images.image" (dict "imageRoot" .Values.image "global" .Values.global "chart" .Chart "cloudProviderImageKey" "wave" "context" $) }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["sh", "-c", "> /tmp/config.yml"]
           volumeMounts:
             - name: tmp

--- a/charts/platform/charts/wave/templates/deployment.yaml
+++ b/charts/platform/charts/wave/templates/deployment.yaml
@@ -1,0 +1,155 @@
+{{/*
+ Copyright (c) 2026 Seqera Labs
+ All rights reserved.
+
+ SPDX-License-Identifier: Apache-2.0
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/}}
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "common.names.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" (dict "customLabels" .Values.commonLabels "context" $) | nindent 4 }}
+    app.kubernetes.io/component: wave
+{{- with .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" (dict "value" . "context" $) | nindent 4 }}
+{{- end }}
+
+spec:
+{{- $podLabels := include "common.tplvalues.merge" (dict "values" (list .Values.podLabels .Values.commonLabels) "context" .) }}
+  selector:
+    matchLabels: {{- include "common.labels.matchLabels" (dict "customLabels" $podLabels "context" $) | nindent 6 }}
+      app.kubernetes.io/component: wave
+# This prevents an empty dict {} to be rendered when extraOptionsSpec only contains keys that are
+# already rendered explicitly in the template (selector is always rendered by the template)
+{{- $extraOptionsSpec := omit .Values.extraOptionsSpec "selector" }}
+{{- if $extraOptionsSpec }}
+  {{- include "seqera.tplvalues.render" (dict "value" $extraOptionsSpec "context" $) | nindent 2 }}
+{{- end }}
+  template:
+    metadata:
+      labels: {{- include "common.labels.standard" (dict "customLabels" $podLabels "context" $) | nindent 8 }}
+        app.kubernetes.io/component: wave
+      annotations:
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+{{- if or .Values.podAnnotations .Values.commonAnnotations }}
+  {{- $podAnnotations := include "common.tplvalues.merge" (dict "values" (list .Values.podAnnotations .Values.commonAnnotations) "context" $) }}
+        {{- include "common.tplvalues.render" (dict "value" $podAnnotations "context" $) | nindent 8 }}
+{{- end }}
+
+    spec:
+      serviceAccountName: {{ include "wave.serviceAccountName" . }}
+{{- if .Values.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 8 }}
+{{- end }}
+{{- $extraOptionsTemplateSpec := omit .Values.extraOptionsTemplateSpec "serviceAccountName" "serviceAccount" "securityContext" "initContainers" "containers" "volumes" "imagePullSecrets" }}
+{{- if $extraOptionsTemplateSpec }}
+      {{- include "seqera.tplvalues.render" (dict "value" $extraOptionsTemplateSpec "context" $) | nindent 6 }}
+{{- end }}
+
+      initContainers:
+        - name: busybox
+          image: busybox:latest
+          command: ["sh", "-c", "> /tmp/config.yml"]
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+{{- with .Values.initContainers }}
+        {{- include "seqera.tplvalues.render" (dict "value" . "context" $) | nindent 8 }}
+{{- end }}
+{{- if .Values.initContainerDependencies.enabled }}
+  {{- if .Values.initContainerDependencies.waitForPostgres.enabled }}
+        {{- include "seqera.initContainers.waitForPostgres" (dict "name" "db" "waitValues" .Values.initContainerDependencies.waitForPostgres "connDetails" .Values.database "secretNameTemplate" "wave.database.existingSecret.secretName" "secretKeyTemplate" "wave.database.existingSecret.secretKey" "cloudProviderImageKey" "waitForPostgres" "context" $) | nindent 8 }}
+  {{- end }}
+  {{- if .Values.initContainerDependencies.waitForRedis.enabled }}
+        {{- include "seqera.initContainers.waitForRedis" (dict "name" "redis" "waitValues" .Values.initContainerDependencies.waitForRedis "uriTemplate" "wave.redis.uri" "secretNameTemplate" "wave.redis.existingSecret.secretName" "secretKeyTemplate" "wave.redis.existingSecret.secretKey" "cloudProviderImageKey" "waitForRedis" "context" $) | nindent 8 }}
+  {{- end }}
+{{- end }}
+
+      containers:
+        - name: wave
+          image: {{ include "seqera.images.image" (dict "imageRoot" .Values.image "global" .Values.global "chart" .Chart "cloudProviderImageKey" "wave" "context" $) }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          workingDir: {{ tpl .Values.workingDir $ | quote }}
+{{- with .Values.command }}
+          command: {{- toYaml . | nindent 12 }}
+{{- end }}
+{{- with .Values.args }}
+          args: {{- toYaml . | nindent 12 }}
+{{- end }}
+          env:
+            - name: WAVE_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "wave.database.existingSecret.secretName" . }}
+                  key: {{ include "wave.database.existingSecret.secretKey" . }}
+{{- if or .Values.redis.password .Values.redis.existingSecretName }}
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "wave.redis.existingSecret.secretName" . }}
+                  key: {{ include "wave.redis.existingSecret.secretKey" . }}
+{{- end }}
+{{- with .Values.extraEnvVars }}
+            {{- include "seqera.envVars.render" (dict "value" . "context" $) | nindent 12 }}
+{{- end }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "common.names.fullname" . }}
+{{- range .Values.extraEnvVarsCMs }}
+            - configMapRef:
+                name: {{ include "common.tplvalues.render" (dict "value" . "context" $) }}
+{{- end }}
+{{- range .Values.extraEnvVarsSecrets }}
+            - secretRef:
+                name: {{ include "common.tplvalues.render" (dict "value" . "context" $) }}
+{{- end }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /work
+{{- with .Values.extraVolumeMounts }}
+            {{- include "seqera.tplvalues.render" (dict "value" . "context" $) | nindent 12 }}
+{{- end }}
+{{- if .Values.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+{{- end }}
+
+{{- if .Values.livenessProbe.enabled }}
+          livenessProbe: {{- include "seqera.tplvalues.render" (dict "value" (omit .Values.livenessProbe "enabled") "context" $) | nindent 12 }}
+{{- end }}
+{{- if .Values.readinessProbe.enabled }}
+          readinessProbe: {{- include "seqera.tplvalues.render" (dict "value" (omit .Values.readinessProbe "enabled") "context" $) | nindent 12 }}
+{{- end }}
+{{- if .Values.startupProbe.enabled }}
+          startupProbe: {{- include "seqera.tplvalues.render" (dict "value" (omit .Values.startupProbe "enabled") "context" $) | nindent 12 }}
+{{- end }}
+{{- if .Values.resources }}
+          resources: {{- toYaml .Values.resources | nindent 12 }}
+{{- end }}
+      volumes:
+        - name: tmp
+          emptyDir: {}
+{{- with .Values.extraVolumes }}
+        {{- include "seqera.tplvalues.render" (dict "value" . "context" $) | nindent 8 }}
+{{- end }}
+{{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+  {{- range .Values.image.pullSecrets }}
+        - name: {{ . | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/platform/charts/wave/templates/extra-list.yaml
+++ b/charts/platform/charts/wave/templates/extra-list.yaml
@@ -1,0 +1,23 @@
+{{/*
+ Copyright (c) 2026 Seqera Labs
+ All rights reserved.
+
+ SPDX-License-Identifier: Apache-2.0
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/}}
+
+{{- range .Values.extraDeploy }}
+---
+{{ include "common.tplvalues.render" (dict "value" . "context" $) }}
+{{- end }}

--- a/charts/platform/charts/wave/templates/ingress.yaml
+++ b/charts/platform/charts/wave/templates/ingress.yaml
@@ -1,0 +1,73 @@
+{{/*
+ Copyright (c) 2026 Seqera Labs
+ All rights reserved.
+
+ SPDX-License-Identifier: Apache-2.0
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/}}
+
+{{ if .Values.ingress.enabled }}
+  {{- $commonLabels := include "common.labels.standard" (dict "customLabels" .Values.commonLabels "context" $) | fromYaml -}}
+  {{- $mergedlabels := include "common.tplvalues.merge" (dict "values" (list .Values.ingress.extraLabels $commonLabels) "context" .) -}}
+  {{- $labels := include "common.tplvalues.render" (dict "value" $mergedlabels "context" $) -}}
+  {{- $mergedAnnotations := include "common.tplvalues.merge" (dict "values" (list .Values.ingress.annotations .Values.commonAnnotations) "context" .) -}}
+  {{- $annotations := include "common.tplvalues.render" (dict "value" $mergedAnnotations "context" $) -}}
+
+apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
+kind: Ingress
+metadata:
+  name: {{ include "common.names.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- $labels | nindent 4 }}
+  annotations: {{- $annotations | nindent 4 }}
+spec:
+  {{- with .Values.ingress.defaultBackend }}
+  defaultBackend: {{- include "seqera.tplvalues.render" (dict "value" . "context" $) | nindent 4 }}
+  {{- end }}
+
+  {{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
+  {{- end }}
+
+  {{- with .Values.ingress.tls }}
+  tls: {{- include "common.tplvalues.render" (dict "value" . "context" $) | nindent 4 }}
+  {{- end }}
+
+  rules:
+    {{/* Wildcard subdomain where to expose Studios */}}
+    - host: {{ tpl .Values.global.waveDomain . | quote }}
+      http:
+        paths:
+          - path: {{ .Values.ingress.path | quote }}
+            pathType: {{ .Values.ingress.defaultPathType }}
+            backend:
+              service:
+                name: {{ (include "common.names.fullname" .) | quote }}
+                port:
+                  number: {{ tpl (toString .Values.service.http.port) . | int }}
+  {{- range .Values.ingress.extraHosts }}
+    - host: {{ tpl .host $ | quote }}
+      http:
+        paths:
+    {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType | default $.Values.ingress.defaultPathType }}
+            backend:
+              service:
+                name: {{ tpl .serviceName $ | quote }}
+                port:
+                  number: {{ tpl (toString .portNumber) $ | int }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/platform/charts/wave/templates/secret.yaml
+++ b/charts/platform/charts/wave/templates/secret.yaml
@@ -1,0 +1,57 @@
+{{/*
+ Copyright (c) 2026 Seqera Labs
+ All rights reserved.
+
+ SPDX-License-Identifier: Apache-2.0
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/}}
+
+{{- /* Don't use stringData in Secrets, as it may lead to weird glitches due to bugs in kubectl:
+https://github.com/kubernetes/kubernetes/issues/89938
+*/}}
+{{- $commonLabels := include "common.labels.standard" (dict "customLabels" .Values.commonLabels "context" $) | fromYaml -}}
+{{- $mergedlabels := include "common.tplvalues.merge" (dict "values" (list .Values.secretLabels $commonLabels) "context" .) -}}
+{{- $labels := include "common.tplvalues.render" (dict "value" $mergedlabels "context" $) -}}
+{{- $mergedAnnotations := include "common.tplvalues.merge" (dict "values" (list .Values.secretAnnotations .Values.commonAnnotations) "context" .) -}}
+{{- $annotations := include "common.tplvalues.render" (dict "value" $mergedAnnotations "context" $) -}}
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: {{ include "common.names.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- $labels | nindent 4 }}
+  annotations: {{- $annotations | nindent 4 }}
+data:
+{{- if not (include "wave.database.existingSecret" .) }}
+  WAVE_DB_PASSWORD: {{ include "common.secrets.passwords.manage" (dict "secret" (include "wave.database.existingSecret.secretName" .) "key" (include "wave.database.existingSecret.secretKey" .) "providedValues" (list "database.password") "context" $ "honorProvidedValues" true) }}
+{{- end }}
+{{- if and (not (include "wave.redis.existingSecret" .)) .Values.redis.password }}
+  REDIS_PASSWORD: {{ include "common.secrets.passwords.manage" (dict "secret" (include "wave.redis.existingSecret.secretName" .) "key" (include "wave.redis.existingSecret.secretKey" .) "providedValues" (list "redis.password") "context" $ "honorProvidedValues" true) }}
+{{- end }}
+---
+{{- if .Values.global.imageCredentials }}
+# Only add the imagePullSecret template if it's defined.
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/dockerconfigjson
+metadata:
+  name: {{ printf "%s-imagepullsecret" (include "common.names.fullname" .) }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- $labels | nindent 4 }}
+  annotations: {{- $annotations | nindent 4 }}
+data:
+  .dockerconfigjson: {{ include "seqera.images.pullSecretCredentials" . | quote }}
+{{- end }}

--- a/charts/platform/charts/wave/templates/service.yaml
+++ b/charts/platform/charts/wave/templates/service.yaml
@@ -1,0 +1,64 @@
+{{/*
+ Copyright (c) 2026 Seqera Labs
+ All rights reserved.
+
+ SPDX-License-Identifier: Apache-2.0
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/}}
+
+{{- $commonLabels := include "common.labels.standard" (dict "customLabels" .Values.commonLabels "context" $) | fromYaml -}}
+{{- $labels := include "common.tplvalues.render" (dict "value" $commonLabels "context" $) -}}
+{{- $mergedAnnotations := include "common.tplvalues.merge" (dict "values" (list dict .Values.commonAnnotations) "context" .) -}}
+{{- $annotations := include "common.tplvalues.render" (dict "value" $mergedAnnotations "context" $) -}}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "common.names.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- $labels | nindent 4 }}
+    app.kubernetes.io/component: wave
+  annotations: {{- $annotations | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    app.kubernetes.io/component: wave
+  ports:
+    - name: {{ tpl .Values.service.http.name . }}
+      port: {{ tpl (toString .Values.service.http.port) . | int }}
+{{- $targetPort := tpl (toString .Values.service.http.targetPort) . }}
+{{- if regexMatch "^[0-9]+$" $targetPort }}
+      targetPort: {{ $targetPort | int }}
+{{- else }}
+      targetPort: {{ $targetPort }}
+{{- end }}
+{{- if and .Values.service.http.nodePort (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) }}
+      nodePort: {{ .Values.service.http.nodePort }}
+{{- end }}
+{{- range .Values.service.extraServices }}
+    - name: {{ tpl .name $ }}
+      port: {{ tpl (toString .port) $ | int }}
+  {{- $extraTargetPort := tpl (toString .targetPort) $ }}
+  {{- if regexMatch "^[0-9]+$" $extraTargetPort }}
+      targetPort: {{ $extraTargetPort | int }}
+  {{- else }}
+      targetPort: {{ $extraTargetPort }}
+  {{- end }}
+  {{- if and .nodePort (or (eq $.Values.service.type "NodePort") (eq $.Values.service.type "LoadBalancer")) }}
+      nodePort: {{ .nodePort }}
+  {{- end }}
+{{- end }}
+{{- with .Values.service.extraOptions }}
+  {{- tpl (toYaml .) $ | nindent 2 }}
+{{- end }}

--- a/charts/platform/charts/wave/templates/serviceaccount.yaml
+++ b/charts/platform/charts/wave/templates/serviceaccount.yaml
@@ -1,0 +1,44 @@
+{{/*
+ Copyright (c) 2026 Seqera Labs
+ All rights reserved.
+
+ SPDX-License-Identifier: Apache-2.0
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/}}
+
+{{- if not .Values.serviceAccount.name }}
+  {{- $commonLabels := include "common.labels.standard" (dict "customLabels" .Values.commonLabels "context" $) | fromYaml -}}
+  {{- $labels := include "common.tplvalues.render" (dict "value" $commonLabels "context" $) -}}
+  {{- $mergedAnnotations := include "common.tplvalues.merge" (dict "values" (list .Values.serviceAccount.annotations .Values.commonAnnotations) "context" .) -}}
+  {{- $annotations := include "common.tplvalues.render" (dict "value" $mergedAnnotations "context" $) -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "wave.serviceAccountName" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- $labels | nindent 4 }}
+  annotations: {{- $annotations | nindent 4 }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+imagePullSecrets:
+  {{/* Include the global image pull secret if configured, and any additional secrets requested by the user. */}}
+  {{- if .Values.global.imageCredentials }}
+  - name: {{ printf "%s-imagepullsecret" (include "common.names.fullname" .) }}
+  {{- end }}
+  {{- range .Values.global.imageCredentialsSecrets }}
+  - name: {{ . }}
+  {{- end }}
+  {{- range .Values.serviceAccount.imagePullSecretNames }}
+  - name: {{ . }}
+  {{- end }}
+{{- end }}

--- a/charts/platform/charts/wave/tests/NOTES_test.yaml
+++ b/charts/platform/charts/wave/tests/NOTES_test.yaml
@@ -1,0 +1,202 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+#
+# Copyright (c) 2026 Seqera Labs
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+suite: test Wave NOTES.txt
+templates:
+  - NOTES.txt
+chart:
+  version: 1.0.0
+  appVersion: "v1.0.0"
+tests:
+  # Database host tests
+  - it: should fail when database.host is not defined
+    set:
+      database:
+        host: ""
+        name: "wavedb"
+        username: "wave"
+        password: "test-password"
+      redis.host: "redis.example.com"
+    asserts:
+      - failedTemplate:
+          errorPattern: "Define the Wave database host at 'database.host'\\."
+
+  - it: should fail when database.host is missing
+    set:
+      database:
+        name: "wavedb"
+        username: "wave"
+        password: "test-password"
+      redis.host: "redis.example.com"
+    asserts:
+      - failedTemplate:
+          errorPattern: "Define the Wave database host at 'database.host'\\."
+
+  # Database name tests
+  - it: should fail when database.name is not defined
+    set:
+      database:
+        host: "db.example.com"
+        name: ""
+        username: "wave"
+        password: "test-password"
+      redis.host: "redis.example.com"
+    asserts:
+      - failedTemplate:
+          errorPattern: "Define the Wave database name at 'database.name'\\."
+
+  - it: should fail when database.name is missing
+    set:
+      database:
+        host: "db.example.com"
+        username: "wave"
+        password: "test-password"
+      redis.host: "redis.example.com"
+    asserts:
+      - failedTemplate:
+          errorPattern: "Define the Wave database name at 'database.name'\\."
+
+  # Database username tests
+  - it: should fail when database.username is not defined
+    set:
+      database:
+        host: "db.example.com"
+        name: "wavedb"
+        username: ""
+        password: "test-password"
+      redis.host: "redis.example.com"
+    asserts:
+      - failedTemplate:
+          errorPattern: "Define the Wave database username at 'database.username'\\."
+
+  - it: should fail when database.username is missing
+    set:
+      database:
+        host: "db.example.com"
+        name: "wavedb"
+        password: "test-password"
+      redis.host: "redis.example.com"
+    asserts:
+      - failedTemplate:
+          errorPattern: "Define the Wave database username at 'database.username'\\."
+
+  # Database password tests
+  - it: should fail when database.password is not defined and no existingSecretName
+    set:
+      database:
+        host: "db.example.com"
+        name: "wavedb"
+        username: "wave"
+        password: ""
+        existingSecretName: ""
+      redis.host: "redis.example.com"
+    asserts:
+      - failedTemplate:
+          errorPattern: "Define the Wave database password at 'database.password' or provide an existing secret name at 'database.existingSecretName'\\."
+
+  - it: should fail when both database.password and database.existingSecretName are defined
+    set:
+      database:
+        host: "db.example.com"
+        name: "wavedb"
+        username: "wave"
+        password: "test-password"
+        existingSecretName: "my-secret"
+      redis.host: "redis.example.com"
+    asserts:
+      - failedTemplate:
+          errorPattern: "Either provide 'database.password' or an existing secret name in 'database.existingSecretName', but not both\\."
+
+  - it: should pass when only database.password is set
+    set:
+      database:
+        host: "db.example.com"
+        name: "wavedb"
+        username: "wave"
+        password: "test-password"
+      redis.host: "redis.example.com"
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  - it: should pass when only database.existingSecretName is set
+    set:
+      database:
+        host: "db.example.com"
+        name: "wavedb"
+        username: "wave"
+        existingSecretName: "my-secret"
+      redis.host: "redis.example.com"
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  # Redis host tests
+  - it: should fail when redis.host is not defined
+    set:
+      database:
+        host: "db.example.com"
+        name: "wavedb"
+        username: "wave"
+        password: "test-password"
+      redis.host: ""
+    asserts:
+      - failedTemplate:
+          errorPattern: "Define the Wave Redis host at 'redis.host'\\."
+
+  - it: should fail when both redis.password and redis.existingSecretName are defined
+    set:
+      database:
+        host: "db.example.com"
+        name: "wavedb"
+        username: "wave"
+        password: "test-password"
+      redis.host: "redis.example.com"
+      redis.password: "my-redis-password"
+      redis.existingSecretName: "my-redis-secret"
+    asserts:
+      - failedTemplate:
+          errorPattern: "Either provide 'redis.password' or an existing secret name in 'redis.existingSecretName', but not both\\."
+
+  # Complete valid configuration test
+  - it: should pass with all required values properly set
+    set:
+      database:
+        host: "db.example.com"
+        name: "wavedb"
+        username: "wave"
+        password: "test-password"
+      redis.host: "redis.example.com"
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  # Valid configuration with external secrets
+  - it: should pass with all required values using external secrets
+    set:
+      database:
+        host: "db.example.com"
+        name: "wavedb"
+        username: "wave"
+        existingSecretName: "db-secret"
+      redis.host: "redis.example.com"
+      redis.existingSecretName: "redis-secret"
+    asserts:
+      - hasDocuments:
+          count: 1

--- a/charts/platform/charts/wave/tests/__snapshot__/configmap_test.yaml.snap
+++ b/charts/platform/charts/wave/tests/__snapshot__/configmap_test.yaml.snap
@@ -1,0 +1,22 @@
+should render a ConfigMap with default values:
+  1: |
+    apiVersion: v1
+    data:
+      MICRONAUT_ENVIRONMENTS: postgres,redis,lite
+      MICRONAUT_SERVER_PORT: "9090"
+      REDIS_URI: redis://:6379
+      TOWER_ENDPOINT_URL: '"https://example.com/api"'
+      WAVE_DB_URI: jdbc:postgresql://db.example.com:5432/wavedb
+      WAVE_DB_USER: waveuser
+      WAVE_SERVER_URL: https://example.com
+    kind: ConfigMap
+    metadata:
+      annotations: {}
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: wave
+        app.kubernetes.io/version: v1.32.4
+        helm.sh/chart: wave-1.2.3
+      name: release-name-wave
+      namespace: NAMESPACE

--- a/charts/platform/charts/wave/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/platform/charts/wave/tests/__snapshot__/deployment_test.yaml.snap
@@ -21,7 +21,7 @@ should render a Deployment with default values:
       template:
         metadata:
           annotations:
-            checksum/configmap: 3a0726c1a33f58cedf793d45ed0b1ae7b1e4a695cbcec6bfd424af6d9a000c9b
+            checksum/configmap: 253619a7171c2e26b76c97806e3bf7d1d826296faf074fe4a09a23f12d4b36f9
             checksum/secret: d612594cf83ec8761d401b8770dc0f1773a5465202c0190a5bd356068e945bea
           labels:
             app.kubernetes.io/component: wave

--- a/charts/platform/charts/wave/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/platform/charts/wave/tests/__snapshot__/deployment_test.yaml.snap
@@ -1,0 +1,164 @@
+should render a Deployment with default values:
+  1: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        app.kubernetes.io/component: wave
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: wave
+        app.kubernetes.io/version: v1.32.4
+        helm.sh/chart: wave-1.2.3
+      name: release-name-wave
+      namespace: NAMESPACE
+    spec:
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: wave
+          app.kubernetes.io/instance: RELEASE-NAME
+          app.kubernetes.io/name: wave
+      template:
+        metadata:
+          annotations:
+            checksum/configmap: 3a0726c1a33f58cedf793d45ed0b1ae7b1e4a695cbcec6bfd424af6d9a000c9b
+            checksum/secret: d612594cf83ec8761d401b8770dc0f1773a5465202c0190a5bd356068e945bea
+          labels:
+            app.kubernetes.io/component: wave
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: wave
+            app.kubernetes.io/version: v1.32.4
+            helm.sh/chart: wave-1.2.3
+        spec:
+          containers:
+            - env:
+                - name: WAVE_DB_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      key: WAVE_DB_PASSWORD
+                      name: release-name-wave
+              envFrom:
+                - configMapRef:
+                    name: release-name-wave
+              image: private/nf-tower-enterprise/wave:v1.32.4
+              imagePullPolicy: IfNotPresent
+              livenessProbe:
+                failureThreshold: 10
+                httpGet:
+                  path: /health
+                  port: 9090
+                initialDelaySeconds: 5
+                periodSeconds: 10
+                successThreshold: 1
+                timeoutSeconds: 3
+              name: wave
+              readinessProbe:
+                failureThreshold: 5
+                httpGet:
+                  path: /health
+                  port: 9090
+                initialDelaySeconds: 5
+                periodSeconds: 5
+                successThreshold: 1
+                timeoutSeconds: 3
+              securityContext:
+                capabilities:
+                  drop:
+                    - ALL
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                runAsUser: 101
+              volumeMounts:
+                - mountPath: /work
+                  name: tmp
+              workingDir: /work
+          initContainers:
+            - command:
+                - sh
+                - -c
+                - '> /tmp/config.yml'
+              image: busybox:latest
+              name: busybox
+              volumeMounts:
+                - mountPath: /tmp
+                  name: tmp
+            - command:
+                - sh
+                - -c
+                - |
+                  echo "$(date): starting check for db $DB_HOST:$DB_PORT"
+                  until PGPASSWORD="$DB_PASSWORD" psql -h "$DB_HOST" -p "$DB_PORT" -d "$DB_NAME" -U "$DB_USERNAME" $PSQL_EXTRA_ARGS -c "SELECT VERSION()"; do
+                    echo "$(date): see you in $SLEEP_PERIOD_SECONDS seconds"
+                    sleep $SLEEP_PERIOD_SECONDS
+                  done
+                  echo "$(date): db server ready"
+              env:
+                - name: SLEEP_PERIOD_SECONDS
+                  value: "5"
+                - name: DB_HOST
+                  value: db.example.com
+                - name: DB_PORT
+                  value: "5432"
+                - name: DB_NAME
+                  value: wavedb
+                - name: DB_USERNAME
+                  value: wave
+                - name: DB_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      key: WAVE_DB_PASSWORD
+                      name: release-name-wave
+              image: postgres:12
+              imagePullPolicy: IfNotPresent
+              name: wait-for-db
+              resources:
+                limits:
+                  memory: 100Mi
+                requests:
+                  cpu: "0.5"
+                  memory: 50Mi
+              securityContext:
+                capabilities:
+                  drop:
+                    - ALL
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                runAsUser: 101
+            - command:
+                - sh
+                - -c
+                - |
+                  echo "$(date): starting check redis '$REDIS_URI' with password (if set) '$REDISCLI_AUTH'";
+                  until redis-cli -u "$REDIS_URI" get hello; do
+                    echo "$(date): see you in $SLEEP_PERIOD_SECONDS seconds"
+                    sleep $SLEEP_PERIOD_SECONDS
+                  done
+                  echo "$(date): redis server ready"
+              env:
+                - name: SLEEP_PERIOD_SECONDS
+                  value: "5"
+                - name: REDIS_URI
+                  value: redis://redis.example.com:6379
+              image: redis:7-alpine
+              imagePullPolicy: IfNotPresent
+              name: wait-for-redis
+              resources:
+                limits:
+                  memory: 100Mi
+                requests:
+                  cpu: "0.5"
+                  memory: 50Mi
+              securityContext:
+                capabilities:
+                  drop:
+                    - ALL
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                runAsUser: 101
+          securityContext:
+            fsGroup: 101
+          serviceAccountName: release-name-wave-sa
+          volumes:
+            - emptyDir: {}
+              name: tmp

--- a/charts/platform/charts/wave/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/platform/charts/wave/tests/__snapshot__/deployment_test.yaml.snap
@@ -78,8 +78,9 @@ should render a Deployment with default values:
                 - sh
                 - -c
                 - '> /tmp/config.yml'
-              image: busybox:latest
-              name: busybox
+              image: private/nf-tower-enterprise/wave:v1.32.4
+              imagePullPolicy: IfNotPresent
+              name: touch-config-file
               volumeMounts:
                 - mountPath: /tmp
                   name: tmp
@@ -109,7 +110,7 @@ should render a Deployment with default values:
                     secretKeyRef:
                       key: WAVE_DB_PASSWORD
                       name: release-name-wave
-              image: postgres:12
+              image: postgres:16-alpine
               imagePullPolicy: IfNotPresent
               name: wait-for-db
               resources:

--- a/charts/platform/charts/wave/tests/__snapshot__/extra-list_test.yaml.snap
+++ b/charts/platform/charts/wave/tests/__snapshot__/extra-list_test.yaml.snap
@@ -1,0 +1,46 @@
+should create extra resources as requested by the user:
+  1: |
+    apiVersion: v1
+    kind: Service
+    metadata:
+      name: test-service
+    spec:
+      ports:
+        - name: testport
+          port: 1234
+          targetPort: 5678
+      selector:
+        app.kubernetes.io/component: whatever
+      type: ClusterIP
+should create multiple extra resources as requested by the user:
+  1: |
+    apiVersion: v1
+    kind: Service
+    metadata:
+      name: test-service
+    spec:
+      ports:
+        - name: testport
+          port: 1234
+          targetPort: 5678
+      selector:
+        app.kubernetes.io/component: whatever
+      type: ClusterIP
+  2: |
+    apiVersion: v1
+    data:
+      key: somevalue
+    kind: ConfigMap
+    metadata:
+      name: myConfigMap
+should evaluate template strings in extraDeploy resources:
+  1: |
+    apiVersion: v1
+    data:
+      namespace: NAMESPACE
+      release: RELEASE-NAME
+    kind: ConfigMap
+    metadata:
+      labels:
+        app: wave
+      name: RELEASE-NAME-dynamic-config

--- a/charts/platform/charts/wave/tests/__snapshot__/ingress_test.yaml.snap
+++ b/charts/platform/charts/wave/tests/__snapshot__/ingress_test.yaml.snap
@@ -1,0 +1,26 @@
+should render when ingress.enabled is true:
+  1: |
+    apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      annotations: {}
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: wave
+        app.kubernetes.io/version: v1.32.4
+        helm.sh/chart: wave-1.2.3
+      name: release-name-wave
+      namespace: NAMESPACE
+    spec:
+      rules:
+        - host: wave.example.com
+          http:
+            paths:
+              - backend:
+                  service:
+                    name: release-name-wave
+                    port:
+                      number: 9090
+                path: /
+                pathType: ImplementationSpecific

--- a/charts/platform/charts/wave/tests/__snapshot__/secret_test.yaml.snap
+++ b/charts/platform/charts/wave/tests/__snapshot__/secret_test.yaml.snap
@@ -1,0 +1,17 @@
+should render a Secret with default values:
+  1: |
+    apiVersion: v1
+    data:
+      WAVE_DB_PASSWORD: dGVzdC1kYi1wYXNzd29yZA==
+    kind: Secret
+    metadata:
+      annotations: {}
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: wave
+        app.kubernetes.io/version: v1.32.4
+        helm.sh/chart: wave-1.2.3
+      name: release-name-wave
+      namespace: NAMESPACE
+    type: Opaque

--- a/charts/platform/charts/wave/tests/__snapshot__/service_test.yaml.snap
+++ b/charts/platform/charts/wave/tests/__snapshot__/service_test.yaml.snap
@@ -1,0 +1,57 @@
+should render a Service with default values:
+  1: |
+    apiVersion: v1
+    kind: Service
+    metadata:
+      annotations: {}
+      labels:
+        app.kubernetes.io/component: wave
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: wave
+        app.kubernetes.io/version: v1.32.4
+        helm.sh/chart: wave-1.2.3
+      name: release-name-wave
+      namespace: NAMESPACE
+    spec:
+      ports:
+        - name: http
+          port: 9090
+          targetPort: 9090
+      selector:
+        app.kubernetes.io/component: wave
+      type: ClusterIP
+should render complete service with all options using matchSnapshot:
+  1: |
+    apiVersion: v1
+    kind: Service
+    metadata:
+      annotations: {}
+      labels:
+        app.kubernetes.io/component: wave
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: wave
+        app.kubernetes.io/version: v1.32.4
+        helm.sh/chart: wave-1.2.3
+      name: release-name-wave
+      namespace: NAMESPACE
+    spec:
+      externalTrafficPolicy: Local
+      ports:
+        - name: custom-http
+          nodePort: 30080
+          port: 8080
+          targetPort: 8080
+        - name: metrics
+          nodePort: 30090
+          port: 9090
+          targetPort: 9091
+        - name: admin
+          nodePort: 30888
+          port: 8888
+          targetPort: 8889
+      selector:
+        app.kubernetes.io/component: wave
+      sessionAffinity: ClientIP
+      type: NodePort

--- a/charts/platform/charts/wave/tests/__snapshot__/serviceaccount_test.yaml.snap
+++ b/charts/platform/charts/wave/tests/__snapshot__/serviceaccount_test.yaml.snap
@@ -1,0 +1,16 @@
+should render a ServiceAccount by default:
+  1: |
+    apiVersion: v1
+    automountServiceAccountToken: true
+    imagePullSecrets: null
+    kind: ServiceAccount
+    metadata:
+      annotations: {}
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: wave
+        app.kubernetes.io/version: v1.32.4
+        helm.sh/chart: wave-1.2.3
+      name: release-name-wave-sa
+      namespace: NAMESPACE

--- a/charts/platform/charts/wave/tests/_helpers_test.yaml
+++ b/charts/platform/charts/wave/tests/_helpers_test.yaml
@@ -1,0 +1,86 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+#
+# Copyright (c) 2026 Seqera Labs
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+suite: test Wave helpers
+templates:
+  - deployment.yaml
+  - secret.yaml
+  - configmap.yaml
+chart:
+  version: 1.2.3
+  appVersion: "v1.32.4"
+tests:
+  - it: should use custom image from global registry override
+    template: deployment.yaml
+    set:
+      database.host: db.example.com
+      database.name: wavedb
+      database.username: wave
+      database.password: test-db-password
+      redis.host: redis.example.com
+      global.imageRegistry: global-registry.io
+      image.repository: private/wave
+      image.tag: v1.0.0
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: global-registry.io/private/wave:v1.0.0
+
+  - it: should use custom image with registry, repository, and tag
+    template: deployment.yaml
+    set:
+      database.host: db.example.com
+      database.name: wavedb
+      database.username: wave
+      database.password: test-db-password
+      redis.host: redis.example.com
+      image.registry: custom-registry.io
+      image.repository: custom/wave
+      image.tag: v2.0.0
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: custom-registry.io/custom/wave:v2.0.0
+
+  - it: should use default serviceAccount name when none is set
+    template: deployment.yaml
+    set:
+      database.host: db.example.com
+      database.name: wavedb
+      database.username: wave
+      database.password: test-db-password
+      redis.host: redis.example.com
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: release-name-wave-sa
+
+  - it: should use custom serviceAccount name when set
+    template: deployment.yaml
+    set:
+      database.host: db.example.com
+      database.name: wavedb
+      database.username: wave
+      database.password: test-db-password
+      redis.host: redis.example.com
+      serviceAccount.name: my-custom-sa
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: my-custom-sa

--- a/charts/platform/charts/wave/tests/configmap_test.yaml
+++ b/charts/platform/charts/wave/tests/configmap_test.yaml
@@ -1,0 +1,178 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+#
+# Copyright (c) 2026 Seqera Labs
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+suite: test Wave configmap
+templates:
+  - configmap.yaml
+chart:
+  version: 1.2.3
+  appVersion: "v1.32.4"
+tests:
+  - it: should render a ConfigMap with default values
+    set:
+      database.host: db.example.com
+      database.name: wavedb
+      database.username: waveuser
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchSnapshot: {}
+
+  - it: should contain database configuration
+    set:
+      database.host: db.example.com
+      database.name: wavedb
+      database.username: waveuser
+    asserts:
+      - equal:
+          path: data.WAVE_DB_USER
+          value: waveuser
+      - equal:
+          path: data.WAVE_DB_URI
+          value: "jdbc:postgresql://db.example.com:5432/wavedb"
+
+  - it: should use custom database port
+    set:
+      database.host: db.example.com
+      database.port: 5433
+      database.name: wavedb
+      database.username: waveuser
+    asserts:
+      - equal:
+          path: data.WAVE_DB_URI
+          value: "jdbc:postgresql://db.example.com:5433/wavedb"
+
+  - it: should contain platform endpoint URL
+    set:
+      global.platformExternalDomain: prod.example.com
+      database.host: db.example.com
+      database.name: wavedb
+      database.username: waveuser
+    asserts:
+      - equal:
+          path: data['TOWER_ENDPOINT_URL']
+          value: '"https://prod.example.com/api"'
+
+  - it: should contain Wave server URL
+    set:
+      global.platformExternalDomain: prod.example.com
+      database.host: db.example.com
+      database.name: wavedb
+      database.username: waveuser
+    asserts:
+      - equal:
+          path: data.WAVE_SERVER_URL
+          value: "https://prod.example.com"
+
+  - it: should contain Redis URI with default values
+    set:
+      database.host: db.example.com
+      database.name: wavedb
+      database.username: waveuser
+      redis.host: redis.example.com
+    asserts:
+      - equal:
+          path: data.REDIS_URI
+          value: "redis://redis.example.com:6379"
+
+  - it: should contain Redis URI with TLS enabled
+    set:
+      database.host: db.example.com
+      database.name: wavedb
+      database.username: waveuser
+      redis.host: redis.example.com
+      redis.enableTls: true
+    asserts:
+      - equal:
+          path: data.REDIS_URI
+          value: "rediss://redis.example.com:6379"
+
+  - it: should contain Redis URI with custom port
+    set:
+      database.host: db.example.com
+      database.name: wavedb
+      database.username: waveuser
+      redis.host: redis.example.com
+      redis.port: 6380
+    asserts:
+      - equal:
+          path: data.REDIS_URI
+          value: "redis://redis.example.com:6380"
+
+  - it: should contain MICRONAUT_ENVIRONMENTS
+    set:
+      database.host: db.example.com
+      database.name: wavedb
+      database.username: waveuser
+    asserts:
+      - equal:
+          path: data.MICRONAUT_ENVIRONMENTS
+          value: "postgres,redis,lite"
+
+  - it: should apply commonLabels to configmap
+    set:
+      database.host: db.example.com
+      database.name: wavedb
+      database.username: waveuser
+      commonLabels:
+        custom-label: custom-value
+    asserts:
+      - isSubset:
+          path: metadata.labels
+          content:
+            custom-label: custom-value
+
+  - it: should apply commonAnnotations to configmap
+    set:
+      database.host: db.example.com
+      database.name: wavedb
+      database.username: waveuser
+      commonAnnotations:
+        custom-annotation: custom-value
+    asserts:
+      - isSubset:
+          path: metadata.annotations
+          content:
+            custom-annotation: custom-value
+
+  - it: should apply configMapLabels to configmap
+    set:
+      database.host: db.example.com
+      database.name: wavedb
+      database.username: waveuser
+      configMapLabels:
+        cm-label: cm-value
+    asserts:
+      - isSubset:
+          path: metadata.labels
+          content:
+            cm-label: cm-value
+
+  - it: should apply configMapAnnotations to configmap
+    set:
+      database.host: db.example.com
+      database.name: wavedb
+      database.username: waveuser
+      configMapAnnotations:
+        cm-annotation: cm-value
+    asserts:
+      - isSubset:
+          path: metadata.annotations
+          content:
+            cm-annotation: cm-value

--- a/charts/platform/charts/wave/tests/configmap_test.yaml
+++ b/charts/platform/charts/wave/tests/configmap_test.yaml
@@ -115,7 +115,7 @@ tests:
           path: data.REDIS_URI
           value: "redis://redis.example.com:6380"
 
-  - it: should contain MICRONAUT_ENVIRONMENTS
+  - it: should contain MICRONAUT_ENVIRONMENTS with default values
     set:
       database.host: db.example.com
       database.name: wavedb
@@ -124,6 +124,34 @@ tests:
       - equal:
           path: data.MICRONAUT_ENVIRONMENTS
           value: "postgres,redis,lite"
+
+  - it: should contain MICRONAUT_ENVIRONMENTS with custom values
+    set:
+      database.host: db.example.com
+      database.name: wavedb
+      database.username: waveuser
+      micronautEnvironments:
+        - postgres
+        - redis
+        - lite
+        - custom-env
+    asserts:
+      - equal:
+          path: data.MICRONAUT_ENVIRONMENTS
+          value: "postgres,redis,lite,custom-env"
+
+  - it: should always include required postgres and redis micronaut environments
+    set:
+      database.host: db.example.com
+      database.name: wavedb
+      database.username: waveuser
+      micronautEnvironments:
+        - lite
+        - custom-env
+    asserts:
+      - equal:
+          path: data.MICRONAUT_ENVIRONMENTS
+          value: "lite,custom-env,postgres,redis"
 
   - it: should apply commonLabels to configmap
     set:

--- a/charts/platform/charts/wave/tests/deployment_test.yaml
+++ b/charts/platform/charts/wave/tests/deployment_test.yaml
@@ -1,0 +1,932 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+#
+# Copyright (c) 2026 Seqera Labs
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+suite: test Wave deployment
+templates:
+  - deployment.yaml
+  - secret.yaml
+  - configmap.yaml
+chart:
+  version: 1.2.3
+  appVersion: "v1.32.4"
+tests:
+  - it: should render a Deployment with default values
+    template: deployment.yaml
+    set:
+      database.host: db.example.com
+      database.name: wavedb
+      database.username: wave
+      database.password: test-db-password
+      redis.host: redis.example.com
+    asserts:
+      - matchSnapshot: {}
+
+  - it: should use custom image
+    template: deployment.yaml
+    set:
+      database.host: db.example.com
+      database.name: wavedb
+      database.username: wave
+      database.password: test-db-password
+      redis.host: redis.example.com
+      image.registry: custom-registry.io
+      image.repository: custom/wave
+      image.tag: v1.2.3
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: custom-registry.io/custom/wave:v1.2.3
+
+  - it: should render extraEnvVars, extraEnvVarsCMs and extraEnvVarsSecrets
+    template: deployment.yaml
+    set:
+      database.host: db.example.com
+      database.name: wavedb
+      database.username: wave
+      database.password: test-db-password
+      redis.host: redis.example.com
+      extraEnvVars:
+        - name: EXTRA_ENV_VAR_1
+          value: set-a-value-here
+        - name: EXTRA_ENV_VAR_2
+          value: set-a-value-here
+      extraEnvVarsCMs:
+        - CMContainingExtraEnvVars
+      extraEnvVarsSecrets:
+        - SecretContainingExtraEnvVars
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: EXTRA_ENV_VAR_1
+            value: set-a-value-here
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: EXTRA_ENV_VAR_2
+            value: set-a-value-here
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            configMapRef:
+              name: CMContainingExtraEnvVars
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            secretRef:
+              name: SecretContainingExtraEnvVars
+
+  - it: should mount extra volumes
+    template: deployment.yaml
+    set:
+      database.host: db.example.com
+      database.name: wavedb
+      database.username: wave
+      database.password: test-db-password
+      redis.host: redis.example.com
+      extraVolumes:
+        - name: custom-volume
+          emptyDir: {}
+      extraVolumeMounts:
+        - name: custom-volume
+          mountPath: /custom
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: custom-volume
+            emptyDir: {}
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: custom-volume
+            mountPath: /custom
+
+  - it: should apply custom resources
+    template: deployment.yaml
+    set:
+      database.host: db.example.com
+      database.name: wavedb
+      database.username: wave
+      database.password: test-db-password
+      redis.host: redis.example.com
+      resources:
+        limits:
+          cpu: 1000m
+          memory: 4Gi
+        requests:
+          cpu: 500m
+          memory: 2Gi
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources
+          value:
+            limits:
+              cpu: 1000m
+              memory: 4Gi
+            requests:
+              cpu: 500m
+              memory: 2Gi
+
+  - it: should include custom init containers
+    template: deployment.yaml
+    set:
+      database.host: db.example.com
+      database.name: wavedb
+      database.username: wave
+      database.password: test-db-password
+      redis.host: redis.example.com
+      initContainers:
+        - name: custom-init
+          image: busybox
+          command: ['sh', '-c', 'echo waiting']
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers
+          content:
+            name: custom-init
+            image: busybox
+            command: ['sh', '-c', 'echo waiting']
+
+  - it: should apply common labels
+    template: deployment.yaml
+    set:
+      database.host: db.example.com
+      database.name: wavedb
+      database.username: wave
+      database.password: test-db-password
+      redis.host: redis.example.com
+      commonLabels:
+        custom-label: custom-value
+    asserts:
+      - isSubset:
+          path: metadata.labels
+          content:
+            custom-label: custom-value
+
+  - it: should include both built-in init containers by default
+    template: deployment.yaml
+    set:
+      database.host: db.example.com
+      database.name: wavedb
+      database.username: wave
+      database.password: test-db-password
+      redis.host: redis.example.com
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.initContainers
+          count: 3
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: busybox
+      - equal:
+          path: spec.template.spec.initContainers[1].name
+          value: wait-for-db
+      - equal:
+          path: spec.template.spec.initContainers[2].name
+          value: wait-for-redis
+
+  - it: should allow disabling postgres waiting init container
+    template: deployment.yaml
+    set:
+      database.host: db.example.com
+      database.name: wavedb
+      database.username: wave
+      database.password: test-db-password
+      redis.host: redis.example.com
+      initContainerDependencies.waitForPostgres.enabled: false
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.initContainers
+          count: 2
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: busybox
+      - equal:
+          path: spec.template.spec.initContainers[1].name
+          value: wait-for-redis
+
+  - it: should allow disabling redis waiting init container
+    template: deployment.yaml
+    set:
+      database.host: db.example.com
+      database.name: wavedb
+      database.username: wave
+      database.password: test-db-password
+      redis.host: redis.example.com
+      initContainerDependencies.waitForRedis.enabled: false
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.initContainers
+          count: 2
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: busybox
+      - equal:
+          path: spec.template.spec.initContainers[1].name
+          value: wait-for-db
+
+  - it: should allow disabling all init container dependencies
+    template: deployment.yaml
+    set:
+      database.host: db.example.com
+      database.name: wavedb
+      database.username: wave
+      database.password: test-db-password
+      redis.host: redis.example.com
+      initContainerDependencies.enabled: false
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.initContainers
+          count: 1
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: busybox
+
+  - it: should support custom init containers alongside built-in ones
+    template: deployment.yaml
+    set:
+      database.host: db.example.com
+      database.name: wavedb
+      database.username: wave
+      database.password: test-db-password
+      redis.host: redis.example.com
+      initContainerDependencies.enabled: true
+      initContainerDependencies.waitForPostgres.enabled: true
+      initContainerDependencies.waitForRedis.enabled: true
+      initContainers:
+        - name: custom-init
+          image: busybox
+          command: ['sh', '-c', 'echo custom']
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: busybox
+      - equal:
+          path: spec.template.spec.initContainers[1].name
+          value: custom-init
+      - equal:
+          path: spec.template.spec.initContainers[2].name
+          value: wait-for-db
+      - equal:
+          path: spec.template.spec.initContainers[3].name
+          value: wait-for-redis
+
+  - it: should use external secret for database password
+    template: deployment.yaml
+    set:
+      database.host: db.example.com
+      database.name: wavedb
+      database.username: wave
+      database.existingSecretName: my-db-secret
+      database.existingSecretKey: db-password
+      redis.host: redis.example.com
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[0]
+          value:
+            name: WAVE_DB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: my-db-secret
+                key: db-password
+
+  - it: should use default key when external secret is set without custom key
+    template: deployment.yaml
+    set:
+      database.host: db.example.com
+      database.name: wavedb
+      database.username: wave
+      database.existingSecretName: my-db-secret
+      redis.host: redis.example.com
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[0]
+          value:
+            name: WAVE_DB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: my-db-secret
+                key: WAVE_DB_PASSWORD
+
+  - it: should configure main container with env before envFrom
+    template: deployment.yaml
+    set:
+      database.host: db.example.com
+      database.name: wavedb
+      database.username: wave
+      database.password: test-db-password
+      redis.host: redis.example.com
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env
+          value:
+            - name: WAVE_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: release-name-wave
+                  key: WAVE_DB_PASSWORD
+
+  - it: should include REDIS_PASSWORD in env when redis.password is set
+    template: deployment.yaml
+    set:
+      database.host: db.example.com
+      database.name: wavedb
+      database.username: wave
+      database.password: test-db-password
+      redis.host: redis.example.com
+      redis.password: my-redis-password
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: release-name-wave
+                key: WAVE_REDIS_PASSWORD
+
+  - it: should NOT include REDIS_PASSWORD in env when redis.password is not set
+    template: deployment.yaml
+    set:
+      database.host: db.example.com
+      database.name: wavedb
+      database.username: wave
+      database.password: test-db-password
+      redis.host: redis.example.com
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_PASSWORD
+
+  - it: should use external secret for Redis password
+    template: deployment.yaml
+    set:
+      database.host: db.example.com
+      database.name: wavedb
+      database.username: wave
+      database.password: test-db-password
+      redis.host: redis.example.com
+      redis.existingSecretName: my-redis-secret
+      redis.existingSecretKey: redis-password
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: my-redis-secret
+                key: redis-password
+
+  - it: should use default key when Redis external secret is set without custom key
+    template: deployment.yaml
+    set:
+      database.host: db.example.com
+      database.name: wavedb
+      database.username: wave
+      database.password: test-db-password
+      redis.host: redis.example.com
+      redis.existingSecretName: my-redis-secret
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: my-redis-secret
+                key: WAVE_REDIS_PASSWORD
+
+  - it: should render extraOptionsSpec under spec
+    template: deployment.yaml
+    set:
+      database.host: db.example.com
+      database.name: wavedb
+      database.username: wave
+      database.password: test-db-password
+      redis.host: redis.example.com
+      extraOptionsSpec:
+        replicas: 3
+        revisionHistoryLimit: 5
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 3
+      - equal:
+          path: spec.revisionHistoryLimit
+          value: 5
+
+  - it: shouldn't obey custom selector requests in extraOptionsSpec
+    template: deployment.yaml
+    set:
+      database.host: db.example.com
+      database.name: wavedb
+      database.username: wave
+      database.password: test-db-password
+      redis.host: redis.example.com
+      extraOptionsSpec:
+        selector:
+          matchLabels:
+            app: something-else
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels
+          value:
+            app.kubernetes.io/component: wave
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/name: wave
+
+  - it: should render extraOptionsTemplateSpec under spec.template.spec
+    template: deployment.yaml
+    set:
+      database.host: db.example.com
+      database.name: wavedb
+      database.username: wave
+      database.password: test-db-password
+      redis.host: redis.example.com
+      extraOptionsTemplateSpec:
+        nodeSelector:
+          disktype: ssd
+        affinity:
+          podAntiAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchExpressions:
+                    - key: app
+                      operator: In
+                      values:
+                        - wave
+                topologyKey: kubernetes.io/hostname
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector
+          value:
+            disktype: ssd
+      - equal:
+          path: spec.template.spec.affinity
+          value:
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - labelSelector:
+                    matchExpressions:
+                      - key: app
+                        operator: In
+                        values:
+                          - wave
+                  topologyKey: kubernetes.io/hostname
+
+  - it: should ignore managed fields in extraOptionsTemplateSpec
+    template: deployment.yaml
+    set:
+      database.host: db.example.com
+      database.name: wavedb
+      database.username: wave
+      database.password: test-db-password
+      redis.host: redis.example.com
+      extraOptionsTemplateSpec:
+        serviceAccountName: some-other-sa
+        dnsPolicy: ClusterFirstWithHostNet
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: release-name-wave-sa
+      - equal:
+          path: spec.template.spec.dnsPolicy
+          value: ClusterFirstWithHostNet
+
+  - it: should render podAnnotations on the pod template
+    template: deployment.yaml
+    set:
+      database.host: db.example.com
+      database.name: wavedb
+      database.username: wave
+      database.password: test-db-password
+      redis.host: redis.example.com
+      podAnnotations:
+        custom-annotation: custom-value
+        another-annotation: another-value
+    asserts:
+      - isSubset:
+          path: spec.template.metadata.annotations
+          content:
+            custom-annotation: custom-value
+            another-annotation: another-value
+
+  - it: should render podLabels on the pod template
+    template: deployment.yaml
+    set:
+      database.host: db.example.com
+      database.name: wavedb
+      database.username: wave
+      database.password: test-db-password
+      redis.host: redis.example.com
+      podLabels:
+        custom-pod-label: custom-value
+    asserts:
+      - isSubset:
+          path: spec.template.metadata.labels
+          content:
+            custom-pod-label: custom-value
+
+  - it: should render image pullSecrets
+    template: deployment.yaml
+    set:
+      database.host: db.example.com
+      database.name: wavedb
+      database.username: wave
+      database.password: test-db-password
+      redis.host: redis.example.com
+      image.pullSecrets:
+        - myRegistrySecret
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets
+          value:
+            - name: myRegistrySecret
+
+  - it: should render pod security context when enabled
+    template: deployment.yaml
+    set:
+      database.host: db.example.com
+      database.name: wavedb
+      database.username: wave
+      database.password: test-db-password
+      redis.host: redis.example.com
+      podSecurityContext:
+        enabled: true
+        fsGroup: 101
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext
+          value:
+            fsGroup: 101
+
+  - it: should not render pod security context when disabled
+    template: deployment.yaml
+    set:
+      database.host: db.example.com
+      database.name: wavedb
+      database.username: wave
+      database.password: test-db-password
+      redis.host: redis.example.com
+      podSecurityContext:
+        enabled: false
+    asserts:
+      - notExists:
+          path: spec.template.spec.securityContext
+
+  - it: should render container security context when enabled
+    template: deployment.yaml
+    set:
+      database.host: db.example.com
+      database.name: wavedb
+      database.username: wave
+      database.password: test-db-password
+      redis.host: redis.example.com
+      containerSecurityContext:
+        enabled: true
+        runAsUser: 101
+        runAsNonRoot: true
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop:
+            - ALL
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext
+          value:
+            runAsUser: 101
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+
+  - it: should not render container security context when disabled
+    template: deployment.yaml
+    set:
+      database.host: db.example.com
+      database.name: wavedb
+      database.username: wave
+      database.password: test-db-password
+      redis.host: redis.example.com
+      containerSecurityContext:
+        enabled: false
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].securityContext
+
+  - it: should render liveness probe when enabled
+    template: deployment.yaml
+    set:
+      database.host: db.example.com
+      database.name: wavedb
+      database.username: wave
+      database.password: test-db-password
+      redis.host: redis.example.com
+      livenessProbe:
+        enabled: true
+        httpGet:
+          path: /health
+          port: "{{ .Values.service.http.targetPort }}"
+        initialDelaySeconds: 5
+        periodSeconds: 10
+        timeoutSeconds: 3
+        failureThreshold: 10
+        successThreshold: 1
+    asserts:
+      - isNotNull:
+          path: spec.template.spec.containers[0].livenessProbe
+
+  - it: should not render liveness probe when disabled
+    template: deployment.yaml
+    set:
+      database.host: db.example.com
+      database.name: wavedb
+      database.username: wave
+      database.password: test-db-password
+      redis.host: redis.example.com
+      livenessProbe:
+        enabled: false
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].livenessProbe
+
+  - it: should render readiness probe when enabled
+    template: deployment.yaml
+    set:
+      database.host: db.example.com
+      database.name: wavedb
+      database.username: wave
+      database.password: test-db-password
+      redis.host: redis.example.com
+      readinessProbe:
+        enabled: true
+        httpGet:
+          path: /health
+          port: "{{ .Values.service.http.targetPort }}"
+        initialDelaySeconds: 5
+        periodSeconds: 5
+        timeoutSeconds: 3
+        failureThreshold: 5
+        successThreshold: 1
+    asserts:
+      - isNotNull:
+          path: spec.template.spec.containers[0].readinessProbe
+
+  - it: should not render readiness probe when disabled
+    template: deployment.yaml
+    set:
+      database.host: db.example.com
+      database.name: wavedb
+      database.username: wave
+      database.password: test-db-password
+      redis.host: redis.example.com
+      readinessProbe:
+        enabled: false
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].readinessProbe
+
+  - it: should render startup probe when enabled
+    template: deployment.yaml
+    set:
+      database.host: db.example.com
+      database.name: wavedb
+      database.username: wave
+      database.password: test-db-password
+      redis.host: redis.example.com
+      startupProbe:
+        enabled: true
+        httpGet:
+          path: /health
+          port: "{{ .Values.service.http.targetPort }}"
+        initialDelaySeconds: 5
+        periodSeconds: 10
+        timeoutSeconds: 3
+        failureThreshold: 5
+        successThreshold: 1
+    asserts:
+      - isNotNull:
+          path: spec.template.spec.containers[0].startupProbe
+
+  - it: should not render startup probe when disabled
+    template: deployment.yaml
+    set:
+      database.host: db.example.com
+      database.name: wavedb
+      database.username: wave
+      database.password: test-db-password
+      redis.host: redis.example.com
+      startupProbe:
+        enabled: false
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].startupProbe
+
+  - it: should set workingDir
+    template: deployment.yaml
+    set:
+      database.host: db.example.com
+      database.name: wavedb
+      database.username: wave
+      database.password: test-db-password
+      redis.host: redis.example.com
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].workingDir
+          value: /work
+
+  - it: should render custom command and args
+    template: deployment.yaml
+    set:
+      database.host: db.example.com
+      database.name: wavedb
+      database.username: wave
+      database.password: test-db-password
+      redis.host: redis.example.com
+      command:
+        - /bin/sh
+        - -c
+      args:
+        - "echo hello"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].command
+          value:
+            - /bin/sh
+            - -c
+      - equal:
+          path: spec.template.spec.containers[0].args
+          value:
+            - "echo hello"
+
+  - it: should always include tmp volume
+    template: deployment.yaml
+    set:
+      database.host: db.example.com
+      database.name: wavedb
+      database.username: wave
+      database.password: test-db-password
+      redis.host: redis.example.com
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: tmp
+            emptyDir: {}
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: tmp
+            mountPath: /work
+
+  - it: should render commonAnnotations on deployment metadata
+    template: deployment.yaml
+    set:
+      database.host: db.example.com
+      database.name: wavedb
+      database.username: wave
+      database.password: test-db-password
+      redis.host: redis.example.com
+      commonAnnotations:
+        custom-annotation: custom-value
+    asserts:
+      - isSubset:
+          path: metadata.annotations
+          content:
+            custom-annotation: custom-value
+
+  - it: should set REDISCLI_TLS on the wait-for-redis init container when redis.enableTls is true
+    template: deployment.yaml
+    set:
+      database.host: db.example.com
+      database.name: wavedb
+      database.username: wave
+      database.password: test-db-password
+      redis.host: redis.example.com
+      redis.enableTls: true
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers[2].env
+          content:
+            name: REDISCLI_TLS
+            value: "1"
+
+  - it: should not set REDISCLI_TLS on the wait-for-redis init container when redis.enableTls is false
+    template: deployment.yaml
+    set:
+      database.host: db.example.com
+      database.name: wavedb
+      database.username: wave
+      database.password: test-db-password
+      redis.host: redis.example.com
+      redis.enableTls: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.initContainers[2].env
+          content:
+            name: REDISCLI_TLS
+            value: "1"
+
+  - it: should render extraEnvVars on the wait-for-Postgres init container
+    template: deployment.yaml
+    set:
+      database.host: db.example.com
+      database.name: wavedb
+      database.username: wave
+      database.password: test-db-password
+      redis.host: redis.example.com
+      initContainerDependencies.waitForPostgres.enabled: true
+      initContainerDependencies.waitForPostgres.extraEnvVars:
+        - name: PGSSLROOTCERT
+          value: "/certs/ca.pem"
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers[1].env
+          content:
+            name: PGSSLROOTCERT
+            value: "/certs/ca.pem"
+
+  - it: should render extraVolumeMounts on the wait-for-Postgres init container
+    template: deployment.yaml
+    set:
+      database.host: db.example.com
+      database.name: wavedb
+      database.username: wave
+      database.password: test-db-password
+      redis.host: redis.example.com
+      initContainerDependencies.waitForPostgres.enabled: true
+      initContainerDependencies.waitForPostgres.extraVolumeMounts:
+        - name: ca-certs
+          mountPath: /certs/ca.pem
+          subPath: ca.pem
+          readOnly: true
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[1].volumeMounts
+          value:
+            - name: ca-certs
+              mountPath: /certs/ca.pem
+              subPath: ca.pem
+              readOnly: true
+
+  - it: should render extraEnvVars on the wait-for-Redis init container
+    template: deployment.yaml
+    set:
+      database.host: db.example.com
+      database.name: wavedb
+      database.username: wave
+      database.password: test-db-password
+      redis.host: redis.example.com
+      initContainerDependencies.waitForRedis.enabled: true
+      initContainerDependencies.waitForPostgres.enabled: false
+      initContainerDependencies.waitForRedis.extraEnvVars:
+        - name: MY_EXTRA_VAR
+          value: "some-value"
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers[1].env
+          content:
+            name: MY_EXTRA_VAR
+            value: "some-value"
+
+  - it: should render extraVolumeMounts on the wait-for-Redis init container
+    template: deployment.yaml
+    set:
+      database.host: db.example.com
+      database.name: wavedb
+      database.username: wave
+      database.password: test-db-password
+      redis.host: redis.example.com
+      initContainerDependencies.waitForRedis.enabled: true
+      initContainerDependencies.waitForPostgres.enabled: false
+      initContainerDependencies.waitForRedis.extraVolumeMounts:
+        - name: ca-certs
+          mountPath: /certs
+          readOnly: true
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[1].volumeMounts
+          value:
+            - name: ca-certs
+              mountPath: /certs
+              readOnly: true

--- a/charts/platform/charts/wave/tests/deployment_test.yaml
+++ b/charts/platform/charts/wave/tests/deployment_test.yaml
@@ -194,7 +194,7 @@ tests:
           count: 3
       - equal:
           path: spec.template.spec.initContainers[0].name
-          value: busybox
+          value: touch-config-file
       - equal:
           path: spec.template.spec.initContainers[1].name
           value: wait-for-db
@@ -217,7 +217,7 @@ tests:
           count: 2
       - equal:
           path: spec.template.spec.initContainers[0].name
-          value: busybox
+          value: touch-config-file
       - equal:
           path: spec.template.spec.initContainers[1].name
           value: wait-for-redis
@@ -237,7 +237,7 @@ tests:
           count: 2
       - equal:
           path: spec.template.spec.initContainers[0].name
-          value: busybox
+          value: touch-config-file
       - equal:
           path: spec.template.spec.initContainers[1].name
           value: wait-for-db
@@ -257,7 +257,7 @@ tests:
           count: 1
       - equal:
           path: spec.template.spec.initContainers[0].name
-          value: busybox
+          value: touch-config-file
 
   - it: should support custom init containers alongside built-in ones
     template: deployment.yaml
@@ -277,7 +277,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.initContainers[0].name
-          value: busybox
+          value: touch-config-file
       - equal:
           path: spec.template.spec.initContainers[1].name
           value: custom-init

--- a/charts/platform/charts/wave/tests/extra-list_test.yaml
+++ b/charts/platform/charts/wave/tests/extra-list_test.yaml
@@ -1,0 +1,269 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+#
+# Copyright (c) 2026 Seqera Labs
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+suite: test Wave extra resources
+templates:
+  - extra-list.yaml
+tests:
+  - it: should not create extra resources by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should handle explicitly empty extraDeploy list
+    set:
+      extraDeploy: []
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create extra resources as requested by the user
+    set:
+      extraDeploy:
+        - apiVersion: v1
+          kind: Service
+          metadata:
+            name: test-service
+          spec:
+            type: ClusterIP
+            ports:
+              - name: testport
+                port: 1234
+                targetPort: 5678
+            selector:
+              app.kubernetes.io/component: whatever
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Service
+      - matchSnapshot: {}
+
+  - it: should create multiple extra resources as requested by the user
+    set:
+      extraDeploy:
+        - apiVersion: v1
+          kind: Service
+          metadata:
+            name: test-service
+          spec:
+            type: ClusterIP
+            ports:
+              - name: testport
+                port: 1234
+                targetPort: 5678
+            selector:
+              app.kubernetes.io/component: whatever
+
+        - apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: myConfigMap
+          data:
+            key: somevalue
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: metadata.name
+          value: test-service
+        documentSelector:
+          path: kind
+          value: Service
+      - matchSnapshot: {}
+        documentSelector:
+          path: kind
+          value: Service
+      - equal:
+          path: metadata.name
+          value: myConfigMap
+        documentSelector:
+          path: kind
+          value: ConfigMap
+      - matchSnapshot: {}
+        documentSelector:
+          path: kind
+          value: ConfigMap
+
+  - it: should evaluate template strings in extraDeploy resources
+    set:
+      extraDeploy:
+        - apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: "{{ .Release.Name }}-dynamic-config"
+            labels:
+              app: "{{ .Chart.Name }}"
+          data:
+            release: "{{ .Release.Name }}"
+            namespace: "{{ .Release.Namespace }}"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchSnapshot: {}
+
+  - it: should create three or more extra resources
+    set:
+      extraDeploy:
+        - apiVersion: v1
+          kind: Service
+          metadata:
+            name: service-1
+          spec:
+            type: ClusterIP
+            ports:
+              - port: 80
+
+        - apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: config-1
+          data:
+            key: value
+
+        - apiVersion: v1
+          kind: Secret
+          metadata:
+            name: secret-1
+          stringData:
+            key: value
+    asserts:
+      - hasDocuments:
+          count: 3
+      - isKind:
+          of: Service
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: service-1
+        documentIndex: 0
+      - equal:
+          path: spec
+          value:
+            type: ClusterIP
+            ports:
+              - port: 80
+        documentIndex: 0
+      - isKind:
+          of: ConfigMap
+        documentIndex: 1
+      - equal:
+          path: metadata.name
+          value: config-1
+        documentIndex: 1
+      - equal:
+          path: data
+          value:
+            key: value
+        documentIndex: 1
+      - isKind:
+          of: Secret
+        documentIndex: 2
+      - equal:
+          path: metadata.name
+          value: secret-1
+        documentIndex: 2
+      - equal:
+          path: stringData
+          value:
+            key: value
+        documentIndex: 2
+
+  - it: should create complex resource types like Deployments
+    set:
+      extraDeploy:
+        - apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: extra-deployment
+          spec:
+            replicas: 2
+            selector:
+              matchLabels:
+                app: extra
+            template:
+              metadata:
+                labels:
+                  app: extra
+              spec:
+                containers:
+                  - name: nginx
+                    image: nginx:latest
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.name
+          value: extra-deployment
+      - equal:
+          path: spec.replicas
+          value: 2
+      - equal:
+          path: spec.selector
+          value:
+            matchLabels:
+              app: extra
+      - equal:
+          path: spec.template.metadata.labels
+          value:
+            app: extra
+      - equal:
+          path: spec.template.spec.containers
+          value:
+            - name: nginx
+              image: nginx:latest
+
+  - it: should preserve complex nested structures
+    set:
+      extraDeploy:
+        - apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: complex-config
+            annotations:
+              key1: value1
+              key2: value2
+          data:
+            config.yaml: |
+              nested:
+                level1:
+                  level2:
+                    key: value
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: complex-config
+      - equal:
+          path: metadata.annotations
+          value:
+            key1: value1
+            key2: value2
+      - equal:
+          path: data["config.yaml"]
+          value: |
+            nested:
+              level1:
+                level2:
+                  key: value

--- a/charts/platform/charts/wave/tests/ingress_test.yaml
+++ b/charts/platform/charts/wave/tests/ingress_test.yaml
@@ -1,0 +1,281 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+#
+# Copyright (c) 2026 Seqera Labs
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+suite: test Wave ingress
+templates:
+  - ingress.yaml
+chart:
+  version: 1.2.3
+  appVersion: "v1.32.4"
+tests:
+  - it: should NOT render by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render when ingress.enabled is true
+    set:
+      ingress.enabled: true
+    asserts:
+      - isKind:
+          of: Ingress
+      - matchSnapshot: {}
+
+  - it: should set ingressClassName
+    set:
+      ingress.enabled: true
+      ingress.ingressClassName: nginx
+    asserts:
+      - equal:
+          path: spec.ingressClassName
+          value: nginx
+
+  - it: should not set ingressClassName when empty
+    set:
+      ingress.enabled: true
+      ingress.ingressClassName: ""
+    asserts:
+      - notExists:
+          path: spec.ingressClassName
+
+  - it: should configure TLS
+    set:
+      ingress.enabled: true
+      ingress.tls:
+        - hosts:
+            - wave.example.com
+          secretName: wave-tls
+    asserts:
+      - isNotNull:
+          path: spec.tls
+      - equal:
+          path: spec.tls[0].secretName
+          value: wave-tls
+
+  - it: should include default rule using global.waveDomain
+    set:
+      global.platformExternalDomain: test.example.com
+      global.waveDomain: wave.test.example.com
+      ingress.enabled: true
+      ingress.path: /
+      ingress.defaultPathType: Prefix
+    asserts:
+      - equal:
+          path: spec.rules[0].host
+          value: wave.test.example.com
+      - equal:
+          path: spec.rules[0].http.paths[0].path
+          value: /
+      - equal:
+          path: spec.rules[0].http.paths[0].pathType
+          value: Prefix
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: release-name-wave
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.port.number
+          value: 9090
+
+  - it: should template global.waveDomain
+    set:
+      global.platformExternalDomain: test.example.com
+      global.waveDomain: "{{ .Release.Name }}-wave.example.com"
+      ingress.enabled: true
+    asserts:
+      - equal:
+          path: spec.rules[0].host
+          value: RELEASE-NAME-wave.example.com
+
+  - it: should handle service.http.port as integer
+    set:
+      ingress.enabled: true
+      service.http.port: 8888
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.port.number
+          value: 8888
+
+  - it: should handle service.http.port as template string
+    set:
+      ingress.enabled: true
+      service.http.port: "{{ .Release.Namespace | len | add 8000 }}"
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.port.number
+          value: 8009
+
+  - it: should include both default rule and extraHosts
+    set:
+      global.waveDomain: wave.example.com
+      ingress.enabled: true
+      ingress.path: /
+      ingress.defaultPathType: Prefix
+      ingress.extraHosts:
+        - host: custom.example.com
+          paths:
+            - path: /api
+              pathType: Prefix
+              serviceName: api-service
+              portNumber: 8080
+    asserts:
+      - lengthEqual:
+          path: spec.rules
+          count: 2
+      - equal:
+          path: spec.rules[0].host
+          value: wave.example.com
+      - equal:
+          path: spec.rules[1].host
+          value: custom.example.com
+      - equal:
+          path: spec.rules[1].http.paths[0].backend.service.name
+          value: api-service
+
+  - it: should handle portNumber as integer value
+    set:
+      ingress.enabled: true
+      ingress.extraHosts:
+        - host: test.example.com
+          paths:
+            - path: /api
+              serviceName: api-service
+              portNumber: 8080
+    asserts:
+      - equal:
+          path: spec.rules[1].http.paths[0].backend.service.port.number
+          value: 8080
+
+  - it: should handle portNumber as string integer
+    set:
+      ingress.enabled: true
+      ingress.extraHosts:
+        - host: test.example.com
+          paths:
+            - path: /api
+              serviceName: api-service
+              portNumber: "9000"
+    asserts:
+      - equal:
+          path: spec.rules[1].http.paths[0].backend.service.port.number
+          value: 9000
+
+  - it: should handle portNumber as template string
+    set:
+      ingress.enabled: true
+      service.http.port: 7777
+      ingress.extraHosts:
+        - host: test.example.com
+          paths:
+            - path: /api
+              serviceName: api-service
+              portNumber: "{{ .Values.service.http.port }}"
+    asserts:
+      - equal:
+          path: spec.rules[1].http.paths[0].backend.service.port.number
+          value: 7777
+
+  - it: should handle multiple extraHosts with different portNumber types
+    set:
+      ingress.enabled: true
+      service.http.port: 5555
+      ingress.extraHosts:
+        - host: api.example.com
+          paths:
+            - path: /v1
+              serviceName: api-v1
+              portNumber: 8001
+            - path: /v2
+              serviceName: api-v2
+              portNumber: "8002"
+        - host: admin.example.com
+          paths:
+            - path: /
+              serviceName: admin-service
+              portNumber: "{{ .Values.service.http.port }}"
+    asserts:
+      - equal:
+          path: spec.rules[1].http.paths[0].backend.service.port.number
+          value: 8001
+      - equal:
+          path: spec.rules[1].http.paths[1].backend.service.port.number
+          value: 8002
+      - equal:
+          path: spec.rules[2].http.paths[0].backend.service.port.number
+          value: 5555
+
+  - it: should apply ingress annotations
+    set:
+      ingress.enabled: true
+      ingress.annotations:
+        nginx.ingress.kubernetes.io/rewrite-target: /
+    asserts:
+      - isSubset:
+          path: metadata.annotations
+          content:
+            nginx.ingress.kubernetes.io/rewrite-target: /
+
+  - it: should apply ingress extraLabels
+    set:
+      ingress.enabled: true
+      ingress.extraLabels:
+        ingress-label: ingress-value
+    asserts:
+      - isSubset:
+          path: metadata.labels
+          content:
+            ingress-label: ingress-value
+
+  - it: should apply commonLabels to ingress
+    set:
+      ingress.enabled: true
+      commonLabels:
+        custom-label: custom-value
+    asserts:
+      - isSubset:
+          path: metadata.labels
+          content:
+            custom-label: custom-value
+
+  - it: should apply commonAnnotations to ingress
+    set:
+      ingress.enabled: true
+      commonAnnotations:
+        custom-annotation: custom-value
+    asserts:
+      - isSubset:
+          path: metadata.annotations
+          content:
+            custom-annotation: custom-value
+
+  - it: should render defaultBackend when configured
+    set:
+      ingress.enabled: true
+      ingress.defaultBackend:
+        service:
+          name: default-backend
+          port:
+            number: 80
+    asserts:
+      - equal:
+          path: spec.defaultBackend
+          value:
+            service:
+              name: default-backend
+              port:
+                number: 80

--- a/charts/platform/charts/wave/tests/secret_test.yaml
+++ b/charts/platform/charts/wave/tests/secret_test.yaml
@@ -1,0 +1,142 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+#
+# Copyright (c) 2026 Seqera Labs
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+suite: test Wave secret
+templates:
+  - secret.yaml
+chart:
+  version: 1.2.3
+  appVersion: "v1.32.4"
+tests:
+  - it: should render a Secret with default values
+    set:
+      database.password: test-db-password
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Secret
+      - matchSnapshot: {}
+
+  - it: should include WAVE_DB_PASSWORD when not using external secret
+    set:
+      database.password: mysecretpassword
+    asserts:
+      - isNotNull:
+          path: data.WAVE_DB_PASSWORD
+
+  - it: should NOT include WAVE_DB_PASSWORD when using external secret
+    set:
+      database.existingSecretName: my-external-secret
+    asserts:
+      - isNull:
+          path: data.WAVE_DB_PASSWORD
+
+  - it: should NOT include REDIS_PASSWORD when redis.password is not set
+    asserts:
+      - isNull:
+          path: data.REDIS_PASSWORD
+
+  - it: should include REDIS_PASSWORD when redis.password is set
+    set:
+      redis.password: my-redis-password
+    asserts:
+      - isNotNull:
+          path: data.REDIS_PASSWORD
+
+  - it: should NOT include REDIS_PASSWORD when using external secret
+    set:
+      redis.existingSecretName: my-redis-secret
+    asserts:
+      - isNull:
+          path: data.REDIS_PASSWORD
+
+  - it: should have null data when all secrets are external
+    set:
+      database.existingSecretName: my-db-secret
+      redis.existingSecretName: my-redis-secret
+    asserts:
+      - isNull:
+          path: data.WAVE_DB_PASSWORD
+      - isNull:
+          path: data.REDIS_PASSWORD
+
+  - it: should apply secretLabels to secret
+    set:
+      secretLabels:
+        secret-label: secret-value
+    asserts:
+      - isSubset:
+          path: metadata.labels
+          content:
+            secret-label: secret-value
+
+  - it: should apply secretAnnotations to secret
+    set:
+      secretAnnotations:
+        secret-annotation: secret-value
+    asserts:
+      - isSubset:
+          path: metadata.annotations
+          content:
+            secret-annotation: secret-value
+
+  - it: should apply commonLabels to secret
+    set:
+      commonLabels:
+        custom-label: custom-value
+    asserts:
+      - isSubset:
+          path: metadata.labels
+          content:
+            custom-label: custom-value
+
+  - it: should apply commonAnnotations to secret
+    set:
+      commonAnnotations:
+        custom-annotation: custom-value
+    asserts:
+      - isSubset:
+          path: metadata.annotations
+          content:
+            custom-annotation: custom-value
+
+  - it: should render imagePullSecret when global.imageCredentials is set
+    set:
+      global.imageCredentials:
+        - registry: cr.seqera.io
+          username: robot
+          password: secret123
+    asserts:
+      - hasDocuments:
+          count: 2
+      - isKind:
+          of: Secret
+        documentIndex: 1
+      - equal:
+          path: type
+          value: kubernetes.io/dockerconfigjson
+        documentIndex: 1
+
+  - it: should NOT render imagePullSecret when global.imageCredentials is empty
+    set:
+      global.imageCredentials: []
+    asserts:
+      - hasDocuments:
+          count: 1

--- a/charts/platform/charts/wave/tests/service_test.yaml
+++ b/charts/platform/charts/wave/tests/service_test.yaml
@@ -1,0 +1,308 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+#
+# Copyright (c) 2026 Seqera Labs
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+suite: test Wave service
+templates:
+  - service.yaml
+chart:
+  version: 1.2.3
+  appVersion: "v1.32.4"
+tests:
+  - it: should render a Service with default values
+    asserts:
+      - isKind:
+          of: Service
+      - matchSnapshot: {}
+
+  - it: should set custom service type
+    set:
+      service.type: NodePort
+    asserts:
+      - equal:
+          path: spec.type
+          value: NodePort
+
+  - it: should set custom port
+    set:
+      service.http.port: 9000
+      service.http.targetPort: 9000
+    asserts:
+      - equal:
+          path: spec.ports[0].port
+          value: 9000
+      - equal:
+          path: spec.ports[0].targetPort
+          value: 9000
+
+  - it: should include nodePort when service type is NodePort
+    set:
+      service.type: NodePort
+      service.http.nodePort: 30090
+    asserts:
+      - equal:
+          path: spec.ports[0].nodePort
+          value: 30090
+
+  - it: should include nodePort when service type is LoadBalancer
+    set:
+      service.type: LoadBalancer
+      service.http.nodePort: 30090
+    asserts:
+      - equal:
+          path: spec.type
+          value: LoadBalancer
+      - equal:
+          path: spec.ports[0].nodePort
+          value: 30090
+
+  - it: should not include nodePort when service type is ClusterIP
+    set:
+      service.type: ClusterIP
+      service.http.nodePort: 30090
+    asserts:
+      - equal:
+          path: spec.type
+          value: ClusterIP
+      - notExists:
+          path: spec.ports[0].nodePort
+
+  - it: should render extraServices with numeric ports
+    set:
+      service.extraServices:
+        - name: metrics
+          port: 9090
+          targetPort: 9090
+    asserts:
+      - equal:
+          path: spec.ports[1]
+          value:
+            name: metrics
+            port: 9090
+            targetPort: 9090
+
+  - it: should render extraServices with named targetPort
+    set:
+      service.extraServices:
+        - name: admin
+          port: 8080
+          targetPort: admin-port
+    asserts:
+      - equal:
+          path: spec.ports[1]
+          value:
+            name: admin
+            port: 8080
+            targetPort: admin-port
+
+  - it: should render multiple extraServices
+    set:
+      service.extraServices:
+        - name: metrics
+          port: 9090
+          targetPort: 9090
+        - name: admin
+          port: 8888
+          targetPort: 8888
+    asserts:
+      - equal:
+          path: spec.ports[1]
+          value:
+            name: metrics
+            port: 9090
+            targetPort: 9090
+      - equal:
+          path: spec.ports[2]
+          value:
+            name: admin
+            port: 8888
+            targetPort: 8888
+
+  - it: should render extraServices with nodePort when service type is NodePort
+    set:
+      service.type: NodePort
+      service.extraServices:
+        - name: metrics
+          port: 9090
+          targetPort: 9090
+          nodePort: 30090
+    asserts:
+      - equal:
+          path: spec.ports[1]
+          value:
+            name: metrics
+            port: 9090
+            targetPort: 9090
+            nodePort: 30090
+
+  - it: should render extraServices with nodePort when service type is LoadBalancer
+    set:
+      service.type: LoadBalancer
+      service.extraServices:
+        - name: metrics
+          port: 9090
+          targetPort: 9090
+          nodePort: 30090
+    asserts:
+      - equal:
+          path: spec.type
+          value: LoadBalancer
+      - equal:
+          path: spec.ports[1]
+          value:
+            name: metrics
+            port: 9090
+            targetPort: 9090
+            nodePort: 30090
+
+  - it: should not render nodePort in extraServices when service type is ClusterIP
+    set:
+      service.type: ClusterIP
+      service.extraServices:
+        - name: metrics
+          port: 9090
+          targetPort: 9090
+          nodePort: 30090
+    asserts:
+      - equal:
+          path: spec.type
+          value: ClusterIP
+      - equal:
+          path: spec.ports[1].name
+          value: metrics
+      - equal:
+          path: spec.ports[1].port
+          value: 9090
+      - equal:
+          path: spec.ports[1].targetPort
+          value: 9090
+      - notExists:
+          path: spec.ports[1].nodePort
+
+  - it: should evaluate template expressions in extraServices
+    set:
+      service.extraServices:
+        - name: "{{ .Release.Name }}-metrics"
+          port: "{{ .Values.service.http.port }}"
+          targetPort: "{{ .Values.service.http.targetPort }}"
+    asserts:
+      - equal:
+          path: spec.ports[1].name
+          value: RELEASE-NAME-metrics
+      - equal:
+          path: spec.ports[1].port
+          value: 9090
+      - equal:
+          path: spec.ports[1].targetPort
+          value: 9090
+
+  - it: should render service with both default http port and extraServices
+    set:
+      service.http.port: 8080
+      service.http.targetPort: 8080
+      service.extraServices:
+        - name: metrics
+          port: 9090
+          targetPort: 9091
+        - name: admin
+          port: 7070
+          targetPort: 7071
+    asserts:
+      - equal:
+          path: spec.ports
+          value:
+            - name: http
+              port: 8080
+              targetPort: 8080
+            - name: metrics
+              port: 9090
+              targetPort: 9091
+            - name: admin
+              port: 7070
+              targetPort: 7071
+
+  - it: should render extraServices with numeric string ports
+    set:
+      service.extraServices:
+        - name: metrics
+          port: "9090"
+          targetPort: "9091"
+    asserts:
+      - equal:
+          path: spec.ports[1].port
+          value: 9090
+      - equal:
+          path: spec.ports[1].targetPort
+          value: 9091
+
+  - it: should apply commonLabels to service
+    set:
+      commonLabels:
+        custom-label: custom-value
+    asserts:
+      - isSubset:
+          path: metadata.labels
+          content:
+            custom-label: custom-value
+
+  - it: should apply commonAnnotations to service
+    set:
+      commonAnnotations:
+        custom-annotation: custom-value
+    asserts:
+      - isSubset:
+          path: metadata.annotations
+          content:
+            custom-annotation: custom-value
+
+  - it: should render extraOptions under spec
+    set:
+      service.extraOptions:
+        externalTrafficPolicy: Local
+        sessionAffinity: ClientIP
+    asserts:
+      - equal:
+          path: spec.externalTrafficPolicy
+          value: Local
+      - equal:
+          path: spec.sessionAffinity
+          value: ClientIP
+
+  - it: should render complete service with all options using matchSnapshot
+    set:
+      service:
+        type: NodePort
+        http:
+          name: custom-http
+          port: 8080
+          targetPort: 8080
+          nodePort: 30080
+        extraServices:
+          - name: metrics
+            port: 9090
+            targetPort: 9091
+            nodePort: 30090
+          - name: admin
+            port: 8888
+            targetPort: 8889
+            nodePort: 30888
+        extraOptions:
+          externalTrafficPolicy: Local
+          sessionAffinity: ClientIP
+    asserts:
+      - matchSnapshot: {}

--- a/charts/platform/charts/wave/tests/serviceaccount_test.yaml
+++ b/charts/platform/charts/wave/tests/serviceaccount_test.yaml
@@ -1,0 +1,143 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+#
+# Copyright (c) 2026 Seqera Labs
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+suite: test Wave serviceaccount
+templates:
+  - serviceaccount.yaml
+  - secret.yaml
+chart:
+  version: 1.2.3
+  appVersion: "v1.32.4"
+tests:
+  - it: should render a ServiceAccount by default
+    template: serviceaccount.yaml
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - matchSnapshot: {}
+
+  - it: should NOT render when serviceAccount.name is set
+    template: serviceaccount.yaml
+    set:
+      serviceAccount.name: existing-sa
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should include imagePullSecrets from global.imageCredentials
+    template: serviceaccount.yaml
+    set:
+      global.imageCredentials:
+        - registry: cr.seqera.io
+          username: robot
+          password: secret123
+    asserts:
+      - contains:
+          path: imagePullSecrets
+          content:
+            name: release-name-wave-imagepullsecret
+
+  - it: should include imagePullSecrets from global.imageCredentialsSecrets
+    template: serviceaccount.yaml
+    set:
+      global.imageCredentialsSecrets:
+        - my-existing-secret
+    asserts:
+      - contains:
+          path: imagePullSecrets
+          content:
+            name: my-existing-secret
+
+  - it: should include imagePullSecrets from serviceAccount.imagePullSecretNames
+    template: serviceaccount.yaml
+    set:
+      serviceAccount.imagePullSecretNames:
+        - my-sa-pull-secret
+    asserts:
+      - contains:
+          path: imagePullSecrets
+          content:
+            name: my-sa-pull-secret
+
+  - it: should set automountServiceAccountToken
+    template: serviceaccount.yaml
+    set:
+      serviceAccount.automountServiceAccountToken: false
+    asserts:
+      - equal:
+          path: automountServiceAccountToken
+          value: false
+
+  - it: should apply serviceAccount annotations
+    template: serviceaccount.yaml
+    set:
+      serviceAccount.annotations:
+        eks.amazonaws.com/role-arn: arn:aws:iam::role/my-role
+    asserts:
+      - isSubset:
+          path: metadata.annotations
+          content:
+            eks.amazonaws.com/role-arn: arn:aws:iam::role/my-role
+
+  - it: should apply commonLabels to serviceaccount
+    template: serviceaccount.yaml
+    set:
+      commonLabels:
+        custom-label: custom-value
+    asserts:
+      - isSubset:
+          path: metadata.labels
+          content:
+            custom-label: custom-value
+
+  - it: should apply commonAnnotations to serviceaccount
+    template: serviceaccount.yaml
+    set:
+      commonAnnotations:
+        custom-annotation: custom-value
+    asserts:
+      - isSubset:
+          path: metadata.annotations
+          content:
+            custom-annotation: custom-value
+
+  - it: should include imagePullSecrets from all sources
+    template: serviceaccount.yaml
+    set:
+      global.imageCredentials:
+        - registry: cr.seqera.io
+          username: robot
+          password: secret123
+      global.imageCredentialsSecrets:
+        - global-existing-secret
+      serviceAccount.imagePullSecretNames:
+        - sa-pull-secret
+    asserts:
+      - contains:
+          path: imagePullSecrets
+          content:
+            name: release-name-wave-imagepullsecret
+      - contains:
+          path: imagePullSecrets
+          content:
+            name: global-existing-secret
+      - contains:
+          path: imagePullSecrets
+          content:
+            name: sa-pull-secret

--- a/charts/platform/charts/wave/values.yaml
+++ b/charts/platform/charts/wave/values.yaml
@@ -1,0 +1,463 @@
+# Copyright (c) 2026 Seqera Labs
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Values in the .global section can be accessed by both parent and child subcharts as
+# .Values.global.*: https://helm.sh/docs/chart_template_guide/subcharts_and_globals/
+global:
+  # -- Domain where Seqera Platform listens
+  platformExternalDomain: example.com
+
+  # -- Domain where Wave listens. Evaluated as a template
+  waveDomain: '{{ printf "wave.%s" .Values.global.platformExternalDomain }}'
+
+  # -- Optional credentials to log in and fetch images from a private registry. These credentials
+  # are shared with all the subcharts automatically
+  imageCredentials: []
+  # imageCredentials:
+  # - registry: ""
+  #   username: ""
+  #   password: ""
+  #   email: someone@example.com  # Optional
+
+  # -- Optional list of existing Secrets containing image pull credentials to use for pulling
+  # images from private registries. These Secrets are shared with all the subcharts automatically
+  imageCredentialsSecrets: []
+  # imageCredentialsSecrets:
+  # - myPrivateRegistryKeySecretName
+  #
+  # Each secret must be of type `kubernetes.io/dockerconfigjson` and contain the field
+  # `.dockerconfigjson` with value created with:
+  #   kubectl create secret docker-registry mycreds --docker-server='cr.example.com' --docker-username='robot$robotnamehere' --docker-password='passwordhere' --dry-run=client -o yaml
+  # https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-secret-by-providing-credentials-on-the-command-line
+
+database:
+  # -- PostgreSQL database hostname
+  host: ""
+  # -- PostgreSQL database port
+  port: 5432
+  # -- PostgreSQL database name
+  name: ""
+  # -- PostgreSQL database username
+  username: ""
+  # -- PostgreSQL database password
+  password: ""
+  # -- Name of an existing Secret containing credentials for the PostgreSQL database, as an
+  # alternative to the password field. Note: the Secret must already exist in the  same namespace at
+  # the time of
+  # deployment
+  existingSecretName: ""
+  # -- Key in the existing Secret containing the password for the PostgreSQL database
+  # @default -- `"WAVE_DB_PASSWORD"`
+  existingSecretKey: ""
+  # -- Enable TLS for the PostgreSQL database connection
+  enableTls: false
+
+redis:
+  # -- Redis hostname
+  host: ""
+  # -- Redis port
+  port: 6379
+  # -- Redis database index
+  db: 0
+  # -- Enable TLS when connecting to Redis
+  enableTls: false
+  # -- Redis password
+  password: ""
+  # -- Name of an existing Secret containing the Redis password, as an alternative to the password
+  # field. Note: the Secret must already exist in the same namespace at the time of deployment
+  existingSecretName: ""
+  # -- Key in the existing Secret containing the Redis password
+  # @default -- `"REDIS_PASSWORD"`
+  existingSecretKey: ""
+
+image:
+  # -- Container image registry
+  registry: ""
+  # -- Container image repository
+  repository: private/nf-tower-enterprise/wave
+  # -- Container image tag
+  # @default -- `"{{ .chart.AppVersion }}"`
+  tag: ""
+  # -- Container image digest in the format `sha256:1234abcdef`
+  digest: ""
+  # -- imagePullPolicy for the container
+  # Ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images
+  pullPolicy: IfNotPresent
+  # -- List of imagePullSecrets
+  # Secrets must be created in the same namespace, for example using the .extraDeploy array
+  # Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  pullSecrets: []
+  # pullSecrets:
+  #   - myRegistryKeySecretName
+
+# -- Service configuration
+service:
+  # -- Service type.
+  # Note: ingresses using AWS ALB require the service to be NodePort
+  type: ClusterIP
+  http:
+    # -- Service name to use
+    name: http
+    # -- Service port
+    port: 9090
+    # -- Port on the pod/container that the Service forwards traffic to (can be a number or
+    # named port, distinct from the Service's external port)
+    targetPort: 9090
+    # -- Service node port, only used when service.type is Nodeport or LoadBalancer
+    # Choose port between 30000-32767, unless the cluster was configured differently than default
+    nodePort: null
+
+  # -- Other services that should live in the Service object
+  # https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service
+  extraServices: []
+  # extraServices:
+  # - name: myspecialservice
+  #   port: 1234
+  #   targetPort: 5678
+  #   nodePort: null
+
+  # -- Extra Service options to place under .spec (for example, clusterIP, loadBalancerIP,
+  # externalTrafficPolicy, externalIPs). Evaluated as a template
+  extraOptions: {}
+
+# -- Additional init containers for the pod. Evaluated as a template
+initContainers: []
+
+# -- Override default container command (useful when using custom images)
+command: []
+# -- Override default container args (useful when using custom images)
+args: []
+# -- Working directory for the main container process. Evaluated as a template
+workingDir: /work
+
+# -- Additional labels for the pod. Evaluated as a template
+podLabels: {}
+# -- Additional annotations for the pod. Evaluated as a template
+podAnnotations: {}
+
+# -- Extra options to place under .spec (e.g. replicas, strategy, revisionHistoryLimit, etc).
+# Evaluated as a template
+extraOptionsSpec: {}
+# extraOptionsSpec:
+#   strategy:
+#     rollingUpdate:
+#       maxUnavailable: 1
+#   strategy:
+#     rollingUpdate:
+#       maxUnavailable: x
+#       maxSurge: y
+
+# -- Extra options to place under .spec.template.spec (e.g. nodeSelector, affinity, restartPolicy,
+# etc). Evaluated as a template
+extraOptionsTemplateSpec: {}
+# extraOptionsTemplateSpec:
+#   nodeSelector:
+#     service: myspecialnodegroup
+
+# -- Extra environment variables
+extraEnvVars: []
+# extraEnvVars:
+#   - name: "CUSTOM_ENV_VAR"
+#     value: "set-a-value-here"
+
+# -- List of ConfigMaps containing extra env vars
+extraEnvVarsCMs: []
+# -- List of Secrets containing extra env vars
+extraEnvVarsSecrets: []
+# -- List of volumes to add to the deployment (evaluated as template). Requires setting
+# `extraVolumeMounts`
+extraVolumes: []
+# -- List of volume mounts to add to the container (evaluated as template). Normally used with
+# `extraVolumes`
+extraVolumeMounts: []
+
+# Configure Pods Security Context.
+# Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+# Empty map to disable Pod Security Context configuration
+podSecurityContext:
+  # -- Enable pod Security Context
+  enabled: true
+  # -- Sets the GID that Kubernetes will apply to mounted volumes and created files so processes
+  # in the pod can share group-owned access
+  fsGroup: 101
+
+# Configure Container Security Context.
+# Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+containerSecurityContext:
+  # -- Enable container Security Context
+  enabled: true
+  # -- UID the container processes run as (overrides container image default)
+  runAsUser: 101
+  # -- Boolean that requires the container to run as a non-root UID (prevents starting if UID 0)
+  runAsNonRoot: true
+  # -- Mounts the container root filesystem read-only to prevent in-place writes or tampering
+  readOnlyRootFilesystem: true
+  # -- Fine-grained Linux kernel privileges to add or drop for the container
+  capabilities:
+    drop:
+      - ALL
+
+# -- Container requests and limits for different resources like CPU or memory
+resources: {}
+# `.requests` are the minimum CPU/memory resources the scheduler uses to place a pod;
+# the kubelet then guarantees at least these resources to the pod. `.limits` are the
+# maximum resources a container is allowed to use
+# Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+# Seqera recommends tuning resources to match the expected workload. The following are
+# sensible defaults to start with:
+#
+# resources:
+#   requests:
+#     cpu: "200m"
+#     memory: "1400Mi"
+#   limits:
+#     memory: "1400Mi"
+
+initContainerDependencies:
+  # -- Enable init containers that coordinate startup dependencies
+  enabled: true
+
+  waitForRedis:
+    # -- Enable wait for Redis init container before starting the main container
+    enabled: true
+    image:
+      # -- Override default wait for Redis init container image
+      registry: ""
+      repository: redis
+      tag: 7-alpine
+      # Digest must be in the format `sha256:1234abcdef`
+      digest: ""
+      pullPolicy: IfNotPresent
+
+    securityContext:
+      # -- UID the container processes run as (overrides container image default)
+      runAsUser: 101
+      # -- Require the container to run as a non-root UID (prevents starting if UID is 0)
+      runAsNonRoot: true
+      # -- Mount the container root filesystem read-only to prevent in-place writes or tampering
+      readOnlyRootFilesystem: true
+      # -- Fine-grained Linux kernel privileges to add or drop for the container
+      capabilities:
+        drop:
+          - ALL
+
+    # -- Container requests and limits for different resources like CPU or memory
+    resources:
+      requests:
+        cpu: "0.5"
+        memory: "50Mi"
+      limits:
+        memory: "100Mi"
+
+    # -- Additional environment variables for the init container
+    extraEnvVars: []
+    # -- Additional volume mounts for the init container (e.g. to mount a CA certificate)
+    extraVolumeMounts: []
+
+  waitForPostgres:
+    # -- Enable wait for PostgreSQL init container before starting the main container
+    enabled: true
+    image:
+      # -- Override default wait for PostgreSQL init container image
+      registry: ""
+      repository: postgres
+      tag: "12"
+      # Digest must be in the format `sha256:1234abcdef`
+      digest: ""
+      pullPolicy: IfNotPresent
+
+    securityContext:
+      # -- UID the container processes run as (overrides container image default)
+      runAsUser: 101
+      # -- Require the container to run as a non-root UID (prevents starting if UID is 0)
+      runAsNonRoot: true
+      # -- Mount the container root filesystem read-only to prevent in-place writes or tampering
+      readOnlyRootFilesystem: true
+      # -- Fine-grained Linux kernel privileges to add or drop for the container
+      capabilities:
+        drop:
+          - ALL
+
+    # -- Container requests and limits for different resources like CPU or memory
+    resources:
+      requests:
+        cpu: "0.5"
+        memory: "50Mi"
+      limits:
+        memory: "100Mi"
+
+    # -- Additional environment variables for the init container.
+    # The special variable `MYSQL_EXTRA_ARGS` is appended verbatim to the `mysql` readiness
+    # check command, and can be used to pass TLS flags when connecting to managed MySQL services
+    # such as AWS RDS or Azure Database for MySQL that require certificate verification.
+    # Pair with `extraVolumeMounts` to mount the CA certificate into the container.
+    # Example (TLS with CA certificate mounted from a volume):
+    # extraEnvVars:
+    #   - name: MYSQL_EXTRA_ARGS
+    #     value: "--ssl-ca=/certs/ca.pem --ssl-mode=VERIFY_IDENTITY"
+    extraEnvVars: []
+    # -- Additional volume mounts for the init container. Use this to mount CA certificates
+    # (e.g. from a Secret or ConfigMap populated by an extraInitContainer) so that
+    # `MYSQL_EXTRA_ARGS` can reference them.
+    extraVolumeMounts: []
+
+# Configure extra options for the startup probe
+startupProbe:
+  # -- Enable startup probe
+  enabled: false
+  httpGet:
+    # -- HTTP GET path for startup probe
+    path: "/health"
+    # -- HTTP GET port for startup probe. Evaluated as a template
+    port: "{{ .Values.service.http.targetPort }}"
+  # -- Longer initial wait to accommodate slow-starting apps
+  initialDelaySeconds: 5
+  # -- Often set longer to avoid frequent checks while starting
+  periodSeconds: 10
+  # -- Can be longer to allow slow initialization responses
+  timeoutSeconds: 3
+  # -- Consecutive failures during startup before killing the container (instead of immediate
+  # restarts)
+  failureThreshold: 5
+  # -- Number of consecutive successes required to consider startup complete and enable
+  # liveness/readiness
+  successThreshold: 1
+
+# Configure extra options for the readiness probe
+readinessProbe:
+  # -- Enable readiness probe
+  enabled: true
+  httpGet:
+    # -- HTTP GET path for readiness probe
+    path: "/health"
+    # -- HTTP GET port for readiness probe. Evaluated as a template
+    port: "{{ .Values.service.http.targetPort }}"
+  # -- Delay before first check (normal start timing)
+  initialDelaySeconds: 5
+  # -- Regular check interval during normal operation
+  periodSeconds: 5
+  # -- Short timeout to detect unresponsive containers for readiness
+  timeoutSeconds: 3
+  # -- Consecutive failures before marking the container Unready (no restart)
+  failureThreshold: 5
+  # -- Number of consecutive successes required to mark the container Ready after failures
+  successThreshold: 1
+
+# Configure extra options for the liveness probe
+livenessProbe:
+  # -- Enable liveness probe
+  enabled: true
+  httpGet:
+    # -- HTTP GET path for liveness probe
+    path: "/health"
+    # -- HTTP GET port for liveness probe. Evaluated as a template
+    port: "{{ .Values.service.http.targetPort }}"
+  # -- Delay before first check (normal start timing)
+  initialDelaySeconds: 5
+  # -- Regular check interval during normal operation
+  periodSeconds: 10
+  # -- Short timeout to detect hung containers quickly
+  timeoutSeconds: 3
+  # -- Consecutive failures before restarting the container
+  failureThreshold: 10
+  # -- Typically 1 (usually ignored)
+  successThreshold: 1
+
+# -- Service account configuration
+serviceAccount:
+  # -- Service account name
+  name: ""
+  # -- Service account annotations
+  annotations: {}
+  # -- Names of Secrets containing credentials to pull images from registries
+  imagePullSecretNames: []
+  # -- Automatically mount service account token
+  automountServiceAccountToken: true
+
+ingress:
+  # -- Enable ingress for Wave
+  enabled: false
+
+  # -- Path for the main ingress rule
+  # Note: this needs to be set to '/*' to be used with AWS ALB ingress controller
+  path: "/"
+
+  # -- Default path type for the Ingress
+  defaultPathType: "ImplementationSpecific"
+
+  # -- Configure the default service for the ingress (evaluated as template)
+  # Important: make sure only one defaultBackend is defined across the k8s cluster: if the
+  # ingress doesn't reconcile successfully, 'describe ingress <name>' will report problems
+  defaultBackend: {}
+  # defaultBackend:
+  #   service:
+  #     name: '{{ printf "%s-frontend" (include "common.names.fullname" .) }}'
+  #     port:
+  #       number: '{{ .Values.frontend.service.http.port }}'
+
+  # -- Additional hosts you want to include. Evaluated as a template
+  extraHosts: []
+  # extraHosts:
+  #   - host: '{{ printf "api.%s" .Values.global.platformExternalDomain }}'
+  #     paths:
+  #       - path: /*
+  #         pathType: Prefix  # Optional, defaults to defaultPathType
+  #         serviceName: '{{ printf "%s-backend" (include "common.names.fullname" .) }}'
+  #         portNumber: '{{ .Values.global.platformServicePort }}'
+  #   - host: '{{ printf "www.%s" .Values.global.platformExternalDomain }}'
+  #     paths:
+  #       - path: /*
+  #         pathType: Prefix  # Optional, defaults to defaultPathType
+  #         serviceName: '{{ printf "%s-frontend" (include "common.names.fullname" .) }}'
+  #         portNumber: '{{ .Values.frontend.service.http.port }}'
+
+  # -- Ingress annotations specific to your load balancer. Evaluated as a template
+  annotations: {}
+  # -- Additional labels for the ingress object. Evaluated as a template
+  extraLabels: {}
+  # -- Name of the ingress class (replaces the deprecated annotation `kubernetes.io/ingress.class`)
+  ingressClassName: ""
+  # -- TLS configuration. Evaluated as a template
+  tls: []
+  # tls:
+  #   - hosts:
+  #       - '{{ .Values.global.platformExternalDomain }}'
+  #       - '{{ printf "user-data.%s" .Values.global.platformExternalDomain }}'
+  #     secretName: my-tls
+
+# -- Array of extra objects to deploy with the release
+extraDeploy: []
+# extraDeploy:
+#   - apiVersion: v1
+#     kind: MyExtraObjectKind
+#     ...
+#   - apiVersion: v1
+#     kind: AnotherExtraObjectKind
+#     ...
+
+# -- Annotations to add to all deployed objects
+commonAnnotations: {}
+# -- Labels to add to all deployed objects
+commonLabels: {}
+# -- Additional labels for the Secret objects. Evaluated as a template
+secretLabels: {}
+# -- Additional annotations for the Secret objects. Evaluated as a template
+secretAnnotations: {}
+# -- Additional labels for the ConfigMap objects. Evaluated as a template
+configMapLabels: {}
+# -- Additional annotations for the ConfigMap objects. Evaluated as a template
+configMapAnnotations: {}

--- a/charts/platform/charts/wave/values.yaml
+++ b/charts/platform/charts/wave/values.yaml
@@ -281,7 +281,7 @@ initContainerDependencies:
       # -- Override default wait for PostgreSQL init container image
       registry: ""
       repository: postgres
-      tag: "12"
+      tag: "16-alpine"
       # Digest must be in the format `sha256:1234abcdef`
       digest: ""
       pullPolicy: IfNotPresent

--- a/charts/platform/charts/wave/values.yaml
+++ b/charts/platform/charts/wave/values.yaml
@@ -44,6 +44,12 @@ global:
   #   kubectl create secret docker-registry mycreds --docker-server='cr.example.com' --docker-username='robot$robotnamehere' --docker-password='passwordhere' --dry-run=client -o yaml
   # https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-secret-by-providing-credentials-on-the-command-line
 
+# -- List of Micronaut environments to enable
+micronautEnvironments:
+  - postgres
+  - redis
+  - lite
+
 database:
   # -- PostgreSQL database hostname
   host: ""

--- a/charts/platform/values.yaml
+++ b/charts/platform/values.yaml
@@ -53,6 +53,9 @@ global:
   # subdomain under `.global.studiosDomain` anyway to connect. Evaluated as a template
   studiosConnectionUrl: '{{ printf "https://connect.%s" (tpl .Values.global.studiosDomain $) }}'
 
+  # -- Domain where Wave listens. Evaluated as a template
+  waveDomain: '{{ printf "wave.%s" .Values.global.platformExternalDomain }}'
+
   # -- Domain where Seqera MCP listens. Evaluated as a template
   mcpDomain: '{{ printf "mcp.%s" .Values.global.platformExternalDomain }}'
 

--- a/charts/seqera-common/CHANGELOG.md
+++ b/charts/seqera-common/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] - 2026-04-10
+
+### Added
+
+- Add `seqera.initContainers.waitForPostgres` init container helper for PostgreSQL database readiness checks
+
 ## [2.0.2] - 2026-04-08
 
 ### Fixed

--- a/charts/seqera-common/Chart.yaml
+++ b/charts/seqera-common/Chart.yaml
@@ -19,7 +19,7 @@ apiVersion: v2
 type: library
 name: seqera-common
 appVersion: 1.0.0
-version: 2.0.2
+version: 2.1.0
 description: A Library Helm Chart for grouping common logic between Seqera charts.
   This chart is not deployable by itself.
 home: https://github.com/seqeralabs/helm-charts

--- a/charts/seqera-common/README.md
+++ b/charts/seqera-common/README.md
@@ -1,6 +1,6 @@
 # seqera-common
 
-![Version: 2.0.2](https://img.shields.io/badge/Version-2.0.2-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 2.1.0](https://img.shields.io/badge/Version-2.1.0-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 A Library Helm Chart for grouping common logic between Seqera charts. This chart is not deployable by itself.
 

--- a/charts/seqera-common/templates/_initcontainers.tpl
+++ b/charts/seqera-common/templates/_initcontainers.tpl
@@ -65,6 +65,52 @@ include "seqera.initContainers.waitForMySQL" (dict "name" "platform-db"         
 {{- end -}}
 
 {{/*
+Common initContainer to wait for PostgreSQL database to be ready.
+
+Usage example:
+include "seqera.initContainers.waitForPostgres" (dict "name" "db" "waitValues" .Values.initContainerDependencies.waitForPostgres "connDetails" .Values.database "secretNameTemplate" "wave.database.existingSecret.secretName" "secretKeyTemplate" "wave.database.existingSecret.secretKey" "context" $)
+*/}}
+{{- define "seqera.initContainers.waitForPostgres" -}}
+- name: wait-for-{{ .name }}
+  image: {{ include "seqera.images.image" (dict "imageRoot" .waitValues.image "global" .context.Values.global "chart" .context.Chart "cloudProviderImageKey" .cloudProviderImageKey "context" .context) }}
+  imagePullPolicy: {{ .waitValues.image.pullPolicy }}
+  command:
+    - 'sh'
+    - '-c'
+    - |
+      echo "$(date): starting check for db $DB_HOST:$DB_PORT"
+      until PGPASSWORD="$DB_PASSWORD" psql -h "$DB_HOST" -p "$DB_PORT" -d "$DB_NAME" -U "$DB_USERNAME" $PSQL_EXTRA_ARGS -c "SELECT VERSION()"; do
+        echo "$(date): see you in $SLEEP_PERIOD_SECONDS seconds"
+        sleep $SLEEP_PERIOD_SECONDS
+      done
+      echo "$(date): db server ready"
+  env:
+    - name: SLEEP_PERIOD_SECONDS
+      value: "5"
+    - name: DB_HOST
+      value: {{ .connDetails.host | quote }}
+    - name: DB_PORT
+      value: {{ .connDetails.port | quote }}
+    - name: DB_NAME
+      value: {{ .connDetails.name | quote }}
+    - name: DB_USERNAME
+      value: {{ .connDetails.username | quote }}
+    - name: DB_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: {{ include .secretNameTemplate .context }}
+          key: {{ include .secretKeyTemplate .context }}
+  {{- if .waitValues.extraEnvVars }}
+    {{- include "seqera.tplvalues.render" (dict "value" .waitValues.extraEnvVars "context" .context) | nindent 4 }}
+  {{- end }}
+  {{- if .waitValues.extraVolumeMounts }}
+  volumeMounts: {{- include "seqera.tplvalues.render" (dict "value" .waitValues.extraVolumeMounts "context" .context) | nindent 4 }}
+  {{- end }}
+  securityContext: {{- include "seqera.tplvalues.render" (dict "value" .waitValues.securityContext) | nindent 4 }}
+  resources: {{- include "seqera.tplvalues.render" (dict "value" .waitValues.resources) | nindent 4 }}
+{{- end -}}
+
+{{/*
 Common initContainer to wait for Redis to be ready.
 
 Usage example:


### PR DESCRIPTION
Add an initial release of the wave chart, with wave lite only for now.
Create a new waitForPostgres function in seqera-common, requiring a bump of all charts.
I tested it locally and it works, up next I'll add it to an enterprise dev installation to test it in the field.