### PR TITLE
fix: mcp oauth initial access token name in helpers DEVOPS-1390

### DIFF
--- a/charts/platform/CHANGELOG.md
+++ b/charts/platform/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.32.2] - 2026-04-28
+
+### Changed
+
+- Bump `mcp` subchart to 0.3.2 to fix wrong oauth initial access token environment variable
+
 ## [0.32.1] - 2026-04-20
 
 ### Changed

--- a/charts/platform/Chart.lock
+++ b/charts/platform/Chart.lock
@@ -16,7 +16,7 @@ dependencies:
   version: 0.1.0
 - name: mcp
   repository: file://charts/mcp
-  version: 0.3.1
+  version: 0.3.2
 - name: agent-backend
   repository: file://charts/agent-backend
   version: 0.4.6

--- a/charts/platform/Chart.yaml
+++ b/charts/platform/Chart.yaml
@@ -37,7 +37,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.32.1
+version: 0.32.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/platform/README.md
+++ b/charts/platform/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart to deploy Seqera Platform (also referred to as Tower) on Kubernetes.
 
-![Version: 0.32.1](https://img.shields.io/badge/Version-0.32.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v25.3.4](https://img.shields.io/badge/AppVersion-v25.3.4-informational?style=flat-square)
+![Version: 0.32.2](https://img.shields.io/badge/Version-0.32.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v25.3.4](https://img.shields.io/badge/AppVersion-v25.3.4-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -41,7 +41,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/platform \
-  --version 0.32.1 \
+  --version 0.32.2 \
   --namespace my-namespace \
   --create-namespace
 ```
@@ -166,7 +166,7 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | platform.oidcPrivateKeySecretKey | string | `"oidc.pem"` | Key in the existing Secret containing the OIDC private key in PEM format |
 | platform.oidcClientRegistrationToken | string | `""` | OIDC client registration token as a string. Used by Studios and MCP to dynamically register OAuth clients with Seqera Platform's OIDC provider. If neither this nor oidcClientRegistrationTokenSecretName is set, a random value is generated. WARNING: Always explicitly set this value or use an existing secret when using Kustomize. Auto-generated random values are incompatible with Kustomize. When upgrading releases via Kustomize, Helm cannot query the cluster to check if a secret already exists, causing it to regenerate a new random value on each upgrade |
 | platform.oidcClientRegistrationTokenSecretName | string | `""` | Name of an existing Secret containing the OIDC client registration token, as an alternative to the string field. Note: the Secret must already exist in the same namespace at the time of deployment |
-| platform.oidcClientRegistrationTokenSecretKey | string | `"OIDC_CLIENT_REGISTRATION_TOKEN"` | Key in the existing Secret containing the OIDC client registration token |
+| platform.oidcClientRegistrationTokenSecretKey | string | `"MCP_OAUTH_INITIAL_ACCESS_TOKEN"` | Key in the existing Secret containing the OIDC client registration token |
 | platform.smtp.host | string | `""` | SMTP server hostname to let users authenticate through email, and to send email notifications for events |
 | platform.smtp.port | string | `""` | SMTP server port |
 | platform.smtp.user | string | `""` | SMTP server username |

--- a/charts/platform/charts/mcp/CHANGELOG.md
+++ b/charts/platform/charts/mcp/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed the name of the initial access token variable in the helper script
+- Fixed the name of the oauth initial access token variable in the helper script
+- Made oauth initial access token a requirement for the MCP chart
 
 ## [0.3.1] - 2026-04-10
 

--- a/charts/platform/charts/mcp/CHANGELOG.md
+++ b/charts/platform/charts/mcp/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.2] - 2026-04-28
+
+### Fixed
+
+- Fixed the name of the initial access token variable in the helper script
+
 ## [0.3.1] - 2026-04-10
 
 ### Changed

--- a/charts/platform/charts/mcp/Chart.yaml
+++ b/charts/platform/charts/mcp/Chart.yaml
@@ -22,7 +22,7 @@ description: |
   Wave container provisioning, bioinformatics data, and nf-core modules through intelligent
   RAG-based natural language interactions.
 type: application
-version: 0.3.1
+version: 0.3.2
 appVersion: "1.1.0"
 maintainers:
   - name: Seqera Labs

--- a/charts/platform/charts/mcp/README.md
+++ b/charts/platform/charts/mcp/README.md
@@ -4,7 +4,7 @@ A Model Context Protocol (MCP) server that provides comprehensive access to the 
 Wave container provisioning, bioinformatics data, and nf-core modules through intelligent
 RAG-based natural language interactions.
 
-![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
+![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -37,7 +37,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/mcp \
-  --version 0.3.1 \
+  --version 0.3.2 \
   --namespace my-namespace \
   --create-namespace
 ```

--- a/charts/platform/charts/mcp/templates/NOTES.txt
+++ b/charts/platform/charts/mcp/templates/NOTES.txt
@@ -24,6 +24,14 @@
 {{- printf "\nVALUES VALIDATION:\n%s" $message | fail -}}
 {{- end -}}
 
+{{- if and .Values.oidcToken.tokenString .Values.oidcToken.existingSecretName -}}
+{{- fail "Either provide 'oidcToken.tokenString' or an existing secret name in 'oidcToken.existingSecretName', but not both." -}}
+{{- end -}}
+
+{{- if not (or .Values.oidcToken.tokenString .Values.oidcToken.existingSecretName) -}}
+{{- fail "An OIDC client registration token must be provided: set 'oidcToken.tokenString' or point to an existing secret via 'oidcToken.existingSecretName'." -}}
+{{- end -}}
+
 Thank you for installing {{ .Chart.Name | title }}!
 
 Your release is named '{{ .Release.Name }}' and was installed in the '{{ include "common.names.namespace" . }}' namespace.

--- a/charts/platform/charts/mcp/templates/_helpers.tpl
+++ b/charts/platform/charts/mcp/templates/_helpers.tpl
@@ -66,8 +66,8 @@ Return the name of the secret containing the OIDC client registration token.
 {{- end -}}
 {{- define "mcp.oidcToken.secretKey" -}}
   {{- if (include "mcp.oidcToken.existingSecret" .) -}}
-    {{- printf "%s" (tpl .Values.oidcToken.existingSecretKey .) | default "OIDC_CLIENT_REGISTRATION_TOKEN" -}}
+    {{- printf "%s" (tpl .Values.oidcToken.existingSecretKey .) | default "MCP_OAUTH_INITIAL_ACCESS_TOKEN" -}}
   {{- else -}}
-    {{- printf "OIDC_CLIENT_REGISTRATION_TOKEN" -}}
+    {{- printf "MCP_OAUTH_INITIAL_ACCESS_TOKEN" -}}
   {{- end -}}
 {{- end -}}

--- a/charts/platform/charts/mcp/tests/NOTES_test.yaml
+++ b/charts/platform/charts/mcp/tests/NOTES_test.yaml
@@ -29,6 +29,8 @@ tests:
     set:
       micronautEnvironments:
         - oauth-platform
+      oidcToken.tokenString: ""
+      oidcToken.existingSecretName: "my-oidc-secret"
       oauth.jwtSeedString: "my-jwt-seed"
       oauth.jwtSeedSecretName: "my-jwt-secret"
     asserts:
@@ -39,6 +41,8 @@ tests:
     set:
       micronautEnvironments:
         - oauth-platform
+      oidcToken.tokenString: ""
+      oidcToken.existingSecretName: "my-oidc-secret"
       oauth.jwtSeedString: "my-jwt-seed"
     asserts:
       - hasDocuments:
@@ -48,6 +52,8 @@ tests:
     set:
       micronautEnvironments:
         - oauth-platform
+      oidcToken.tokenString: ""
+      oidcToken.existingSecretName: "my-oidc-secret"
       oauth.jwtSeedSecretName: "my-jwt-secret"
     asserts:
       - hasDocuments:
@@ -57,6 +63,49 @@ tests:
     set:
       micronautEnvironments:
         - oauth-platform
+      oidcToken.tokenString: ""
+      oidcToken.existingSecretName: "my-oidc-secret"
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  # OIDC token mutual exclusion and requirement
+  - it: should fail when both oidcToken.tokenString and oidcToken.existingSecretName are set
+    set:
+      micronautEnvironments:
+        - oauth-platform
+      oidcToken.tokenString: "my-oidc-token"
+      oidcToken.existingSecretName: "my-oidc-secret"
+    asserts:
+      - failedTemplate:
+          errorPattern: "Either provide 'oidcToken.tokenString' or an existing secret name in 'oidcToken.existingSecretName', but not both\\."
+
+  - it: should fail when neither oidcToken.tokenString nor oidcToken.existingSecretName are set
+    set:
+      micronautEnvironments:
+        - oauth-platform
+      oidcToken.tokenString: ""
+      oidcToken.existingSecretName: ""
+    asserts:
+      - failedTemplate:
+          errorPattern: "An OIDC client registration token must be provided"
+
+  - it: should pass when only oidcToken.tokenString is set
+    set:
+      micronautEnvironments:
+        - oauth-platform
+      oidcToken.tokenString: "my-oidc-token"
+      oidcToken.existingSecretName: ""
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  - it: should pass when only oidcToken.existingSecretName is set
+    set:
+      micronautEnvironments:
+        - oauth-platform
+      oidcToken.tokenString: ""
+      oidcToken.existingSecretName: "my-oidc-secret"
     asserts:
       - hasDocuments:
           count: 1

--- a/charts/platform/charts/mcp/tests/deployment_test.yaml
+++ b/charts/platform/charts/mcp/tests/deployment_test.yaml
@@ -48,7 +48,7 @@ tests:
             valueFrom:
               secretKeyRef:
                 name: release-name-mcp
-                key: OIDC_CLIENT_REGISTRATION_TOKEN
+                key: MCP_OAUTH_INITIAL_ACCESS_TOKEN
 
   - it: should inject MCP_OAUTH_INITIAL_ACCESS_TOKEN from existing secret when set
     template: deployment.yaml

--- a/charts/platform/values.yaml
+++ b/charts/platform/values.yaml
@@ -366,7 +366,7 @@ platform:
   # deployment
   oidcClientRegistrationTokenSecretName: ""
   # -- Key in the existing Secret containing the OIDC client registration token
-  # @default -- `"OIDC_CLIENT_REGISTRATION_TOKEN"`
+  # @default -- `"MCP_OAUTH_INITIAL_ACCESS_TOKEN"`
   oidcClientRegistrationTokenSecretKey: ""
 
   smtp:


### PR DESCRIPTION
Follow up of #110 where I forgot to update the env var name in the MCP chart's helper script and comment.

I'll now open a separate PR to make the OIDC initial token a requirement for the MCP chart and force the user to provide it (e.g. when installing MCP separately from the platform chart).