### PR TITLE
feat: add Bedrock embeddings chart settings

### DIFF
--- a/charts/platform/charts/agent-backend/CHANGELOG.md
+++ b/charts/platform/charts/agent-backend/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.7] - 2026-04-17
+
+### Added
+
+- Add first-class Bedrock embedding configuration values (`embeddings.useBedrockInference`, `embeddings.bedrock.region`, `embeddings.bedrock.modelId`, and `embeddings.bedrock.dimensions`) and render them as `USE_BEDROCK_INFERENCE`, `BEDROCK_REGION`, `NEXTFLOW_DOCS_BEDROCK_MODEL_ID`, and `NEXTFLOW_DOCS_BEDROCK_DIMENSIONS` in the Agent Backend ConfigMap
+
 ## [0.4.6] - 2026-04-10
 
 ### Changed

--- a/charts/platform/charts/agent-backend/CHANGELOG.md
+++ b/charts/platform/charts/agent-backend/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add first-class Bedrock embedding configuration values (`embeddings.useBedrockInference`, `embeddings.bedrock.region`, `embeddings.bedrock.modelId`, and `embeddings.bedrock.dimensions`) and render them as `USE_BEDROCK_INFERENCE`, `BEDROCK_REGION`, `NEXTFLOW_DOCS_BEDROCK_MODEL_ID`, and `NEXTFLOW_DOCS_BEDROCK_DIMENSIONS` in the Agent Backend ConfigMap
+- Add first-class Bedrock embedding configuration values under `.embeddings`
 - Add explicit `bedrockAgentCoreArn` value and render `AGENTCORE_AGENT_ARN` into the chart configmap when configured
 
 ## [0.4.6] - 2026-04-10

--- a/charts/platform/charts/agent-backend/Chart.yaml
+++ b/charts/platform/charts/agent-backend/Chart.yaml
@@ -19,7 +19,7 @@ apiVersion: v2
 name: agent-backend
 description: Backend service for Seqera CLI AI capabilities
 type: application
-version: 0.4.6
+version: 0.4.7
 appVersion: "2.0.0"
 maintainers:
   - name: Seqera Labs

--- a/charts/platform/charts/agent-backend/README.md
+++ b/charts/platform/charts/agent-backend/README.md
@@ -84,7 +84,6 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | anthropicApiKey | string | `""` | Anthropic API key. Define the value as a String or a Secret, not both at the same time |
 | anthropicApiKeyExistingSecretName | string | `""` | Name of an existing Secret containing the Anthropic API key. Note: the Secret must already exist in the same namespace at the time of deployment |
 | anthropicApiKeyExistingSecretKey | string | `"ANTHROPIC_API_KEY"` | Key in the existing Secret containing the Anthropic API key |
-| embeddings | object | `{"bedrock":{"dimensions":"","modelId":"","region":""},"useBedrockInference":false}` |  |
 | embeddings.useBedrockInference | bool | `false` | Enable AWS Bedrock inference for embeddings generation. |
 | embeddings.bedrock.region | string | `""` | AWS region where the Bedrock model is hosted |
 | embeddings.bedrock.modelId | string | `""` | Bedrock model ID used for embeddings |

--- a/charts/platform/charts/agent-backend/README.md
+++ b/charts/platform/charts/agent-backend/README.md
@@ -18,7 +18,7 @@ The required values to set in order to have a working installation are:
 - The redis connection details under the `.redis` section.
 - The Bedrock AgentCore runtime ARN under the `.bedrockAgentCoreArn` section.
 - Anthropic API credentials under `.anthropicApiKey` or `.anthropicApiKeyExistingSecretName`.
-- Bedrock embedding settings under `.embeddings` when using AWS Titan for embeddings.
+- Bedrock embedding settings under `.embeddings` (in particular the AWS region to use for the Bedrock embedding engine).
 - Container registry credentials under the `.global.imageCredentials` section (can be the credentials for cr.seqera.io or your private registry where you vendored the images to).
   * These credentials will be used by all the subcharts unless overridden in the specific subchart.
   * Multiple credentials can be specified to cover different registries.
@@ -83,13 +83,12 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | redis.existingSecretName | string | `""` | Name of an existing Secret containing the Redis password, as an alternative to the password field. Note: the Secret must already exist in the same namespace at the time of deployment |
 | redis.existingSecretKey | string | `"AGENT_BACKEND_REDIS_PASSWORD"` | Key in the existing Secret containing the Redis password |
 | bedrockAgentCoreArn | string | `""` | AWS Bedrock AgentCore runtime ARN for sandbox sessions |
+| embeddings.bedrock.region | string | `""` | AWS region where the Bedrock model is hosted |
+| embeddings.bedrock.modelId | string | `"amazon.titan-embed-text-v2:0"` | Bedrock model ID used for embeddings |
+| embeddings.bedrock.dimensions | string | `"1024"` | Embedding vector dimensions expected from the configured Bedrock model |
 | anthropicApiKey | string | `""` | Anthropic API key. Define the value as a String or a Secret, not both at the same time |
 | anthropicApiKeyExistingSecretName | string | `""` | Name of an existing Secret containing the Anthropic API key. Note: the Secret must already exist in the same namespace at the time of deployment |
 | anthropicApiKeyExistingSecretKey | string | `"ANTHROPIC_API_KEY"` | Key in the existing Secret containing the Anthropic API key |
-| embeddings.useBedrockInference | bool | `false` | Enable AWS Bedrock inference for embeddings generation. |
-| embeddings.bedrock.region | string | `""` | AWS region where the Bedrock model is hosted |
-| embeddings.bedrock.modelId | string | `""` | Bedrock model ID used for embeddings |
-| embeddings.bedrock.dimensions | string | `""` | Embedding vector dimensions expected from the configured Bedrock model |
 | tokenEncryptionKey | string | `""` | Token encryption key (must be a valid Fernet key). Define the value as a String or a Secret, not both at the same time. If not defined, a random Fernet key will be auto-generated at each deployment. WARNING: Always explicitly set this value or use an existing secret when using Kustomize. Auto-generated random values are incompatible with Kustomize. When upgrading releases via Kustomize, Helm cannot query the cluster to check if a secret already exists, causing it to regenerate a new random value on each upgrade |
 | tokenEncryptionKeyExistingSecretName | string | `""` | Name of an existing Secret containing the token encryption key. Note: the Secret must already exist in the same namespace at the time of deployment |
 | tokenEncryptionKeyExistingSecretKey | string | `"AGENT_BACKEND_TOKEN_ENCRYPTION_KEY"` | Key in the existing Secret containing the token encryption key |

--- a/charts/platform/charts/agent-backend/README.md
+++ b/charts/platform/charts/agent-backend/README.md
@@ -2,7 +2,7 @@
 
 Backend service for Seqera CLI AI capabilities
 
-![Version: 0.4.6](https://img.shields.io/badge/Version-0.4.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 0.4.7](https://img.shields.io/badge/Version-0.4.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -17,6 +17,7 @@ The required values to set in order to have a working installation are:
 - The database connection details for the MySQL database under the `.database` section.
 - The redis connection details under the `.redis` section.
 - Anthropic API credentials under `.anthropicApiKey` or `.anthropicApiKeyExistingSecretName`.
+- Bedrock embedding settings under `.embeddings` when using AWS Titan for embeddings.
 - Container registry credentials under the `.global.imageCredentials` section (can be the credentials for cr.seqera.io or your private registry where you vendored the images to).
   * These credentials will be used by all the subcharts unless overridden in the specific subchart.
   * Multiple credentials can be specified to cover different registries.
@@ -36,7 +37,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/agent-backend \
-  --version 0.4.6 \
+  --version 0.4.7 \
   --namespace my-namespace \
   --create-namespace
 ```
@@ -83,6 +84,11 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | anthropicApiKey | string | `""` | Anthropic API key. Define the value as a String or a Secret, not both at the same time |
 | anthropicApiKeyExistingSecretName | string | `""` | Name of an existing Secret containing the Anthropic API key. Note: the Secret must already exist in the same namespace at the time of deployment |
 | anthropicApiKeyExistingSecretKey | string | `"ANTHROPIC_API_KEY"` | Key in the existing Secret containing the Anthropic API key |
+| embeddings | object | `{"bedrock":{"dimensions":"","modelId":"","region":""},"useBedrockInference":false}` |  |
+| embeddings.useBedrockInference | bool | `false` | Enable AWS Bedrock inference for embeddings generation. |
+| embeddings.bedrock.region | string | `""` | AWS region where the Bedrock model is hosted |
+| embeddings.bedrock.modelId | string | `""` | Bedrock model ID used for embeddings |
+| embeddings.bedrock.dimensions | string | `""` | Embedding vector dimensions expected from the configured Bedrock model |
 | tokenEncryptionKey | string | `""` | Token encryption key (must be a valid Fernet key). Define the value as a String or a Secret, not both at the same time. If not defined, a random Fernet key will be auto-generated at each deployment. WARNING: Always explicitly set this value or use an existing secret when using Kustomize. Auto-generated random values are incompatible with Kustomize. When upgrading releases via Kustomize, Helm cannot query the cluster to check if a secret already exists, causing it to regenerate a new random value on each upgrade |
 | tokenEncryptionKeyExistingSecretName | string | `""` | Name of an existing Secret containing the token encryption key. Note: the Secret must already exist in the same namespace at the time of deployment |
 | tokenEncryptionKeyExistingSecretKey | string | `"AGENT_BACKEND_TOKEN_ENCRYPTION_KEY"` | Key in the existing Secret containing the token encryption key |

--- a/charts/platform/charts/agent-backend/README.md.gotmpl
+++ b/charts/platform/charts/agent-backend/README.md.gotmpl
@@ -17,7 +17,7 @@ The required values to set in order to have a working installation are:
 - The redis connection details under the `.redis` section.
 - The Bedrock AgentCore runtime ARN under the `.bedrockAgentCoreArn` section.
 - Anthropic API credentials under `.anthropicApiKey` or `.anthropicApiKeyExistingSecretName`.
-- Bedrock embedding settings under `.embeddings` when using AWS Titan for embeddings.
+- Bedrock embedding settings under `.embeddings` (in particular the AWS region to use for the Bedrock embedding engine).
 - Container registry credentials under the `.global.imageCredentials` section (can be the credentials for cr.seqera.io or your private registry where you vendored the images to).
   * These credentials will be used by all the subcharts unless overridden in the specific subchart.
   * Multiple credentials can be specified to cover different registries.

--- a/charts/platform/charts/agent-backend/README.md.gotmpl
+++ b/charts/platform/charts/agent-backend/README.md.gotmpl
@@ -16,6 +16,7 @@ The required values to set in order to have a working installation are:
 - The database connection details for the MySQL database under the `.database` section.
 - The redis connection details under the `.redis` section.
 - Anthropic API credentials under `.anthropicApiKey` or `.anthropicApiKeyExistingSecretName`.
+- Bedrock embedding settings under `.embeddings` when using AWS Titan for embeddings.
 - Container registry credentials under the `.global.imageCredentials` section (can be the credentials for cr.seqera.io or your private registry where you vendored the images to).
   * These credentials will be used by all the subcharts unless overridden in the specific subchart.
   * Multiple credentials can be specified to cover different registries.

--- a/charts/platform/charts/agent-backend/templates/NOTES.txt
+++ b/charts/platform/charts/agent-backend/templates/NOTES.txt
@@ -69,6 +69,11 @@
 {{- printf "\nVALUES VALIDATION:\n%s" $message | fail -}}
 {{- end -}}
 
+{{- if not (and .Values.embeddings.bedrock.region .Values.embeddings.bedrock.modelId .Values.embeddings.bedrock.dimensions) -}}
+{{- $message := "Define the Bedrock embedding configuration values under '.embeddings.bedrock'." -}}
+{{- printf "\nVALUES VALIDATION:\n%s" $message | fail -}}
+{{- end -}}
+
 Thank you for installing {{ .Chart.Name | title }}!
 
 Your release is named '{{ .Release.Name }}' and was installed in the '{{ include "common.names.namespace" . }}' namespace.

--- a/charts/platform/charts/agent-backend/templates/configmap.yaml
+++ b/charts/platform/charts/agent-backend/templates/configmap.yaml
@@ -52,14 +52,9 @@ data:
 
   AGENTCORE_AGENT_ARN: {{ tpl .Values.bedrockAgentCoreArn . | quote }}
 
-  LOG_LEVEL: {{ .Values.logLevel | default "INFO" | quote }}
-  USE_BEDROCK_INFERENCE: {{ .Values.embeddings.useBedrockInference | quote }}
-{{- if .Values.embeddings.bedrock.region }}
+  USE_BEDROCK_INFERENCE: "true"
   BEDROCK_REGION: {{ tpl (toString .Values.embeddings.bedrock.region) . | quote }}
-{{- end }}
-{{- if .Values.embeddings.bedrock.modelId }}
   NEXTFLOW_DOCS_BEDROCK_MODEL_ID: {{ tpl (toString .Values.embeddings.bedrock.modelId) . | quote }}
-{{- end }}
-{{- if .Values.embeddings.bedrock.dimensions }}
   NEXTFLOW_DOCS_BEDROCK_DIMENSIONS: {{ include "seqera.tplvalues.render" (dict "value" .Values.embeddings.bedrock.dimensions "context" $) | quote }}
-{{- end }}
+
+  LOG_LEVEL: {{ .Values.logLevel | default "INFO" | quote }}

--- a/charts/platform/charts/agent-backend/templates/configmap.yaml
+++ b/charts/platform/charts/agent-backend/templates/configmap.yaml
@@ -51,3 +51,13 @@ data:
   AGENT_BACKEND_REDIS_TLS: {{ .Values.redis.enableTls | quote }}
 
   LOG_LEVEL: {{ .Values.logLevel | default "INFO" | quote }}
+  USE_BEDROCK_INFERENCE: {{ .Values.embeddings.useBedrockInference | quote }}
+{{- if .Values.embeddings.bedrock.region }}
+  BEDROCK_REGION: {{ tpl (toString .Values.embeddings.bedrock.region) . | quote }}
+{{- end }}
+{{- if .Values.embeddings.bedrock.modelId }}
+  NEXTFLOW_DOCS_BEDROCK_MODEL_ID: {{ tpl (toString .Values.embeddings.bedrock.modelId) . | quote }}
+{{- end }}
+{{- if .Values.embeddings.bedrock.dimensions }}
+  NEXTFLOW_DOCS_BEDROCK_DIMENSIONS: {{ include "seqera.tplvalues.render" (dict "value" .Values.embeddings.bedrock.dimensions "context" $) | quote }}
+{{- end }}

--- a/charts/platform/charts/agent-backend/tests/NOTES_test.yaml
+++ b/charts/platform/charts/agent-backend/tests/NOTES_test.yaml
@@ -133,6 +133,7 @@ tests:
       anthropicApiKey: "test-anthropic-key"
       redis.host: "redis.example.com"
       bedrockAgentCoreArn: "arn:aws:bedrock:us-east-1::agent-runtime/test"
+      embeddings.bedrock.region: "us-east-1"
     asserts:
       - hasDocuments:
           count: 1
@@ -147,6 +148,7 @@ tests:
       anthropicApiKey: "test-anthropic-key"
       redis.host: "redis.example.com"
       bedrockAgentCoreArn: "arn:aws:bedrock:us-east-1::agent-runtime/test"
+      embeddings.bedrock.region: "us-east-1"
     asserts:
       - hasDocuments:
           count: 1
@@ -188,6 +190,7 @@ tests:
       anthropicApiKey: "test-anthropic-key"
       redis.host: "redis.example.com"
       bedrockAgentCoreArn: "arn:aws:bedrock:us-east-1::agent-runtime/test"
+      embeddings.bedrock.region: "us-east-1"
     asserts:
       - hasDocuments:
           count: 1
@@ -202,6 +205,7 @@ tests:
       anthropicApiKeyExistingSecretName: "my-anthropic-secret"
       redis.host: "redis.example.com"
       bedrockAgentCoreArn: "arn:aws:bedrock:us-east-1::agent-runtime/test"
+      embeddings.bedrock.region: "us-east-1"
     asserts:
       - hasDocuments:
           count: 1
@@ -265,6 +269,71 @@ tests:
       - failedTemplate:
           errorPattern: "Define the Bedrock AgentCore runtime ARN at 'bedrockAgentCoreArn'\\."
 
+  # Bedrock embeddings configuration tests
+  - it: should fail when embeddings.bedrock.region is not defined
+    set:
+      database:
+        host: "database.example.com"
+        name: "agent_backend"
+        username: "agent"
+        password: "test-password"
+      anthropicApiKey: "test-anthropic-key"
+      redis.host: "redis.example.com"
+      bedrockAgentCoreArn: "arn:aws:bedrock:us-east-1::agent-runtime/test"
+      embeddings.bedrock.region: ""
+    asserts:
+      - failedTemplate:
+          errorPattern: "Define the Bedrock embedding configuration values under '.embeddings.bedrock'\\."
+
+  - it: should fail when embeddings.bedrock.modelId is not defined
+    set:
+      database:
+        host: "database.example.com"
+        name: "agent_backend"
+        username: "agent"
+        password: "test-password"
+      anthropicApiKey: "test-anthropic-key"
+      redis.host: "redis.example.com"
+      bedrockAgentCoreArn: "arn:aws:bedrock:us-east-1::agent-runtime/test"
+      embeddings.bedrock.region: "us-east-1"
+      embeddings.bedrock.modelId: ""
+    asserts:
+      - failedTemplate:
+          errorPattern: "Define the Bedrock embedding configuration values under '.embeddings.bedrock'\\."
+
+  - it: should fail when embeddings.bedrock.dimensions is not defined
+    set:
+      database:
+        host: "database.example.com"
+        name: "agent_backend"
+        username: "agent"
+        password: "test-password"
+      anthropicApiKey: "test-anthropic-key"
+      redis.host: "redis.example.com"
+      bedrockAgentCoreArn: "arn:aws:bedrock:us-east-1::agent-runtime/test"
+      embeddings.bedrock.region: "us-east-1"
+      embeddings.bedrock.dimensions: ""
+    asserts:
+      - failedTemplate:
+          errorPattern: "Define the Bedrock embedding configuration values under '.embeddings.bedrock'\\."
+
+  - it: should pass when all embeddings.bedrock values are set
+    set:
+      database:
+        host: "database.example.com"
+        name: "agent_backend"
+        username: "agent"
+        password: "test-password"
+      anthropicApiKey: "test-anthropic-key"
+      redis.host: "redis.example.com"
+      bedrockAgentCoreArn: "arn:aws:bedrock:us-east-1::agent-runtime/test"
+      embeddings.bedrock.region: "us-east-1"
+      embeddings.bedrock.modelId: "test-model"
+      embeddings.bedrock.dimensions: 1024
+    asserts:
+      - hasDocuments:
+          count: 1
+
   # Complete valid configuration test
   - it: should pass with all required values properly set
     set:
@@ -276,6 +345,7 @@ tests:
       anthropicApiKey: "test-anthropic-key"
       redis.host: "redis.example.com"
       bedrockAgentCoreArn: "arn:aws:bedrock:us-east-1::agent-runtime/test"
+      embeddings.bedrock.region: "us-east-1"
     asserts:
       - hasDocuments:
           count: 1
@@ -292,6 +362,7 @@ tests:
       redis.host: "redis.example.com"
       redis.existingSecretName: "redis-secret"
       bedrockAgentCoreArn: "arn:aws:bedrock:us-east-1::agent-runtime/test"
+      embeddings.bedrock.region: "us-east-1"
     asserts:
       - hasDocuments:
           count: 1

--- a/charts/platform/charts/agent-backend/tests/__snapshot__/configmap_test.yaml.snap
+++ b/charts/platform/charts/agent-backend/tests/__snapshot__/configmap_test.yaml.snap
@@ -16,6 +16,7 @@ should render a ConfigMap with default values:
       LOG_LEVEL: INFO
       SEQERA_MCP_URL: https://mcp.test.example.com/mcp
       SEQERA_PLATFORM_API_URL: https://test.example.com/api
+      USE_BEDROCK_INFERENCE: "false"
     kind: ConfigMap
     metadata:
       annotations: {}

--- a/charts/platform/charts/agent-backend/tests/__snapshot__/configmap_test.yaml.snap
+++ b/charts/platform/charts/agent-backend/tests/__snapshot__/configmap_test.yaml.snap
@@ -14,10 +14,13 @@ should render a ConfigMap with default values:
       AGENT_BACKEND_REDIS_PORT: "6379"
       AGENT_BACKEND_REDIS_TLS: "false"
       AGENTCORE_AGENT_ARN: ""
+      BEDROCK_REGION: ""
       LOG_LEVEL: INFO
+      NEXTFLOW_DOCS_BEDROCK_DIMENSIONS: "1024"
+      NEXTFLOW_DOCS_BEDROCK_MODEL_ID: amazon.titan-embed-text-v2:0
       SEQERA_MCP_URL: https://mcp.test.example.com/mcp
       SEQERA_PLATFORM_API_URL: https://test.example.com/api
-      USE_BEDROCK_INFERENCE: "false"
+      USE_BEDROCK_INFERENCE: "true"
     kind: ConfigMap
     metadata:
       annotations: {}

--- a/charts/platform/charts/agent-backend/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/platform/charts/agent-backend/tests/__snapshot__/deployment_test.yaml.snap
@@ -21,7 +21,7 @@ should render a Deployment with default values:
       template:
         metadata:
           annotations:
-            checksum/configmap: 4eb49ee3c673936de95662cd90fb546c4ec8ac49c41b09dfd1d46f54afc25200
+            checksum/configmap: 13775ee23bf8fb7bc5e8eb7cbf1e4ac2c8cf97c39c74ce78c18129f17985abd1
             checksum/secret: ac4ca92760ab83180bef6b3504a9f7b2663f3c2972a4b7e57a8e3173c6092172
           labels:
             app.kubernetes.io/component: agent-backend

--- a/charts/platform/charts/agent-backend/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/platform/charts/agent-backend/tests/__snapshot__/deployment_test.yaml.snap
@@ -21,7 +21,7 @@ should render a Deployment with default values:
       template:
         metadata:
           annotations:
-            checksum/configmap: a6b239f1bf5b0a334a186b6a0eedac0956b8b54d40642637c0c06eceae81865c
+            checksum/configmap: 57f9f5126e32db37e058a28ba5136b2ac0a0f2b0aad80500009171bdf9371635
             checksum/secret: ac4ca92760ab83180bef6b3504a9f7b2663f3c2972a4b7e57a8e3173c6092172
           labels:
             app.kubernetes.io/component: agent-backend

--- a/charts/platform/charts/agent-backend/tests/configmap_test.yaml
+++ b/charts/platform/charts/agent-backend/tests/configmap_test.yaml
@@ -111,7 +111,7 @@ tests:
           path: data.LOG_LEVEL
           value: DEBUG
 
-  - it: should set Bedrock inference disabled by default
+  - it: should always enable Bedrock inference
     set:
       global.platformExternalDomain: test.example.com
       global.mcpDomain: mcp.test.example.com
@@ -121,22 +121,31 @@ tests:
     asserts:
       - equal:
           path: data.USE_BEDROCK_INFERENCE
-          value: "false"
-      - notExists:
-          path: data.BEDROCK_REGION
-      - notExists:
-          path: data.NEXTFLOW_DOCS_BEDROCK_MODEL_ID
-      - notExists:
-          path: data.NEXTFLOW_DOCS_BEDROCK_DIMENSIONS
+          value: "true"
 
-  - it: should render Bedrock embeddings settings when enabled
+  - it: should render Bedrock embeddings settings with default values
     set:
       global.platformExternalDomain: test.example.com
       global.mcpDomain: mcp.test.example.com
       database.host: mysql
       database.name: db
       database.username: user
-      embeddings.useBedrockInference: true
+    asserts:
+      - isSubset:
+          path: data
+          content:
+            USE_BEDROCK_INFERENCE: "true"
+            BEDROCK_REGION: ""
+            NEXTFLOW_DOCS_BEDROCK_MODEL_ID: amazon.titan-embed-text-v2:0
+            NEXTFLOW_DOCS_BEDROCK_DIMENSIONS: "1024"
+
+  - it: should render Bedrock embeddings settings when configured
+    set:
+      global.platformExternalDomain: test.example.com
+      global.mcpDomain: mcp.test.example.com
+      database.host: mysql
+      database.name: db
+      database.username: user
       embeddings.bedrock.region: eu-west-2
       embeddings.bedrock.modelId: amazon.titan-embed-text-v2:0
       embeddings.bedrock.dimensions: 1024

--- a/charts/platform/charts/agent-backend/tests/configmap_test.yaml
+++ b/charts/platform/charts/agent-backend/tests/configmap_test.yaml
@@ -111,6 +111,44 @@ tests:
           path: data.LOG_LEVEL
           value: DEBUG
 
+  - it: should set Bedrock inference disabled by default
+    set:
+      global.platformExternalDomain: test.example.com
+      global.mcpDomain: mcp.test.example.com
+      database.host: mysql
+      database.name: db
+      database.username: user
+    asserts:
+      - equal:
+          path: data.USE_BEDROCK_INFERENCE
+          value: "false"
+      - notExists:
+          path: data.BEDROCK_REGION
+      - notExists:
+          path: data.NEXTFLOW_DOCS_BEDROCK_MODEL_ID
+      - notExists:
+          path: data.NEXTFLOW_DOCS_BEDROCK_DIMENSIONS
+
+  - it: should render Bedrock embeddings settings when enabled
+    set:
+      global.platformExternalDomain: test.example.com
+      global.mcpDomain: mcp.test.example.com
+      database.host: mysql
+      database.name: db
+      database.username: user
+      embeddings.useBedrockInference: true
+      embeddings.bedrock.region: eu-west-2
+      embeddings.bedrock.modelId: amazon.titan-embed-text-v2:0
+      embeddings.bedrock.dimensions: 1024
+    asserts:
+      - isSubset:
+          path: data
+          content:
+            USE_BEDROCK_INFERENCE: "true"
+            BEDROCK_REGION: eu-west-2
+            NEXTFLOW_DOCS_BEDROCK_MODEL_ID: amazon.titan-embed-text-v2:0
+            NEXTFLOW_DOCS_BEDROCK_DIMENSIONS: "1024"
+
   - it: should contain default Redis configuration
     set:
       global.platformExternalDomain: test.example.com

--- a/charts/platform/charts/agent-backend/values.yaml
+++ b/charts/platform/charts/agent-backend/values.yaml
@@ -94,6 +94,15 @@ redis:
 # -- AWS Bedrock AgentCore runtime ARN for sandbox sessions
 bedrockAgentCoreArn: ""
 
+embeddings:
+  bedrock:
+    # -- AWS region where the Bedrock model is hosted
+    region: ""
+    # -- Bedrock model ID used for embeddings
+    modelId: "amazon.titan-embed-text-v2:0"
+    # -- Embedding vector dimensions expected from the configured Bedrock model
+    dimensions: "1024"
+
 # -- Anthropic API key. Define the value as a String or a Secret, not both at the same time
 anthropicApiKey: ""
 # -- Name of an existing Secret containing the Anthropic API key.
@@ -102,18 +111,6 @@ anthropicApiKeyExistingSecretName: ""
 # -- Key in the existing Secret containing the Anthropic API key
 # @default -- `"ANTHROPIC_API_KEY"`
 anthropicApiKeyExistingSecretKey: ""
-
-embeddings:
-  # -- Enable AWS Bedrock inference for embeddings generation.
-  useBedrockInference: false
-
-  bedrock:
-    # -- AWS region where the Bedrock model is hosted
-    region: ""
-    # -- Bedrock model ID used for embeddings
-    modelId: ""
-    # -- Embedding vector dimensions expected from the configured Bedrock model
-    dimensions: ""
 
 # -- Token encryption key (must be a valid Fernet key). Define the value as a String or a Secret,
 # not both at the same time. If not defined, a random Fernet key will be auto-generated at each

--- a/charts/platform/charts/agent-backend/values.yaml
+++ b/charts/platform/charts/agent-backend/values.yaml
@@ -100,6 +100,18 @@ anthropicApiKeyExistingSecretName: ""
 # @default -- `"ANTHROPIC_API_KEY"`
 anthropicApiKeyExistingSecretKey: ""
 
+embeddings:
+  # -- Enable AWS Bedrock inference for embeddings generation.
+  useBedrockInference: false
+
+  bedrock:
+    # -- AWS region where the Bedrock model is hosted
+    region: ""
+    # -- Bedrock model ID used for embeddings
+    modelId: ""
+    # -- Embedding vector dimensions expected from the configured Bedrock model
+    dimensions: ""
+
 # -- Token encryption key (must be a valid Fernet key). Define the value as a String or a Secret,
 # not both at the same time. If not defined, a random Fernet key will be auto-generated at each
 # deployment.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add first-class Bedrock embedding configuration values to the `agent-backend` subchart (`embeddings.useBedrockInference`, `embeddings.bedrock.region`, `embeddings.bedrock.modelId`, `embeddings.bedrock.dimensions`)
- render these settings into `templates/configmap.yaml` as `USE_BEDROCK_INFERENCE`, `BEDROCK_REGION`, `NEXTFLOW_DOCS_BEDROCK_MODEL_ID`, and `NEXTFLOW_DOCS_BEDROCK_DIMENSIONS`
- add configmap tests for default and Bedrock-enabled behavior, and refresh affected snapshots
- bump `agent-backend` chart version to `0.4.7`, update changelog, and update README docs via helm-docs

## Testing
- `helm dependency build charts/platform/charts/agent-backend`
- `helm unittest -u charts/platform/charts/agent-backend`

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AI-3133](https://linear.app/seqera/issue/AI-3133/update-the-helm-chart-to-support-the-configuration)

<div><a href="https://cursor.com/agents/bc-0056a9e2-708d-423d-9c2f-6b50f6b61b7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0056a9e2-708d-423d-9c2f-6b50f6b61b7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

