### PR TITLE
fix: use same oauth initial token default env var in mcp and studios

### DIFF
--- a/charts/platform/CHANGELOG.md
+++ b/charts/platform/CHANGELOG.md
@@ -9,7 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Bump `mcp` subchart to 0.3.3 and `studios` subchart to 1.2.12 to fix default OIDC external secret key to match each chart's own managed secret key
+- Bump `mcp` subchart to 0.3.3 and `studios` subchart to 1.2.12 to fix default OIDC external secret
+  key to match each chart's own managed secret key
+
+### Changed
+
+- Add `TOWER_SEQERA_AI_PORTAL_URL` env variable to platform backend configmap
 
 ## [0.32.3] - 2026-04-28
 

--- a/charts/platform/CHANGELOG.md
+++ b/charts/platform/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.32.4] - 2026-04-29
+
+### Fixed
+
+- Bump `mcp` subchart to 0.3.3 and `studios` subchart to 1.2.12 to fix default OIDC external secret key to match each chart's own managed secret key
+
 ## [0.32.3] - 2026-04-28
 
 ### Changed

--- a/charts/platform/CHANGELOG.md
+++ b/charts/platform/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `mcp` subchart to 0.3.3 and `studios` subchart to 1.2.12 to fix default OIDC external secret
   key to match each chart's own managed secret key
+- Bump `agent-backend` to 0.4.8 to point `SEQERA_PLATFORM_API_URL` to the internal Platform backend
+  service instead of the external domain, and add `SEQERA_PLATFORM_URL` env var pointing to the external platform URL for use in links and callbacks from the agent backend
 
 ### Changed
 

--- a/charts/platform/Chart.lock
+++ b/charts/platform/Chart.lock
@@ -10,18 +10,18 @@ dependencies:
   version: 2.0.3
 - name: studios
   repository: file://charts/studios
-  version: 1.2.10
+  version: 1.2.12
 - name: wave
   repository: file://charts/wave
   version: 0.1.0
 - name: mcp
   repository: file://charts/mcp
-  version: 0.3.2
+  version: 0.3.3
 - name: agent-backend
   repository: file://charts/agent-backend
-  version: 0.4.6
+  version: 0.4.8
 - name: portal-web
   repository: file://charts/portal-web
   version: 0.2.5
-digest: sha256:4f555bd43be6fa9dac44b8cb65747b0b0c70a3ae96b870d9e8742784f06774f3
-generated: "2026-04-16T15:42:20.627375767+02:00"
+digest: sha256:9b117b6b54df6a1790510af3025dc5a06f8c2e2ee5071bb68b33abf4753511b7
+generated: "2026-04-29T17:00:51.036562924+02:00"

--- a/charts/platform/Chart.yaml
+++ b/charts/platform/Chart.yaml
@@ -37,7 +37,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.32.3
+version: 0.32.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/platform/README.md
+++ b/charts/platform/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart to deploy Seqera Platform (also referred to as Tower) on Kubernetes.
 
-![Version: 0.32.3](https://img.shields.io/badge/Version-0.32.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v25.3.4](https://img.shields.io/badge/AppVersion-v25.3.4-informational?style=flat-square)
+![Version: 0.32.4](https://img.shields.io/badge/Version-0.32.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v25.3.4](https://img.shields.io/badge/AppVersion-v25.3.4-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -41,7 +41,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/platform \
-  --version 0.32.3 \
+  --version 0.32.4 \
   --namespace my-namespace \
   --create-namespace
 ```

--- a/charts/platform/charts/agent-backend/CHANGELOG.md
+++ b/charts/platform/charts/agent-backend/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.8] - 2026-04-29
+
+### Changed
+
+- Point `SEQERA_PLATFORM_API_URL` to the internal Platform backend service (`platformServiceAddress`:`platformServicePort`) instead of the external domain
+
+### Added
+
+- Add `SEQERA_PLATFORM_URL` env var pointing to the external platform URL for use in links and callbacks from the agent backend
+- Add `global.platformServiceAddress` and `global.platformServicePort` values
+- Add `KNOWLEDGE_INDEXER_EMBEDDINGS_PROVIDER` env var set to `bedrock`
+- Add `nextflowDocs.useRedisIndex` value to control `NEXTFLOW_DOCS_USE_REDIS_INDEX` (defaults to `false`)
+- Add `bedrockAssumeRoleArn` value to optionally set `AWS_BEDROCK_SERVICES_DEFAULT_ASSUME_ROLE_ARN` for cross-account Bedrock access
+- Add `bedrockAnthropicModel` value to optionally override `BEDROCK_ANTHROPIC_MODEL`
+
 ## [0.4.7] - 2026-04-20
 
 ### Added

--- a/charts/platform/charts/agent-backend/Chart.yaml
+++ b/charts/platform/charts/agent-backend/Chart.yaml
@@ -19,7 +19,7 @@ apiVersion: v2
 name: agent-backend
 description: Backend service for Seqera CLI AI capabilities
 type: application
-version: 0.4.7
+version: 0.4.8
 appVersion: "2.0.0"
 maintainers:
   - name: Seqera Labs

--- a/charts/platform/charts/agent-backend/README.md
+++ b/charts/platform/charts/agent-backend/README.md
@@ -2,7 +2,7 @@
 
 Backend service for Seqera CLI AI capabilities
 
-![Version: 0.4.7](https://img.shields.io/badge/Version-0.4.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 0.4.8](https://img.shields.io/badge/Version-0.4.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -38,7 +38,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/agent-backend \
-  --version 0.4.7 \
+  --version 0.4.8 \
   --namespace my-namespace \
   --create-namespace
 ```
@@ -61,6 +61,8 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | global.platformExternalDomain | string | `"example.com"` | Domain where Seqera Platform listens |
+| global.platformServiceAddress | string | `"{{ printf \"%s-platform-backend\" .Release.Name | lower }}"` | Seqera Platform Service name: can be the internal Kubernetes hostname or an external ingress hostname. Evaluated as a template |
+| global.platformServicePort | int | `8080` | Seqera Platform Service port |
 | global.agentBackendDomain | string | `"{{ printf \"ai-api.%s\" .Values.global.platformExternalDomain }}"` | Domain where the Agent Backend service listens. Evaluated as a template |
 | global.mcpDomain | string | `"{{ printf \"mcp.%s\" .Values.global.platformExternalDomain }}"` | Domain where Seqera MCP listens. Evaluated as a template |
 | global.imageCredentials | list | `[]` | Optional credentials to log in and fetch images from a private registry. These credentials are shared with all the subcharts automatically |
@@ -83,9 +85,12 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | redis.existingSecretName | string | `""` | Name of an existing Secret containing the Redis password, as an alternative to the password field. Note: the Secret must already exist in the same namespace at the time of deployment |
 | redis.existingSecretKey | string | `"AGENT_BACKEND_REDIS_PASSWORD"` | Key in the existing Secret containing the Redis password |
 | bedrockAgentCoreArn | string | `""` | AWS Bedrock AgentCore runtime ARN for sandbox sessions |
+| bedrockAssumeRoleArn | string | `""` | Optional IAM role ARN that the Agent Backend assumes for cross-account Bedrock access. Leave empty to let the pod directly use the AWS credentials provided to it (single-account setup). |
+| bedrockAnthropicModel | string | `""` | Override the Anthropic model used on Bedrock by specifying an inference profile ARN. You can create a custom inference profile that uses the Anthropic model you want or use the default inference profile for the model provided by AWS. When doing cross-account access with `bedrockAssumeRoleArn`, you may want to specify an inference profile ARN on the account where the hop role is defined |
 | embeddings.bedrock.region | string | `""` | AWS region where the Bedrock model is hosted |
 | embeddings.bedrock.modelId | string | `"amazon.titan-embed-text-v2:0"` | Bedrock model ID used for embeddings |
 | embeddings.bedrock.dimensions | string | `"1024"` | Embedding vector dimensions expected from the configured Bedrock model |
+| nextflowDocs.useRedisIndex | bool | `false` | Use a Redis-backed vector index for the Nextflow documentation knowledge base. Disabled by default. |
 | anthropicApiKey | string | `""` | Anthropic API key. Define the value as a String or a Secret, not both at the same time |
 | anthropicApiKeyExistingSecretName | string | `""` | Name of an existing Secret containing the Anthropic API key. Note: the Secret must already exist in the same namespace at the time of deployment |
 | anthropicApiKeyExistingSecretKey | string | `"ANTHROPIC_API_KEY"` | Key in the existing Secret containing the Anthropic API key |

--- a/charts/platform/charts/agent-backend/templates/configmap.yaml
+++ b/charts/platform/charts/agent-backend/templates/configmap.yaml
@@ -32,7 +32,8 @@ metadata:
 data:
   AGENT_BACKEND_PORT: {{ .Values.service.http.targetPort | quote }}
 
-  SEQERA_PLATFORM_API_URL: {{ printf "https://%s/api" (tpl .Values.global.platformExternalDomain .)  | quote }}
+  SEQERA_PLATFORM_URL: {{ printf "https://%s" (tpl .Values.global.platformExternalDomain .) | quote }}
+  SEQERA_PLATFORM_API_URL: {{ printf "http://%s:%s" (tpl .Values.global.platformServiceAddress .) (toString .Values.global.platformServicePort) | quote }}
   SEQERA_MCP_URL: {{ printf "https://%s/mcp" (tpl .Values.global.mcpDomain .)  | quote }}
 
   AGENT_BACKEND_DB_HOST: {{ tpl .Values.database.host . | quote }}
@@ -53,8 +54,16 @@ data:
   AGENTCORE_AGENT_ARN: {{ tpl .Values.bedrockAgentCoreArn . | quote }}
 
   USE_BEDROCK_INFERENCE: "true"
+  KNOWLEDGE_INDEXER_EMBEDDINGS_PROVIDER: "bedrock"
   BEDROCK_REGION: {{ tpl (toString .Values.embeddings.bedrock.region) . | quote }}
   NEXTFLOW_DOCS_BEDROCK_MODEL_ID: {{ tpl (toString .Values.embeddings.bedrock.modelId) . | quote }}
   NEXTFLOW_DOCS_BEDROCK_DIMENSIONS: {{ include "seqera.tplvalues.render" (dict "value" .Values.embeddings.bedrock.dimensions "context" $) | quote }}
+  NEXTFLOW_DOCS_USE_REDIS_INDEX: {{ .Values.nextflowDocs.useRedisIndex | quote }}
+{{- if .Values.bedrockAssumeRoleArn }}
+  AWS_BEDROCK_SERVICES_DEFAULT_ASSUME_ROLE_ARN: {{ tpl .Values.bedrockAssumeRoleArn . | quote }}
+{{- end }}
+{{- if .Values.bedrockAnthropicModel }}
+  BEDROCK_ANTHROPIC_MODEL: {{ tpl .Values.bedrockAnthropicModel . | quote }}
+{{- end }}
 
   LOG_LEVEL: {{ .Values.logLevel | default "INFO" | quote }}

--- a/charts/platform/charts/agent-backend/tests/__snapshot__/configmap_test.yaml.snap
+++ b/charts/platform/charts/agent-backend/tests/__snapshot__/configmap_test.yaml.snap
@@ -15,11 +15,14 @@ should render a ConfigMap with default values:
       AGENT_BACKEND_REDIS_TLS: "false"
       AGENTCORE_AGENT_ARN: ""
       BEDROCK_REGION: ""
+      KNOWLEDGE_INDEXER_EMBEDDINGS_PROVIDER: bedrock
       LOG_LEVEL: INFO
       NEXTFLOW_DOCS_BEDROCK_DIMENSIONS: "1024"
       NEXTFLOW_DOCS_BEDROCK_MODEL_ID: amazon.titan-embed-text-v2:0
+      NEXTFLOW_DOCS_USE_REDIS_INDEX: "false"
       SEQERA_MCP_URL: https://mcp.test.example.com/mcp
-      SEQERA_PLATFORM_API_URL: https://test.example.com/api
+      SEQERA_PLATFORM_API_URL: http://release-name-platform-backend:8080
+      SEQERA_PLATFORM_URL: https://test.example.com
       USE_BEDROCK_INFERENCE: "true"
     kind: ConfigMap
     metadata:

--- a/charts/platform/charts/agent-backend/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/platform/charts/agent-backend/tests/__snapshot__/deployment_test.yaml.snap
@@ -21,7 +21,7 @@ should render a Deployment with default values:
       template:
         metadata:
           annotations:
-            checksum/configmap: 13775ee23bf8fb7bc5e8eb7cbf1e4ac2c8cf97c39c74ce78c18129f17985abd1
+            checksum/configmap: f133dfcb4869e3b4a713c59b09af19365251f62b2d24f49dc81a5c928bbc0fb2
             checksum/secret: ac4ca92760ab83180bef6b3504a9f7b2663f3c2972a4b7e57a8e3173c6092172
           labels:
             app.kubernetes.io/component: agent-backend

--- a/charts/platform/charts/agent-backend/tests/configmap_test.yaml
+++ b/charts/platform/charts/agent-backend/tests/configmap_test.yaml
@@ -58,7 +58,35 @@ tests:
           path: data.AGENT_BACKEND_DB_USER
           value: agentuser
 
-  - it: should contain platform URLs
+  - it: should set SEQERA_PLATFORM_API_URL from platformServiceAddress and platformServicePort
+    set:
+      global.platformExternalDomain: prod.example.com
+      global.platformServiceAddress: my-platform-backend
+      global.platformServicePort: 9090
+      global.mcpDomain: mcp.prod.example.com
+      database.host: mysql
+      database.name: db
+      database.username: user
+    asserts:
+      - equal:
+          path: data.SEQERA_PLATFORM_API_URL
+          value: "http://my-platform-backend:9090"
+
+  - it: should template platformServiceAddress in SEQERA_PLATFORM_API_URL
+    set:
+      global.platformExternalDomain: prod.example.com
+      global.platformServiceAddress: '{{ printf "%s-platform-backend" .Release.Name | lower }}'
+      global.platformServicePort: 8080
+      global.mcpDomain: mcp.prod.example.com
+      database.host: mysql
+      database.name: db
+      database.username: user
+    asserts:
+      - equal:
+          path: data.SEQERA_PLATFORM_API_URL
+          value: "http://release-name-platform-backend:8080"
+
+  - it: should set SEQERA_PLATFORM_URL from platformExternalDomain
     set:
       global.platformExternalDomain: prod.example.com
       global.mcpDomain: mcp.prod.example.com
@@ -67,8 +95,8 @@ tests:
       database.username: user
     asserts:
       - equal:
-          path: data.SEQERA_PLATFORM_API_URL
-          value: "https://prod.example.com/api"
+          path: data.SEQERA_PLATFORM_URL
+          value: "https://prod.example.com"
       - equal:
           path: data.SEQERA_MCP_URL
           value: "https://mcp.prod.example.com/mcp"
@@ -110,6 +138,18 @@ tests:
       - equal:
           path: data.LOG_LEVEL
           value: DEBUG
+
+  - it: should set KNOWLEDGE_INDEXER_EMBEDDINGS_PROVIDER to bedrock
+    set:
+      global.platformExternalDomain: test.example.com
+      global.mcpDomain: mcp.test.example.com
+      database.host: mysql
+      database.name: db
+      database.username: user
+    asserts:
+      - equal:
+          path: data.KNOWLEDGE_INDEXER_EMBEDDINGS_PROVIDER
+          value: "bedrock"
 
   - it: should always enable Bedrock inference
     set:
@@ -265,6 +305,79 @@ tests:
       - equal:
           path: data.AGENT_BACKEND_REDIS_TLS
           value: "true"
+
+  - it: should set NEXTFLOW_DOCS_USE_REDIS_INDEX to false by default
+    set:
+      global.platformExternalDomain: test.example.com
+      global.mcpDomain: mcp.test.example.com
+      database.host: mysql
+      database.name: db
+      database.username: user
+    asserts:
+      - equal:
+          path: data.NEXTFLOW_DOCS_USE_REDIS_INDEX
+          value: "false"
+
+  - it: should set NEXTFLOW_DOCS_USE_REDIS_INDEX when enabled
+    set:
+      global.platformExternalDomain: test.example.com
+      global.mcpDomain: mcp.test.example.com
+      database.host: mysql
+      database.name: db
+      database.username: user
+      nextflowDocs.useRedisIndex: true
+    asserts:
+      - equal:
+          path: data.NEXTFLOW_DOCS_USE_REDIS_INDEX
+          value: "true"
+
+  - it: should not set AWS_BEDROCK_SERVICES_DEFAULT_ASSUME_ROLE_ARN by default
+    set:
+      global.platformExternalDomain: test.example.com
+      global.mcpDomain: mcp.test.example.com
+      database.host: mysql
+      database.name: db
+      database.username: user
+    asserts:
+      - notExists:
+          path: data.AWS_BEDROCK_SERVICES_DEFAULT_ASSUME_ROLE_ARN
+
+  - it: should set AWS_BEDROCK_SERVICES_DEFAULT_ASSUME_ROLE_ARN when provided
+    set:
+      global.platformExternalDomain: test.example.com
+      global.mcpDomain: mcp.test.example.com
+      database.host: mysql
+      database.name: db
+      database.username: user
+      bedrockAssumeRoleArn: arn:aws:iam::123456789012:role/bedrock-cross-account
+    asserts:
+      - equal:
+          path: data.AWS_BEDROCK_SERVICES_DEFAULT_ASSUME_ROLE_ARN
+          value: arn:aws:iam::123456789012:role/bedrock-cross-account
+
+  - it: should not set BEDROCK_ANTHROPIC_MODEL by default
+    set:
+      global.platformExternalDomain: test.example.com
+      global.mcpDomain: mcp.test.example.com
+      database.host: mysql
+      database.name: db
+      database.username: user
+    asserts:
+      - notExists:
+          path: data.BEDROCK_ANTHROPIC_MODEL
+
+  - it: should set BEDROCK_ANTHROPIC_MODEL when provided
+    set:
+      global.platformExternalDomain: test.example.com
+      global.mcpDomain: mcp.test.example.com
+      database.host: mysql
+      database.name: db
+      database.username: user
+      bedrockAnthropicModel: anthropic.claude-sonnet-4-6
+    asserts:
+      - equal:
+          path: data.BEDROCK_ANTHROPIC_MODEL
+          value: anthropic.claude-sonnet-4-6
 
   - it: should include AgentCore runtime ARN when provided
     set:

--- a/charts/platform/charts/agent-backend/values.yaml
+++ b/charts/platform/charts/agent-backend/values.yaml
@@ -21,6 +21,12 @@ global:
   # -- Domain where Seqera Platform listens
   platformExternalDomain: example.com
 
+  # -- Seqera Platform Service name: can be the internal Kubernetes hostname or an external ingress
+  # hostname. Evaluated as a template
+  platformServiceAddress: '{{ printf "%s-platform-backend" .Release.Name | lower }}'
+  # -- Seqera Platform Service port
+  platformServicePort: 8080
+
   # -- Domain where the Agent Backend service listens. Evaluated as a template
   agentBackendDomain: '{{ printf "ai-api.%s" .Values.global.platformExternalDomain }}'
 
@@ -94,6 +100,17 @@ redis:
 # -- AWS Bedrock AgentCore runtime ARN for sandbox sessions
 bedrockAgentCoreArn: ""
 
+# -- Optional IAM role ARN that the Agent Backend assumes for cross-account Bedrock access.
+# Leave empty to let the pod directly use the AWS credentials provided to it (single-account setup).
+bedrockAssumeRoleArn: ""
+
+# -- Override the Anthropic model used on Bedrock by specifying an inference profile ARN. You can
+# create a custom inference profile that uses the Anthropic model you want or use the default
+# inference profile for the model provided by AWS. When doing cross-account access with
+# `bedrockAssumeRoleArn`, you may want to specify an inference profile ARN on the account where the
+# hop role is defined
+bedrockAnthropicModel: ""
+
 embeddings:
   bedrock:
     # -- AWS region where the Bedrock model is hosted
@@ -102,6 +119,11 @@ embeddings:
     modelId: "amazon.titan-embed-text-v2:0"
     # -- Embedding vector dimensions expected from the configured Bedrock model
     dimensions: "1024"
+
+nextflowDocs:
+  # -- Use a Redis-backed vector index for the Nextflow documentation knowledge base.
+  # Disabled by default.
+  useRedisIndex: false
 
 # -- Anthropic API key. Define the value as a String or a Secret, not both at the same time
 anthropicApiKey: ""

--- a/charts/platform/charts/mcp/CHANGELOG.md
+++ b/charts/platform/charts/mcp/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.3] - 2026-04-29
+
+### Fixed
+
+- Fixed default key for external OIDC secret to use `MCP_OAUTH_INITIAL_ACCESS_TOKEN`, consistent with the key used in the chart-managed secret
+
 ## [0.3.2] - 2026-04-28
 
 ### Fixed

--- a/charts/platform/charts/mcp/Chart.yaml
+++ b/charts/platform/charts/mcp/Chart.yaml
@@ -22,7 +22,7 @@ description: |
   Wave container provisioning, bioinformatics data, and nf-core modules through intelligent
   RAG-based natural language interactions.
 type: application
-version: 0.3.2
+version: 0.3.3
 appVersion: "1.1.0"
 maintainers:
   - name: Seqera Labs

--- a/charts/platform/charts/mcp/README.md
+++ b/charts/platform/charts/mcp/README.md
@@ -4,7 +4,7 @@ A Model Context Protocol (MCP) server that provides comprehensive access to the 
 Wave container provisioning, bioinformatics data, and nf-core modules through intelligent
 RAG-based natural language interactions.
 
-![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
+![Version: 0.3.3](https://img.shields.io/badge/Version-0.3.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -37,7 +37,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/mcp \
-  --version 0.3.2 \
+  --version 0.3.3 \
   --namespace my-namespace \
   --create-namespace
 ```
@@ -71,7 +71,7 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | registryApiEndpoint | string | `"https://registry.nextflow.io"` | API endpoint of Seqera Nextflow Registry. |
 | oidcToken.tokenString | string | `""` | OIDC client registration token as a string. Used to dynamically register an OAuth client with Seqera Platform's OIDC provider. If neither this nor existingSecretName is set, a random value is generated. When deployed via the platform parent chart, this is automatically defined with the value of the OIDC client registration token from the platform backend secret, so it should not be set in that case. When deploying independently of the platform parent chart, this must be set to the same value defined in the platform backend secret. WARNING: Always explicitly set this value or use an existing secret when using Kustomize. Auto-generated random values are incompatible with Kustomize. When upgrading releases via Kustomize, Helm cannot query the cluster to check if a secret already exists, causing it to regenerate a new random value on each upgrade, which will break authentication |
 | oidcToken.existingSecretName | string | `""` | Name of an existing Secret containing the OIDC client registration token, as an alternative to the string field. Note: the Secret must already exist in the same namespace at the time of deployment. |
-| oidcToken.existingSecretKey | string | `"OIDC_CLIENT_REGISTRATION_TOKEN"` | Key in the existing Secret containing the OIDC client registration token. |
+| oidcToken.existingSecretKey | string | `"MCP_OAUTH_INITIAL_ACCESS_TOKEN"` | Key in the existing Secret containing the OIDC client registration token. |
 | oauth.issuerUrl | string | `""` | OAuth provider URL used by MCP to authenticate and obtain tokens. Defaults to the Platform API endpoint when 'oauth-platform' is configured in `.micronautEnvironments` (default behavior). Must be set explicitly when 'oauth' is configured in `.micronautEnvironments`. |
 | oauth.audience | string | `"platform"` | OAuth audience for MCP to authenticate with. This is the expected audience claim in the tokens issued by the OAuth provider. When using Seqera Platform as the OAuth provider, this should be set to "platform" to match the audience of the internal client that Platform creates for MCP. When using a custom OAuth provider, this should match the audience configured for the client that MCP uses to authenticate with that provider |
 | oauth.jwtSeedString | string | `""` | JWT seed, defined as string, used to sign authentication tokens. Define the value as a String or a Secret, not both at the same time. If neither is defined, Helm generates a random 35-character string. WARNING: Always explicitly set this value or use an existing secret when using Kustomize. Auto-generated random values are incompatible with Kustomize. When upgrading releases via Kustomize, Helm cannot query the cluster to check if a secret already exists, causing it to regenerate a new random value on each upgrade, which will break authentication |

--- a/charts/platform/charts/mcp/tests/deployment_test.yaml
+++ b/charts/platform/charts/mcp/tests/deployment_test.yaml
@@ -65,6 +65,21 @@ tests:
                 name: my-platform-backend
                 key: MY_OIDC_KEY
 
+  - it: should default to MCP_OAUTH_INITIAL_ACCESS_TOKEN key when using existing secret without custom key
+    template: deployment.yaml
+    set:
+      oidcToken.existingSecretName: my-platform-backend
+      oidcToken.existingSecretKey: ""
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[0]
+          value:
+            name: MCP_OAUTH_INITIAL_ACCESS_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: my-platform-backend
+                key: MCP_OAUTH_INITIAL_ACCESS_TOKEN
+
   - it: should use custom image
     template: deployment.yaml
     set:

--- a/charts/platform/charts/mcp/values.yaml
+++ b/charts/platform/charts/mcp/values.yaml
@@ -82,7 +82,7 @@ oidcToken:
   # deployment.
   existingSecretName: ""
   # -- Key in the existing Secret containing the OIDC client registration token.
-  # @default -- `"OIDC_CLIENT_REGISTRATION_TOKEN"`
+  # @default -- `"MCP_OAUTH_INITIAL_ACCESS_TOKEN"`
   existingSecretKey: ""
 
 oauth:

--- a/charts/platform/charts/studios/CHANGELOG.md
+++ b/charts/platform/charts/studios/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.12] - 2026-04-29
+
+### Fixed
+
+- Fixed default key for external OIDC secret to use `CONNECT_OIDC_CLIENT_REGISTRATION_TOKEN`, consistent with the key used in the chart-managed secret
+
 ## [1.2.11] - 2026-04-28
 
 ### Added

--- a/charts/platform/charts/studios/Chart.yaml
+++ b/charts/platform/charts/studios/Chart.yaml
@@ -21,7 +21,7 @@ name: studios
 description: Studios is a unified platform for interactive analysis
 sources:
   - https://github.com/seqeralabs/helm-charts/tree/main/seqera/charts/studios
-version: 1.2.11
+version: 1.2.12
 appVersion: "0.11.0"
 maintainers:
   - name: Seqera Labs

--- a/charts/platform/charts/studios/README.md
+++ b/charts/platform/charts/studios/README.md
@@ -2,7 +2,7 @@
 
 Studios is a unified platform for interactive analysis
 
-![Version: 1.2.11](https://img.shields.io/badge/Version-1.2.11-informational?style=flat-square) ![AppVersion: 0.11.0](https://img.shields.io/badge/AppVersion-0.11.0-informational?style=flat-square)
+![Version: 1.2.12](https://img.shields.io/badge/Version-1.2.12-informational?style=flat-square) ![AppVersion: 0.11.0](https://img.shields.io/badge/AppVersion-0.11.0-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -40,7 +40,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/studios \
-  --version 1.2.11 \
+  --version 1.2.12 \
   --namespace my-namespace \
   --create-namespace
 ```

--- a/charts/platform/charts/studios/templates/_helpers.tpl
+++ b/charts/platform/charts/studios/templates/_helpers.tpl
@@ -99,7 +99,7 @@ key: {{ include "studios.oidcToken.secretKey" $studiosContext }}
 
 {{- define "studios.oidcToken.secretKey" -}}
   {{- if (include "studios.oidcToken.existingSecret" .) -}}
-    {{- printf "%s" (tpl .Values.proxy.oidcClientRegistrationTokenSecretKey .) | default "OIDC_CLIENT_REGISTRATION_TOKEN" -}}
+    {{- printf "%s" (tpl .Values.proxy.oidcClientRegistrationTokenSecretKey .) | default "CONNECT_OIDC_CLIENT_REGISTRATION_TOKEN" -}}
   {{- else -}}
     {{- printf "CONNECT_OIDC_CLIENT_REGISTRATION_TOKEN" -}}
   {{- end -}}

--- a/charts/platform/charts/studios/tests/_helpers_test.yaml
+++ b/charts/platform/charts/studios/tests/_helpers_test.yaml
@@ -226,6 +226,18 @@ tests:
           path: spec.template.spec.containers[0].env[0].valueFrom.secretKeyRef.key
           value: "CONNECT_OIDC_CLIENT_REGISTRATION_TOKEN"
 
+  - it: should use default secret key CONNECT_OIDC_CLIENT_REGISTRATION_TOKEN when using external secret without a custom key
+    template: deployment-proxy.yaml
+    set:
+      proxy:
+        oidcClientRegistrationToken: ""
+        oidcClientRegistrationTokenSecretName: "external-secret"
+        oidcClientRegistrationTokenSecretKey: ""
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[0].valueFrom.secretKeyRef.key
+          value: "CONNECT_OIDC_CLIENT_REGISTRATION_TOKEN"
+
   - it: should use custom secret key when oidcClientRegistrationTokenSecretKey is provided with external secret
     template: deployment-proxy.yaml
     set:

--- a/charts/platform/templates/configmap.yaml
+++ b/charts/platform/templates/configmap.yaml
@@ -42,6 +42,9 @@ data:
   TOWER_DATA_STUDIO_WAVE_CUSTOM_IMAGE_REPOSITORY: {{ .Values.platform.studios.customImageRepository | quote }}
 {{- include "platform.studios.toolsEnvVars" . | nindent 2 }}
 {{- end }}
+{{- if (index .Values "portal-web" "enabled") }}
+  TOWER_SEQERA_AI_PORTAL_URL: {{ printf "http://%s" (tpl .Values.global.portalWebDomain $) | quote }}
+{{- end }}
 ---
 kind: ConfigMap
 apiVersion: v1

--- a/charts/platform/tests/__snapshot__/configmap_test.yaml.snap
+++ b/charts/platform/tests/__snapshot__/configmap_test.yaml.snap
@@ -40,6 +40,7 @@ should render Studios tools environment variables when studios is enabled with d
       TOWER_DATA_STUDIO_TEMPLATES_XPRA_TOOL: xpra
       TOWER_DATA_STUDIO_WAVE_CUSTOM_IMAGE_REGISTRY: ""
       TOWER_DATA_STUDIO_WAVE_CUSTOM_IMAGE_REPOSITORY: ""
+      TOWER_SEQERA_AI_PORTAL_URL: http://ai.example.com
     kind: ConfigMap
     metadata:
       annotations: {}
@@ -97,6 +98,7 @@ should render custom Studios tool when provided:
       TOWER_DATA_STUDIO_TEMPLATES_XPRA_TOOL: xpra
       TOWER_DATA_STUDIO_WAVE_CUSTOM_IMAGE_REGISTRY: ""
       TOWER_DATA_STUDIO_WAVE_CUSTOM_IMAGE_REPOSITORY: ""
+      TOWER_SEQERA_AI_PORTAL_URL: http://ai.example.com
     kind: ConfigMap
     metadata:
       annotations: {}
@@ -162,6 +164,7 @@ should render custom Studios tool with deprecated and experimental versions when
       TOWER_DATA_STUDIO_TEMPLATES_XPRA_TOOL: xpra
       TOWER_DATA_STUDIO_WAVE_CUSTOM_IMAGE_REGISTRY: ""
       TOWER_DATA_STUDIO_WAVE_CUSTOM_IMAGE_REPOSITORY: ""
+      TOWER_SEQERA_AI_PORTAL_URL: http://ai.example.com
     kind: ConfigMap
     metadata:
       annotations: {}

--- a/charts/platform/tests/__snapshot__/deployment-backend_test.yaml.snap
+++ b/charts/platform/tests/__snapshot__/deployment-backend_test.yaml.snap
@@ -225,7 +225,7 @@ should render the backend deployment with the correct checksums, labels and anno
       template:
         metadata:
           annotations:
-            checksum/configmap: 4615def3e4d1c9b9b46d32ba4c17fb5758067cb9e209f0be727645b1b3fdf63e
+            checksum/configmap: 9c047b4d94a2312747cba3f6f9024c1976c09c93115ddc631616681e96abb755
             checksum/secret: d3b5ca20c437b2faa4af1b549c817ee78cc2a992f86741120f01bd93a30d4873
             common-annotation-key: common-annotation-value
             pod-annotation-key: pod-annotation-value

--- a/charts/platform/tests/__snapshot__/deployment-cron_test.yaml.snap
+++ b/charts/platform/tests/__snapshot__/deployment-cron_test.yaml.snap
@@ -221,7 +221,7 @@ should render the cron deployment with the correct checksums, labels and annotat
       template:
         metadata:
           annotations:
-            checksum/configmap: 4615def3e4d1c9b9b46d32ba4c17fb5758067cb9e209f0be727645b1b3fdf63e
+            checksum/configmap: 9c047b4d94a2312747cba3f6f9024c1976c09c93115ddc631616681e96abb755
             checksum/secret: d3b5ca20c437b2faa4af1b549c817ee78cc2a992f86741120f01bd93a30d4873
             common-annotation-key: common-annotation-value
             pod-annotation-key: pod-annotation-value

--- a/charts/platform/tests/configmap_test.yaml
+++ b/charts/platform/tests/configmap_test.yaml
@@ -387,6 +387,43 @@ tests:
       path: data.TOWER_DATA_STUDIO_WAVE_CUSTOM_IMAGE_REPOSITORY
       value: myteam/studios-repo
 
+- it: should render TOWER_SEQERA_AI_PORTAL_URL with default portalWebDomain when portal-web is enabled
+  documentSelector:
+    path: metadata.name
+    value: release-name-platform-backend
+  set:
+    portal-web:
+      enabled: true
+  asserts:
+  - equal:
+      path: data.TOWER_SEQERA_AI_PORTAL_URL
+      value: http://ai.example.com
+
+- it: should render TOWER_SEQERA_AI_PORTAL_URL using a custom portalWebDomain when portal-web is enabled
+  documentSelector:
+    path: metadata.name
+    value: release-name-platform-backend
+  set:
+    portal-web:
+      enabled: true
+    global:
+      portalWebDomain: portal.custom.example.org
+  asserts:
+  - equal:
+      path: data.TOWER_SEQERA_AI_PORTAL_URL
+      value: http://portal.custom.example.org
+
+- it: should not render TOWER_SEQERA_AI_PORTAL_URL when portal-web is disabled
+  documentSelector:
+    path: metadata.name
+    value: release-name-platform-backend
+  set:
+    portal-web:
+      enabled: false
+  asserts:
+  - notExists:
+      path: data.TOWER_SEQERA_AI_PORTAL_URL
+
 - it: should fail when database driver is unsupported
   set:
     platformDatabase:
@@ -409,6 +446,7 @@ tests:
         GROUNDSWELL_SERVER_URL: http://RELEASE-NAME-pipeline-optimization:8090
         MICRONAUT_ENVIRONMENTS: prod,redis,ha,oauth-client,wave,groundswell
         TOWER_DATA_EXPLORER_ENABLED: 'false'
+        TOWER_SEQERA_AI_PORTAL_URL: http://ai.example.com
 
 - it: should render TOWER_OIDC_PEM_PATH in the shared-backend-cron configmap regardless of studios.enabled
   documentSelector:


### PR DESCRIPTION
Follow up fix for a bug I noticed while working on #119 and #120.