### PR TITLE
feat: studios subchart provide its own oauth initial registration token DEVOPS-1390

### DIFF
--- a/charts/platform/CHANGELOG.md
+++ b/charts/platform/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.32.3] - 2026-04-28
+
+### Changed
+
+- Bump `studios` subchart to 1.2.11 to write OIDC registration token to chart-managed secret and enforce it as a required value
+
 ## [0.32.2] - 2026-04-28
 
 ### Changed

--- a/charts/platform/Chart.yaml
+++ b/charts/platform/Chart.yaml
@@ -37,7 +37,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.32.2
+version: 0.32.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/platform/README.md
+++ b/charts/platform/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart to deploy Seqera Platform (also referred to as Tower) on Kubernetes.
 
-![Version: 0.32.2](https://img.shields.io/badge/Version-0.32.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v25.3.4](https://img.shields.io/badge/AppVersion-v25.3.4-informational?style=flat-square)
+![Version: 0.32.3](https://img.shields.io/badge/Version-0.32.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v25.3.4](https://img.shields.io/badge/AppVersion-v25.3.4-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -41,7 +41,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/platform \
-  --version 0.32.2 \
+  --version 0.32.3 \
   --namespace my-namespace \
   --create-namespace
 ```

--- a/charts/platform/charts/studios/CHANGELOG.md
+++ b/charts/platform/charts/studios/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.11] - 2026-04-28
+
+### Added
+
+- Write `CONNECT_OIDC_CLIENT_REGISTRATION_TOKEN` to the chart-managed secret when `proxy.oidcClientRegistrationToken` is set as a string, enabling standalone deployments without an external secret
+- Require either `proxy.oidcClientRegistrationToken` or `proxy.oidcClientRegistrationTokenSecretName` to be set at install/upgrade time
+
 ## [1.2.10] - 2026-04-10
 
 ### Changed

--- a/charts/platform/charts/studios/Chart.yaml
+++ b/charts/platform/charts/studios/Chart.yaml
@@ -21,7 +21,7 @@ name: studios
 description: Studios is a unified platform for interactive analysis
 sources:
   - https://github.com/seqeralabs/helm-charts/tree/main/seqera/charts/studios
-version: 1.2.10
+version: 1.2.11
 appVersion: "0.11.0"
 maintainers:
   - name: Seqera Labs

--- a/charts/platform/charts/studios/README.md
+++ b/charts/platform/charts/studios/README.md
@@ -17,8 +17,7 @@ https://docs.seqera.io/platform-enterprise/enterprise/configuration/pipeline_opt
 The chart does not automatically define `cr.seqera.io` as the registry where to take the images from: instructions are available to [vendor the Seqera container images to your private registry](https://docs.seqera.io/platform-enterprise/enterprise/prerequisites/common#vendoring-seqera-container-images-to-your-own-registry).
 
 The required values to set in order to have a working installation are:
-- oidc token (auto set if not)
-
+- The OIDC client registration token under `.proxy.oidcClientRegistrationToken` (or reference an existing Secret with `.proxy.oidcClientRegistrationTokenSecretName`). When deploying as part of the platform parent chart this is set automatically; when deploying standalone it must match the value configured in the platform backend.
 - The `.image` and the `.dbMigrationInitContainer.image` sections to point to your container registry.
 - Container registry credentials under the `.global.imageCredentials` section (can be the credentials for cr.seqera.io or your private registry where you vendored the images to).
   * These credentials will be used by all the subcharts unless overridden in the specific subchart.

--- a/charts/platform/charts/studios/README.md
+++ b/charts/platform/charts/studios/README.md
@@ -2,7 +2,7 @@
 
 Studios is a unified platform for interactive analysis
 
-![Version: 1.2.10](https://img.shields.io/badge/Version-1.2.10-informational?style=flat-square) ![AppVersion: 0.11.0](https://img.shields.io/badge/AppVersion-0.11.0-informational?style=flat-square)
+![Version: 1.2.11](https://img.shields.io/badge/Version-1.2.11-informational?style=flat-square) ![AppVersion: 0.11.0](https://img.shields.io/badge/AppVersion-0.11.0-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -41,7 +41,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/studios \
-  --version 1.2.10 \
+  --version 1.2.11 \
   --namespace my-namespace \
   --create-namespace
 ```
@@ -92,7 +92,7 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | proxy.image.pullSecrets | list | `[]` | List of imagePullSecrets Secrets must be created in the same namespace, for example using the .extraDeploy array Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ |
 | proxy.oidcClientRegistrationToken | string | `""` | Initial access token to share with Seqera Platform to restrict registration requests to only authorized OIDC clients. The token can be provided as a string of random chars or as an external k8s Secret: in the latter case, a key can also be provided. If neither a string nor a Secret is provided, the chart will generate a random token WARNING: Always explicitly set this value or use an existing secret when using Kustomize. Auto-generated random values are incompatible with Kustomize. When upgrading releases via Kustomize, Helm cannot query the cluster to check if a secret already exists, causing it to regenerate a new random value on each upgrade |
 | proxy.oidcClientRegistrationTokenSecretName | string | `""` | Name of an existing Secret containing the OIDC client registration token as an alternative to the oidcClientRegistrationToken field. Note: the Secret must already exist in the same namespace at the time of deployment |
-| proxy.oidcClientRegistrationTokenSecretKey | string | `"OIDC_CLIENT_REGISTRATION_TOKEN"` | Key in the existing Secret containing the OIDC client registration token |
+| proxy.oidcClientRegistrationTokenSecretKey | string | `"CONNECT_OIDC_CLIENT_REGISTRATION_TOKEN"` | Key in the existing Secret containing the OIDC client registration token |
 | proxy.localCacheTTL | string | `"2m"` | TTL for local cache of Redis keys used for resiliency against Redis failures |
 | proxy.service.type | string | `"ClusterIP"` | Proxy Service type. Note: ingresses using AWS ALB require the service to be NodePort |
 | proxy.service.http.name | string | `"http"` | Service name to use |

--- a/charts/platform/charts/studios/README.md.gotmpl
+++ b/charts/platform/charts/studios/README.md.gotmpl
@@ -16,9 +16,7 @@ https://docs.seqera.io/platform-enterprise/enterprise/configuration/pipeline_opt
 The chart does not automatically define `cr.seqera.io` as the registry where to take the images from: instructions are available to [vendor the Seqera container images to your private registry](https://docs.seqera.io/platform-enterprise/enterprise/prerequisites/common#vendoring-seqera-container-images-to-your-own-registry).
 
 The required values to set in order to have a working installation are:
-- oidc token (auto set if not)
-
-
+- The OIDC client registration token under `.proxy.oidcClientRegistrationToken` (or reference an existing Secret with `.proxy.oidcClientRegistrationTokenSecretName`). When deploying as part of the platform parent chart this is set automatically; when deploying standalone it must match the value configured in the platform backend.
 - The `.image` and the `.dbMigrationInitContainer.image` sections to point to your container registry.
 - Container registry credentials under the `.global.imageCredentials` section (can be the credentials for cr.seqera.io or your private registry where you vendored the images to).
   * These credentials will be used by all the subcharts unless overridden in the specific subchart.

--- a/charts/platform/charts/studios/templates/NOTES.txt
+++ b/charts/platform/charts/studios/templates/NOTES.txt
@@ -42,6 +42,10 @@ It contains validations that are run at install/upgrade time.
 {{- fail "Either define an OIDC token in .Values.proxy.oidcClientRegistrationToken or via a secret in .Values.proxy.oidcClientRegistrationTokenSecretName, but not both." -}}
 {{- end -}}
 
+{{- if not (or .Values.proxy.oidcClientRegistrationToken .Values.proxy.oidcClientRegistrationTokenSecretName) -}}
+{{- fail "An OIDC client registration token must be provided: set 'proxy.oidcClientRegistrationToken' or point to an existing secret via 'proxy.oidcClientRegistrationTokenSecretName'." -}}
+{{- end -}}
+
 {{- if not .Values.global.platformServiceAddress -}}
 {{- fail "global.platformServiceAddress must be defined." -}}
 {{- end -}}

--- a/charts/platform/charts/studios/templates/_helpers.tpl
+++ b/charts/platform/charts/studios/templates/_helpers.tpl
@@ -101,6 +101,6 @@ key: {{ include "studios.oidcToken.secretKey" $studiosContext }}
   {{- if (include "studios.oidcToken.existingSecret" .) -}}
     {{- printf "%s" (tpl .Values.proxy.oidcClientRegistrationTokenSecretKey .) | default "OIDC_CLIENT_REGISTRATION_TOKEN" -}}
   {{- else -}}
-    {{- printf "OIDC_CLIENT_REGISTRATION_TOKEN" -}}
+    {{- printf "CONNECT_OIDC_CLIENT_REGISTRATION_TOKEN" -}}
   {{- end -}}
 {{- end -}}

--- a/charts/platform/charts/studios/templates/secret.yaml
+++ b/charts/platform/charts/studios/templates/secret.yaml
@@ -31,6 +31,9 @@ metadata:
   labels: {{- $labels | nindent 4 }}
   annotations: {{- $annotations | nindent 4 }}
 data:
+{{- if not (include "studios.oidcToken.existingSecret" .) }}
+  CONNECT_OIDC_CLIENT_REGISTRATION_TOKEN: {{ include "common.secrets.passwords.manage" (dict "secret" (include "studios.oidcToken.secretName" .) "key" (include "studios.oidcToken.secretKey" .) "providedValues" (list "proxy.oidcClientRegistrationToken") "failOnNew" false "length" 32 "context" $ "honorProvidedValues" true) }}
+{{- end }}
 {{- if (tpl .Values.redis.password $) }}
   CONNECT_REDIS_PASSWORD: {{ include "common.secrets.passwords.manage" (dict "secret" (include "studios.redis.secretName" .) "key" "redis-password" "providedValues" (list "redis.password") "context" $) }}
 {{- end }}

--- a/charts/platform/charts/studios/tests/NOTES_test.yaml
+++ b/charts/platform/charts/studios/tests/NOTES_test.yaml
@@ -25,6 +25,9 @@ tests:
     set:
       redis:
         host: ""
+      proxy:
+        oidcClientRegistrationToken: "asdf"
+        oidcClientRegistrationTokenSecretName: ""
       global:
         redis:
           host: ""
@@ -66,6 +69,23 @@ tests:
     asserts:
       - failedTemplate:
           errorPattern: .*Either define an OIDC token in .Values.proxy.oidcClientRegistrationToken or via a secret in .Values.proxy.oidcClientRegistrationTokenSecretName, but not both.*
+
+  - it: should fail when neither oidcClientRegistrationToken nor oidcClientRegistrationTokenSecretName are set
+    set:
+      redis:
+        host: "redis.example.com"
+      proxy:
+        oidcClientRegistrationToken: ""
+        oidcClientRegistrationTokenSecretName: ""
+      global:
+        platformServiceAddress: "platform.example.com"
+        platformServicePort: 8080
+        platformExternalDomain: "platform.example.com"
+        studiosDomain: '{{ printf "studios.%s" (tpl .Values.global.platformExternalDomain $) }}'
+        studiosConnectionUrl: '{{ printf "https://connect.%s" (tpl .Values.global.studiosDomain $) }}'
+    asserts:
+      - failedTemplate:
+          errorPattern: "An OIDC client registration token must be provided"
 
   - it: should pass when oidcClientRegistrationToken is defined and oidcClientRegistrationTokenSecretName is not
     set:

--- a/charts/platform/charts/studios/tests/__snapshot__/deployment-proxy_test.yaml.snap
+++ b/charts/platform/charts/studios/tests/__snapshot__/deployment-proxy_test.yaml.snap
@@ -9,7 +9,7 @@ should run using config requested by the user:
     template:
       metadata:
         annotations:
-          checksum/secret: b80b1bc08c14341170ea8cd5f96a038d7c2e9fd40f00761cd9c165f9dbe90249
+          checksum/secret: d97a4cdb87cade4c5248eae7c307e7c19445bb1d2c0137fc932ffd8951a14f94
         labels:
           app.kubernetes.io/component: proxy
           app.kubernetes.io/instance: RELEASE-NAME
@@ -28,8 +28,8 @@ should run using config requested by the user:
               - name: CONNECT_OIDC_CLIENT_REGISTRATION_TOKEN
                 valueFrom:
                   secretKeyRef:
-                    key: OIDC_CLIENT_REGISTRATION_TOKEN
-                    name: RELEASE-NAME-platform-backend
+                    key: CONNECT_OIDC_CLIENT_REGISTRATION_TOKEN
+                    name: release-name-studios
               - name: MY_SPECIAL_ENVIRONMENT_VARIABLE
                 value: set-a-value-here
             envFrom:
@@ -132,7 +132,7 @@ should set the proxy deployment image using the chart version and use sane defau
       template:
         metadata:
           annotations:
-            checksum/secret: b80b1bc08c14341170ea8cd5f96a038d7c2e9fd40f00761cd9c165f9dbe90249
+            checksum/secret: d97a4cdb87cade4c5248eae7c307e7c19445bb1d2c0137fc932ffd8951a14f94
           labels:
             app.kubernetes.io/component: proxy
             app.kubernetes.io/instance: RELEASE-NAME
@@ -146,8 +146,8 @@ should set the proxy deployment image using the chart version and use sane defau
                 - name: CONNECT_OIDC_CLIENT_REGISTRATION_TOKEN
                   valueFrom:
                     secretKeyRef:
-                      key: OIDC_CLIENT_REGISTRATION_TOKEN
-                      name: RELEASE-NAME-platform-backend
+                      key: CONNECT_OIDC_CLIENT_REGISTRATION_TOKEN
+                      name: release-name-studios
               envFrom:
                 - configMapRef:
                     name: release-name-studios-common

--- a/charts/platform/charts/studios/tests/__snapshot__/secret_test.yaml.snap
+++ b/charts/platform/charts/studios/tests/__snapshot__/secret_test.yaml.snap
@@ -2,6 +2,7 @@ should render complete secret with all features enabled:
   1: |
     apiVersion: v1
     data:
+      CONNECT_OIDC_CLIENT_REGISTRATION_TOKEN: bXktcmVnaXN0cmF0aW9uLXRva2Vu
       CONNECT_REDIS_PASSWORD: dGVzdC1yZWRpcy1wYXNzd29yZA==
     kind: Secret
     metadata:

--- a/charts/platform/charts/studios/tests/__snapshot__/statefulset-server_test.yaml.snap
+++ b/charts/platform/charts/studios/tests/__snapshot__/statefulset-server_test.yaml.snap
@@ -10,7 +10,7 @@ should run using config requested by the user:
     template:
       metadata:
         annotations:
-          checksum/secret: a72c589f456990485afcc28aea1909ef411996ad3412d8ec207423a9923c9b4c
+          checksum/secret: e573d2931dab1490d7eb5277f2a139fa0524f40786627826519ffee588abbde7
         labels:
           app.kubernetes.io/component: server
           app.kubernetes.io/instance: RELEASE-NAME
@@ -88,7 +88,7 @@ should set the statefulset server image using the chart version and use sane def
       template:
         metadata:
           annotations:
-            checksum/secret: a72c589f456990485afcc28aea1909ef411996ad3412d8ec207423a9923c9b4c
+            checksum/secret: e573d2931dab1490d7eb5277f2a139fa0524f40786627826519ffee588abbde7
           labels:
             app.kubernetes.io/component: server
             app.kubernetes.io/instance: RELEASE-NAME

--- a/charts/platform/charts/studios/tests/_helpers_test.yaml
+++ b/charts/platform/charts/studios/tests/_helpers_test.yaml
@@ -214,16 +214,17 @@ tests:
           value: "RELEASE-NAME-oidc"
 
   # studios.oidcToken.secretKey helper tests
-  - it: should use default secret key OIDC_CLIENT_REGISTRATION_TOKEN when existingSecretKey is not set
+  - it: should use default secret key CONNECT_OIDC_CLIENT_REGISTRATION_TOKEN when existingSecretKey is not set
     template: deployment-proxy.yaml
     set:
       proxy:
         oidcClientRegistrationToken: "test-token"
+        oidcClientRegistrationTokenSecretName: ""
         oidcClientRegistrationTokenSecretKey: ""
     asserts:
       - equal:
           path: spec.template.spec.containers[0].env[0].valueFrom.secretKeyRef.key
-          value: "OIDC_CLIENT_REGISTRATION_TOKEN"
+          value: "CONNECT_OIDC_CLIENT_REGISTRATION_TOKEN"
 
   - it: should use custom secret key when oidcClientRegistrationTokenSecretKey is provided with external secret
     template: deployment-proxy.yaml
@@ -260,7 +261,7 @@ tests:
           path: spec.template.spec.containers[0].env[0].valueFrom.secretKeyRef.name
           value: "RELEASE-NAME-studios-oidc"
 
-  - it: should always use OIDC_CLIENT_REGISTRATION_TOKEN key when using chart-managed secret even if secretKey is customized
+  - it: should always use CONNECT_OIDC_CLIENT_REGISTRATION_TOKEN key when using chart-managed secret even if secretKey is customized
     template: deployment-proxy.yaml
     set:
       proxy:
@@ -270,7 +271,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].env[0].valueFrom.secretKeyRef.key
-          value: "OIDC_CLIENT_REGISTRATION_TOKEN"
+          value: "CONNECT_OIDC_CLIENT_REGISTRATION_TOKEN"
 
   - it: should use custom secret key with tpl evaluation when using external secret
     template: deployment-proxy.yaml
@@ -301,8 +302,9 @@ tests:
     set:
       proxy:
         oidcClientRegistrationToken: "test-token"
+        oidcClientRegistrationTokenSecretName: ""
         oidcClientRegistrationTokenSecretKey: ""
     asserts:
       - equal:
           path: spec.template.spec.containers[0].env[0].valueFrom.secretKeyRef.key
-          value: "OIDC_CLIENT_REGISTRATION_TOKEN"
+          value: "CONNECT_OIDC_CLIENT_REGISTRATION_TOKEN"

--- a/charts/platform/charts/studios/tests/deployment-proxy_test.yaml
+++ b/charts/platform/charts/studios/tests/deployment-proxy_test.yaml
@@ -36,6 +36,7 @@ tests:
       platformServicePort: 8080
     proxy:
       oidcClientRegistrationToken: my-oidc-token
+      oidcClientRegistrationTokenSecretName: ""
   asserts:
   - isKind:
       of: Deployment
@@ -71,6 +72,7 @@ tests:
   set:
     proxy:
       oidcClientRegistrationToken: asdf
+      oidcClientRegistrationTokenSecretName: ""
       podLabels:
         key123: this-overrides-the-commonLabels
     redis:
@@ -82,7 +84,7 @@ tests:
   - equal:
       path: spec.template.metadata.annotations
       value:
-        checksum/secret: cf2e486d918e7aa4728f9c3db088ffd3b7072ecb519195791af6316520aa98b9
+        checksum/secret: 64912ff6a61ee0025ad6e20f4ffca6e51f030509e1ab24c779557491cc74b8a6
   - equal:
       path: spec.template.metadata.labels
       value:
@@ -105,6 +107,7 @@ tests:
       platformServicePort: 8080
     proxy:
       oidcClientRegistrationToken: my-oidc-token
+      oidcClientRegistrationTokenSecretName: ""
       image:
         pullPolicy: Always
         pullSecrets:

--- a/charts/platform/charts/studios/tests/secret_test.yaml
+++ b/charts/platform/charts/studios/tests/secret_test.yaml
@@ -21,7 +21,11 @@ suite: test Studios secrets
 templates:
   - secret.yaml
 tests:
-  - it: should create secret without OIDC token (token moved to platform backend secret) by default
+  - it: should create secret with OIDC token when no existing secret is set
+    set:
+      proxy:
+        oidcClientRegistrationToken: "my-registration-token"
+        oidcClientRegistrationTokenSecretName: ""
     asserts:
       - hasDocuments:
           count: 1
@@ -30,8 +34,27 @@ tests:
       - equal:
           path: metadata.name
           value: release-name-studios
+      - exists:
+          path: data.CONNECT_OIDC_CLIENT_REGISTRATION_TOKEN
+
+  - it: should not include OIDC token when existing secret is set
+    set:
+      proxy:
+        oidcClientRegistrationTokenSecretName: "my-platform-backend"
+    asserts:
       - notExists:
-          path: data.OIDC_CLIENT_REGISTRATION_TOKEN
+          path: data.CONNECT_OIDC_CLIENT_REGISTRATION_TOKEN
+
+  - it: should include OIDC token with provided value when oidcClientRegistrationToken is set
+    set:
+      proxy:
+        oidcClientRegistrationToken: "my-registration-token"
+        oidcClientRegistrationTokenSecretName: ""
+    asserts:
+      - equal:
+          path: data.CONNECT_OIDC_CLIENT_REGISTRATION_TOKEN
+          value: "my-registration-token"
+          decodeBase64: true
 
   - it: should set the correct env var for the redis password
     set:
@@ -48,22 +71,26 @@ tests:
       redis:
         password: ""
         existingSecretName: ""
+      proxy:
+        oidcClientRegistrationTokenSecretName: ""
     asserts:
       - notExists:
           path: data["CONNECT_REDIS_PASSWORD"]
-      - notExists:
-          path: data["OIDC_CLIENT_REGISTRATION_TOKEN"]
+      - exists:
+          path: data["CONNECT_OIDC_CLIENT_REGISTRATION_TOKEN"]
 
   - it: should not include CONNECT_REDIS_PASSWORD when using existing secret
     set:
       redis:
         existingSecretName: "my-redis-secret"
         existingSecretKey: "REDIS_PASSWORD"
+      proxy:
+        oidcClientRegistrationTokenSecretName: ""
     asserts:
       - notExists:
           path: data["CONNECT_REDIS_PASSWORD"]
-      - notExists:
-          path: data["OIDC_CLIENT_REGISTRATION_TOKEN"]
+      - exists:
+          path: data["CONNECT_OIDC_CLIENT_REGISTRATION_TOKEN"]
 
   - it: should create imagepullsecret if requested by the user
     set:
@@ -328,12 +355,14 @@ tests:
       - isKind:
           of: Secret
 
-  - it: should not create any secret data when redis uses an existing secret
+  - it: should not create any secret data when redis uses an existing secret and OIDC uses an existing secret
     set:
       redis:
         password: ""
         existingSecretName: "unittest-redis"
         existingSecretKey: "REDIS_PASSWORD"
+      proxy:
+        oidcClientRegistrationTokenSecretName: "my-platform-backend"
     asserts:
       - equal:
           path: data
@@ -346,6 +375,9 @@ tests:
     set:
       redis:
         password: "test-redis-password"
+      proxy:
+        oidcClientRegistrationToken: "my-registration-token"
+        oidcClientRegistrationTokenSecretName: ""
       secretLabels:
         custom-label: "custom-value"
       secretAnnotations:
@@ -357,8 +389,10 @@ tests:
     asserts:
       - hasDocuments:
           count: 1
-      - notExists:
-          path: data.OIDC_CLIENT_REGISTRATION_TOKEN
+      - equal:
+          path: data.CONNECT_OIDC_CLIENT_REGISTRATION_TOKEN
+          value: "my-registration-token"
+          decodeBase64: true
       - equal:
           path: data.CONNECT_REDIS_PASSWORD
           value: "test-redis-password"
@@ -462,8 +496,10 @@ tests:
         password: ""
         existingSecretName: "my-redis-secret"
         existingSecretKey: "REDIS_PASS"
+      proxy:
+        oidcClientRegistrationTokenSecretName: ""
     asserts:
       - notExists:
           path: data.CONNECT_REDIS_PASSWORD
-      - notExists:
-          path: data.OIDC_CLIENT_REGISTRATION_TOKEN
+      - exists:
+          path: data.CONNECT_OIDC_CLIENT_REGISTRATION_TOKEN

--- a/charts/platform/charts/studios/tests/statefulset-server_test.yaml
+++ b/charts/platform/charts/studios/tests/statefulset-server_test.yaml
@@ -33,6 +33,7 @@ tests:
   set:
     proxy:
       oidcClientRegistrationToken: my-oidc-token
+      oidcClientRegistrationTokenSecretName: ""
   asserts:
   - isKind:
       of: StatefulSet
@@ -68,6 +69,7 @@ tests:
   set:
     proxy:
       oidcClientRegistrationToken: asdf
+      oidcClientRegistrationTokenSecretName: ""
     server:
       podLabels:
         key123: this-overrides-the-commonLabels
@@ -80,7 +82,7 @@ tests:
   - equal:
       path: spec.template.metadata.annotations
       value:
-        checksum/secret: a41b091d75333e0876e6c90366fb95b69620d3ccf3e0ad646ae0d263df246c10
+        checksum/secret: 21967464b5aad616961092d9e460c5f5a498acabe29129cb58441fd15ed70816
   - equal:
       path: spec.template.metadata.labels
       value:
@@ -100,6 +102,7 @@ tests:
   set:
     proxy:
       oidcClientRegistrationToken: my-oidc-token
+      oidcClientRegistrationTokenSecretName: ""
     server:
       image:
         pullPolicy: Always

--- a/charts/platform/charts/studios/values.yaml
+++ b/charts/platform/charts/studios/values.yaml
@@ -115,7 +115,7 @@ proxy:
   # in the same namespace at the time of deployment
   oidcClientRegistrationTokenSecretName: ""
   # -- Key in the existing Secret containing the OIDC client registration token
-  # @default -- `"OIDC_CLIENT_REGISTRATION_TOKEN"`
+  # @default -- `"CONNECT_OIDC_CLIENT_REGISTRATION_TOKEN"`
   oidcClientRegistrationTokenSecretKey: ""
 
   # -- TTL for local cache of Redis keys used for resiliency against Redis failures


### PR DESCRIPTION
Similarly to #119, Studios also needs to take the OIDC initial access token as input from the user; use the env var name used by Studios internally `CONNECT_OIDC_CLIENT_REGISTRATION_TOKEN` instead of the one used by platform `OIDC_CLIENT_REGISTRATION_TOKEN`.