### PR TITLE
feat(ci): attach packaged chart .tgz to GitHub Releases

### DIFF
--- a/.github/workflows/build-helm-charts.yaml
+++ b/.github/workflows/build-helm-charts.yaml
@@ -10,6 +10,8 @@ jobs:
     name: 'Update Helm chart'
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: write
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -141,12 +143,74 @@ jobs:
           \`\`\`
           EOF
 
-            # Create the release with auto-generated notes
+            # Create the release with auto-generated notes and attach the
+            # packaged chart as a release asset so it can be served as a
+            # standard Helm repository via GitHub Pages (see cr index step below).
             gh release create "${release_tag}" \
               --repo ${{ github.repository }} \
               --title "${chart_name} ${chart_version}" \
               --generate-notes \
-              --notes-file ${temp_file}
+              --notes-file ${temp_file} \
+              "${chart_name}-${chart_version}.tgz"
 
             echo "Created release ${release_tag}"
           done
+
+      - name: 'Bootstrap empty gh-pages branch if missing'
+        if: github.ref_name == 'master' && env.charts_to_package != ''
+        shell: bash
+        run: |
+          set -euo pipefail
+          if git ls-remote --exit-code --heads origin gh-pages >/dev/null 2>&1; then
+            echo "gh-pages branch already exists."
+            exit 0
+          fi
+          echo "Creating empty gh-pages branch."
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git worktree add --orphan -b gh-pages gh-pages-init
+          cd gh-pages-init
+          # .nojekyll prevents GitHub Pages from running the index through Jekyll,
+          # which would mangle filenames starting with an underscore.
+          touch .nojekyll
+          git add .nojekyll
+          git commit -m "Initialize gh-pages branch"
+          git push origin gh-pages
+
+      - name: 'Install chart-releaser'
+        if: github.ref_name == 'master' && env.charts_to_package != ''
+        run: |
+          curl -fsSL -o cr.tar.gz https://github.com/helm/chart-releaser/releases/download/v1.8.1/chart-releaser_1.8.1_linux_amd64.tar.gz
+          echo "834046b27b00cd6ba451326875c1937d4f2b671063c2053e031434ade73002b5  cr.tar.gz" | sha256sum -c
+          tar -xzf cr.tar.gz cr
+          sudo mv cr /usr/local/bin/cr
+
+      - name: 'Update GitHub Pages Helm repo index'
+        if: github.ref_name == 'master' && env.charts_to_package != ''
+        shell: bash
+        env:
+          CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          # Stage the freshly packaged .tgz files for cr index. The .tgz themselves
+          # are hosted as GitHub Release assets (uploaded in the previous step);
+          # cr uses this directory only to discover which charts to include.
+          mkdir -p .cr-release-packages
+          for chart in $charts_to_package; do
+            chart_name=$(yq -r '.name' ${chart}/Chart.yaml)
+            chart_version=$(yq -r '.version' ${chart}/Chart.yaml)
+            mv "${chart_name}-${chart_version}.tgz" .cr-release-packages/
+          done
+
+          owner="${GITHUB_REPOSITORY%%/*}"
+          repo="${GITHUB_REPOSITORY##*/}"
+
+          cr index \
+            --owner "${owner}" \
+            --git-repo "${repo}" \
+            --token "${CR_TOKEN}" \
+            --package-path .cr-release-packages \
+            --index-path .cr-index \
+            --pages-branch gh-pages \
+            --push

--- a/.github/workflows/build-helm-charts.yaml
+++ b/.github/workflows/build-helm-charts.yaml
@@ -10,8 +10,6 @@ jobs:
     name: 'Update Helm chart'
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    permissions:
-      contents: write
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -144,8 +142,7 @@ jobs:
           EOF
 
             # Create the release with auto-generated notes and attach the
-            # packaged chart as a release asset so it can be served as a
-            # standard Helm repository via GitHub Pages (see cr index step below).
+            # packaged chart as a release asset.
             gh release create "${release_tag}" \
               --repo ${{ github.repository }} \
               --title "${chart_name} ${chart_version}" \
@@ -155,62 +152,3 @@ jobs:
 
             echo "Created release ${release_tag}"
           done
-
-      - name: 'Bootstrap empty gh-pages branch if missing'
-        if: github.ref_name == 'master' && env.charts_to_package != ''
-        shell: bash
-        run: |
-          set -euo pipefail
-          if git ls-remote --exit-code --heads origin gh-pages >/dev/null 2>&1; then
-            echo "gh-pages branch already exists."
-            exit 0
-          fi
-          echo "Creating empty gh-pages branch."
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git worktree add --orphan -b gh-pages gh-pages-init
-          cd gh-pages-init
-          # .nojekyll prevents GitHub Pages from running the index through Jekyll,
-          # which would mangle filenames starting with an underscore.
-          touch .nojekyll
-          git add .nojekyll
-          git commit -m "Initialize gh-pages branch"
-          git push origin gh-pages
-
-      - name: 'Install chart-releaser'
-        if: github.ref_name == 'master' && env.charts_to_package != ''
-        run: |
-          curl -fsSL -o cr.tar.gz https://github.com/helm/chart-releaser/releases/download/v1.8.1/chart-releaser_1.8.1_linux_amd64.tar.gz
-          echo "834046b27b00cd6ba451326875c1937d4f2b671063c2053e031434ade73002b5  cr.tar.gz" | sha256sum -c
-          tar -xzf cr.tar.gz cr
-          sudo mv cr /usr/local/bin/cr
-
-      - name: 'Update GitHub Pages Helm repo index'
-        if: github.ref_name == 'master' && env.charts_to_package != ''
-        shell: bash
-        env:
-          CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-
-          # Stage the freshly packaged .tgz files for cr index. The .tgz themselves
-          # are hosted as GitHub Release assets (uploaded in the previous step);
-          # cr uses this directory only to discover which charts to include.
-          mkdir -p .cr-release-packages
-          for chart in $charts_to_package; do
-            chart_name=$(yq -r '.name' ${chart}/Chart.yaml)
-            chart_version=$(yq -r '.version' ${chart}/Chart.yaml)
-            mv "${chart_name}-${chart_version}.tgz" .cr-release-packages/
-          done
-
-          owner="${GITHUB_REPOSITORY%%/*}"
-          repo="${GITHUB_REPOSITORY##*/}"
-
-          cr index \
-            --owner "${owner}" \
-            --git-repo "${repo}" \
-            --token "${CR_TOKEN}" \
-            --package-path .cr-release-packages \
-            --index-path .cr-index \
-            --pages-branch gh-pages \
-            --push

--- a/README.md
+++ b/README.md
@@ -23,6 +23,29 @@ Each chart comes with its own README file containing specific instructions and d
 scenarios are also provided in the `examples/` directory to help you configure and deploy the
 charts in different environments.
 
+## Installing the charts
+
+Charts are published in two ways. Pick whichever fits your tooling.
+
+### As a Helm repository (HTTPS)
+
+```bash
+helm repo add seqera https://seqeralabs.github.io/helm-charts
+helm repo update
+helm search repo seqera
+helm install my-platform seqera/platform --version <version>
+```
+
+### From the OCI registry
+
+```bash
+helm pull oci://public.cr.seqera.io/charts/platform --version <version>
+helm install my-platform oci://public.cr.seqera.io/charts/platform --version <version>
+```
+
+The HTTPS repository only contains versions published from April 2026 onwards.
+For older releases, use the OCI registry.
+
 ## Vendoring Seqera container images and charts
 
 Refer to the [vendoring documentation](./VENDORING.md) for instructions on how to vendor Seqera

--- a/README.md
+++ b/README.md
@@ -23,29 +23,6 @@ Each chart comes with its own README file containing specific instructions and d
 scenarios are also provided in the `examples/` directory to help you configure and deploy the
 charts in different environments.
 
-## Installing the charts
-
-Charts are published in two ways. Pick whichever fits your tooling.
-
-### As a Helm repository (HTTPS)
-
-```bash
-helm repo add seqera https://seqeralabs.github.io/helm-charts
-helm repo update
-helm search repo seqera
-helm install my-platform seqera/platform --version <version>
-```
-
-### From the OCI registry
-
-```bash
-helm pull oci://public.cr.seqera.io/charts/platform --version <version>
-helm install my-platform oci://public.cr.seqera.io/charts/platform --version <version>
-```
-
-The HTTPS repository only contains versions published from April 2026 onwards.
-For older releases, use the OCI registry.
-
 ## Vendoring Seqera container images and charts
 
 Refer to the [vendoring documentation](./VENDORING.md) for instructions on how to vendor Seqera


### PR DESCRIPTION
## Summary

- On master, the workflow now attaches each packaged chart `.tgz` to its GitHub Release as an asset.
- This is the minimum-change prerequisite for serving the charts as a Helm repository via GitHub Pages later — the assets need to be hosted somewhere the eventual `index.yaml` can link to.

## Scope

This PR is intentionally small. It does **not** create a `gh-pages` branch, generate `index.yaml`, or enable `helm repo add`. See [this comment](https://github.com/seqeralabs/helm-charts/pull/118#issuecomment-4329692972) for the proposed follow-up that adds the rest of the GitHub Pages plumbing.

## What changed

`.github/workflows/build-helm-charts.yaml` — adds the `.tgz` filename as a positional argument to the existing `gh release create` invocation.

## Test plan

- [ ] Merge to master and confirm the next chart release run succeeds
- [ ] Open the new GitHub Release and verify the `.tgz` is attached as an asset
- [ ] Confirm `helm pull` still works against the OCI registry (unchanged path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)