### PR TITLE
feat: add SEQERA_PLATFORM_URL and rewire SEQERA_PLATFORM_API_URL

### DIFF
--- a/charts/platform/CHANGELOG.md
+++ b/charts/platform/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `mcp` subchart to 0.3.3 and `studios` subchart to 1.2.12 to fix default OIDC external secret
   key to match each chart's own managed secret key
+- Bump `agent-backend` to 0.4.8 to point `SEQERA_PLATFORM_API_URL` to the internal Platform backend
+  service instead of the external domain, and add `SEQERA_PLATFORM_URL` env var pointing to the external platform URL for use in links and callbacks from the agent backend
 
 ### Changed
 

--- a/charts/platform/Chart.lock
+++ b/charts/platform/Chart.lock
@@ -10,18 +10,18 @@ dependencies:
   version: 2.0.3
 - name: studios
   repository: file://charts/studios
-  version: 1.2.10
+  version: 1.2.12
 - name: wave
   repository: file://charts/wave
   version: 0.1.0
 - name: mcp
   repository: file://charts/mcp
-  version: 0.3.2
+  version: 0.3.3
 - name: agent-backend
   repository: file://charts/agent-backend
-  version: 0.4.6
+  version: 0.4.8
 - name: portal-web
   repository: file://charts/portal-web
   version: 0.2.5
-digest: sha256:4f555bd43be6fa9dac44b8cb65747b0b0c70a3ae96b870d9e8742784f06774f3
-generated: "2026-04-16T15:42:20.627375767+02:00"
+digest: sha256:9b117b6b54df6a1790510af3025dc5a06f8c2e2ee5071bb68b33abf4753511b7
+generated: "2026-04-29T17:00:51.036562924+02:00"

--- a/charts/platform/charts/agent-backend/CHANGELOG.md
+++ b/charts/platform/charts/agent-backend/CHANGELOG.md
@@ -10,8 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Point `SEQERA_PLATFORM_API_URL` to the internal Platform backend service (`platformServiceAddress`:`platformServicePort`) instead of the external domain
+
+### Added
+
 - Add `SEQERA_PLATFORM_URL` env var pointing to the external platform URL for use in links and callbacks from the agent backend
 - Add `global.platformServiceAddress` and `global.platformServicePort` values
+- Add `KNOWLEDGE_INDEXER_EMBEDDINGS_PROVIDER` env var set to `bedrock`
+- Add `nextflowDocs.useRedisIndex` value to control `NEXTFLOW_DOCS_USE_REDIS_INDEX` (defaults to `false`)
+- Add `bedrockAssumeRoleArn` value to optionally set `AWS_BEDROCK_SERVICES_DEFAULT_ASSUME_ROLE_ARN` for cross-account Bedrock access
+- Add `bedrockAnthropicModel` value to optionally override `BEDROCK_ANTHROPIC_MODEL`
 
 ## [0.4.7] - 2026-04-20
 

--- a/charts/platform/charts/agent-backend/CHANGELOG.md
+++ b/charts/platform/charts/agent-backend/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.8] - 2026-04-29
+
+### Changed
+
+- Point `SEQERA_PLATFORM_API_URL` to the internal Platform backend service (`platformServiceAddress`:`platformServicePort`) instead of the external domain
+- Add `SEQERA_PLATFORM_URL` env var pointing to the external platform URL for use in links and callbacks from the agent backend
+- Add `global.platformServiceAddress` and `global.platformServicePort` values
+
 ## [0.4.7] - 2026-04-20
 
 ### Added

--- a/charts/platform/charts/agent-backend/Chart.yaml
+++ b/charts/platform/charts/agent-backend/Chart.yaml
@@ -19,7 +19,7 @@ apiVersion: v2
 name: agent-backend
 description: Backend service for Seqera CLI AI capabilities
 type: application
-version: 0.4.7
+version: 0.4.8
 appVersion: "2.0.0"
 maintainers:
   - name: Seqera Labs

--- a/charts/platform/charts/agent-backend/README.md
+++ b/charts/platform/charts/agent-backend/README.md
@@ -85,9 +85,12 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | redis.existingSecretName | string | `""` | Name of an existing Secret containing the Redis password, as an alternative to the password field. Note: the Secret must already exist in the same namespace at the time of deployment |
 | redis.existingSecretKey | string | `"AGENT_BACKEND_REDIS_PASSWORD"` | Key in the existing Secret containing the Redis password |
 | bedrockAgentCoreArn | string | `""` | AWS Bedrock AgentCore runtime ARN for sandbox sessions |
+| bedrockAssumeRoleArn | string | `""` | Optional IAM role ARN that the Agent Backend assumes for cross-account Bedrock access. Leave empty to let the pod directly use the AWS credentials provided to it (single-account setup). |
+| bedrockAnthropicModel | string | `""` | Override the Anthropic model used on Bedrock by specifying an inference profile ARN. You can create a custom inference profile that uses the Anthropic model you want or use the default inference profile for the model provided by AWS. When doing cross-account access with `bedrockAssumeRoleArn`, you may want to specify an inference profile ARN on the account where the hop role is defined |
 | embeddings.bedrock.region | string | `""` | AWS region where the Bedrock model is hosted |
 | embeddings.bedrock.modelId | string | `"amazon.titan-embed-text-v2:0"` | Bedrock model ID used for embeddings |
 | embeddings.bedrock.dimensions | string | `"1024"` | Embedding vector dimensions expected from the configured Bedrock model |
+| nextflowDocs.useRedisIndex | bool | `false` | Use a Redis-backed vector index for the Nextflow documentation knowledge base. Disabled by default. |
 | anthropicApiKey | string | `""` | Anthropic API key. Define the value as a String or a Secret, not both at the same time |
 | anthropicApiKeyExistingSecretName | string | `""` | Name of an existing Secret containing the Anthropic API key. Note: the Secret must already exist in the same namespace at the time of deployment |
 | anthropicApiKeyExistingSecretKey | string | `"ANTHROPIC_API_KEY"` | Key in the existing Secret containing the Anthropic API key |

--- a/charts/platform/charts/agent-backend/README.md
+++ b/charts/platform/charts/agent-backend/README.md
@@ -2,7 +2,7 @@
 
 Backend service for Seqera CLI AI capabilities
 
-![Version: 0.4.7](https://img.shields.io/badge/Version-0.4.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 0.4.8](https://img.shields.io/badge/Version-0.4.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -38,7 +38,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/agent-backend \
-  --version 0.4.7 \
+  --version 0.4.8 \
   --namespace my-namespace \
   --create-namespace
 ```
@@ -61,6 +61,8 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | global.platformExternalDomain | string | `"example.com"` | Domain where Seqera Platform listens |
+| global.platformServiceAddress | string | `"{{ printf \"%s-platform-backend\" .Release.Name | lower }}"` | Seqera Platform Service name: can be the internal Kubernetes hostname or an external ingress hostname. Evaluated as a template |
+| global.platformServicePort | int | `8080` | Seqera Platform Service port |
 | global.agentBackendDomain | string | `"{{ printf \"ai-api.%s\" .Values.global.platformExternalDomain }}"` | Domain where the Agent Backend service listens. Evaluated as a template |
 | global.mcpDomain | string | `"{{ printf \"mcp.%s\" .Values.global.platformExternalDomain }}"` | Domain where Seqera MCP listens. Evaluated as a template |
 | global.imageCredentials | list | `[]` | Optional credentials to log in and fetch images from a private registry. These credentials are shared with all the subcharts automatically |

--- a/charts/platform/charts/agent-backend/templates/configmap.yaml
+++ b/charts/platform/charts/agent-backend/templates/configmap.yaml
@@ -32,7 +32,8 @@ metadata:
 data:
   AGENT_BACKEND_PORT: {{ .Values.service.http.targetPort | quote }}
 
-  SEQERA_PLATFORM_API_URL: {{ printf "https://%s/api" (tpl .Values.global.platformExternalDomain .)  | quote }}
+  SEQERA_PLATFORM_URL: {{ printf "https://%s" (tpl .Values.global.platformExternalDomain .) | quote }}
+  SEQERA_PLATFORM_API_URL: {{ printf "http://%s:%s" (tpl .Values.global.platformServiceAddress .) (toString .Values.global.platformServicePort) | quote }}
   SEQERA_MCP_URL: {{ printf "https://%s/mcp" (tpl .Values.global.mcpDomain .)  | quote }}
 
   AGENT_BACKEND_DB_HOST: {{ tpl .Values.database.host . | quote }}

--- a/charts/platform/charts/agent-backend/templates/configmap.yaml
+++ b/charts/platform/charts/agent-backend/templates/configmap.yaml
@@ -54,8 +54,16 @@ data:
   AGENTCORE_AGENT_ARN: {{ tpl .Values.bedrockAgentCoreArn . | quote }}
 
   USE_BEDROCK_INFERENCE: "true"
+  KNOWLEDGE_INDEXER_EMBEDDINGS_PROVIDER: "bedrock"
   BEDROCK_REGION: {{ tpl (toString .Values.embeddings.bedrock.region) . | quote }}
   NEXTFLOW_DOCS_BEDROCK_MODEL_ID: {{ tpl (toString .Values.embeddings.bedrock.modelId) . | quote }}
   NEXTFLOW_DOCS_BEDROCK_DIMENSIONS: {{ include "seqera.tplvalues.render" (dict "value" .Values.embeddings.bedrock.dimensions "context" $) | quote }}
+  NEXTFLOW_DOCS_USE_REDIS_INDEX: {{ .Values.nextflowDocs.useRedisIndex | quote }}
+{{- if .Values.bedrockAssumeRoleArn }}
+  AWS_BEDROCK_SERVICES_DEFAULT_ASSUME_ROLE_ARN: {{ tpl .Values.bedrockAssumeRoleArn . | quote }}
+{{- end }}
+{{- if .Values.bedrockAnthropicModel }}
+  BEDROCK_ANTHROPIC_MODEL: {{ tpl .Values.bedrockAnthropicModel . | quote }}
+{{- end }}
 
   LOG_LEVEL: {{ .Values.logLevel | default "INFO" | quote }}

--- a/charts/platform/charts/agent-backend/tests/__snapshot__/configmap_test.yaml.snap
+++ b/charts/platform/charts/agent-backend/tests/__snapshot__/configmap_test.yaml.snap
@@ -15,9 +15,11 @@ should render a ConfigMap with default values:
       AGENT_BACKEND_REDIS_TLS: "false"
       AGENTCORE_AGENT_ARN: ""
       BEDROCK_REGION: ""
+      KNOWLEDGE_INDEXER_EMBEDDINGS_PROVIDER: bedrock
       LOG_LEVEL: INFO
       NEXTFLOW_DOCS_BEDROCK_DIMENSIONS: "1024"
       NEXTFLOW_DOCS_BEDROCK_MODEL_ID: amazon.titan-embed-text-v2:0
+      NEXTFLOW_DOCS_USE_REDIS_INDEX: "false"
       SEQERA_MCP_URL: https://mcp.test.example.com/mcp
       SEQERA_PLATFORM_API_URL: http://release-name-platform-backend:8080
       SEQERA_PLATFORM_URL: https://test.example.com

--- a/charts/platform/charts/agent-backend/tests/__snapshot__/configmap_test.yaml.snap
+++ b/charts/platform/charts/agent-backend/tests/__snapshot__/configmap_test.yaml.snap
@@ -19,7 +19,8 @@ should render a ConfigMap with default values:
       NEXTFLOW_DOCS_BEDROCK_DIMENSIONS: "1024"
       NEXTFLOW_DOCS_BEDROCK_MODEL_ID: amazon.titan-embed-text-v2:0
       SEQERA_MCP_URL: https://mcp.test.example.com/mcp
-      SEQERA_PLATFORM_API_URL: https://test.example.com/api
+      SEQERA_PLATFORM_API_URL: http://release-name-platform-backend:8080
+      SEQERA_PLATFORM_URL: https://test.example.com
       USE_BEDROCK_INFERENCE: "true"
     kind: ConfigMap
     metadata:

--- a/charts/platform/charts/agent-backend/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/platform/charts/agent-backend/tests/__snapshot__/deployment_test.yaml.snap
@@ -21,7 +21,7 @@ should render a Deployment with default values:
       template:
         metadata:
           annotations:
-            checksum/configmap: d00fa8cce1d5ae08eb10d7d0028b9252337f37ff264ff3dea9284da551ceff7c
+            checksum/configmap: f133dfcb4869e3b4a713c59b09af19365251f62b2d24f49dc81a5c928bbc0fb2
             checksum/secret: ac4ca92760ab83180bef6b3504a9f7b2663f3c2972a4b7e57a8e3173c6092172
           labels:
             app.kubernetes.io/component: agent-backend

--- a/charts/platform/charts/agent-backend/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/platform/charts/agent-backend/tests/__snapshot__/deployment_test.yaml.snap
@@ -21,7 +21,7 @@ should render a Deployment with default values:
       template:
         metadata:
           annotations:
-            checksum/configmap: 13775ee23bf8fb7bc5e8eb7cbf1e4ac2c8cf97c39c74ce78c18129f17985abd1
+            checksum/configmap: d00fa8cce1d5ae08eb10d7d0028b9252337f37ff264ff3dea9284da551ceff7c
             checksum/secret: ac4ca92760ab83180bef6b3504a9f7b2663f3c2972a4b7e57a8e3173c6092172
           labels:
             app.kubernetes.io/component: agent-backend

--- a/charts/platform/charts/agent-backend/tests/configmap_test.yaml
+++ b/charts/platform/charts/agent-backend/tests/configmap_test.yaml
@@ -58,7 +58,35 @@ tests:
           path: data.AGENT_BACKEND_DB_USER
           value: agentuser
 
-  - it: should contain platform URLs
+  - it: should set SEQERA_PLATFORM_API_URL from platformServiceAddress and platformServicePort
+    set:
+      global.platformExternalDomain: prod.example.com
+      global.platformServiceAddress: my-platform-backend
+      global.platformServicePort: 9090
+      global.mcpDomain: mcp.prod.example.com
+      database.host: mysql
+      database.name: db
+      database.username: user
+    asserts:
+      - equal:
+          path: data.SEQERA_PLATFORM_API_URL
+          value: "http://my-platform-backend:9090"
+
+  - it: should template platformServiceAddress in SEQERA_PLATFORM_API_URL
+    set:
+      global.platformExternalDomain: prod.example.com
+      global.platformServiceAddress: '{{ printf "%s-platform-backend" .Release.Name | lower }}'
+      global.platformServicePort: 8080
+      global.mcpDomain: mcp.prod.example.com
+      database.host: mysql
+      database.name: db
+      database.username: user
+    asserts:
+      - equal:
+          path: data.SEQERA_PLATFORM_API_URL
+          value: "http://release-name-platform-backend:8080"
+
+  - it: should set SEQERA_PLATFORM_URL from platformExternalDomain
     set:
       global.platformExternalDomain: prod.example.com
       global.mcpDomain: mcp.prod.example.com
@@ -67,8 +95,8 @@ tests:
       database.username: user
     asserts:
       - equal:
-          path: data.SEQERA_PLATFORM_API_URL
-          value: "https://prod.example.com/api"
+          path: data.SEQERA_PLATFORM_URL
+          value: "https://prod.example.com"
       - equal:
           path: data.SEQERA_MCP_URL
           value: "https://mcp.prod.example.com/mcp"

--- a/charts/platform/charts/agent-backend/tests/configmap_test.yaml
+++ b/charts/platform/charts/agent-backend/tests/configmap_test.yaml
@@ -139,6 +139,18 @@ tests:
           path: data.LOG_LEVEL
           value: DEBUG
 
+  - it: should set KNOWLEDGE_INDEXER_EMBEDDINGS_PROVIDER to bedrock
+    set:
+      global.platformExternalDomain: test.example.com
+      global.mcpDomain: mcp.test.example.com
+      database.host: mysql
+      database.name: db
+      database.username: user
+    asserts:
+      - equal:
+          path: data.KNOWLEDGE_INDEXER_EMBEDDINGS_PROVIDER
+          value: "bedrock"
+
   - it: should always enable Bedrock inference
     set:
       global.platformExternalDomain: test.example.com
@@ -293,6 +305,79 @@ tests:
       - equal:
           path: data.AGENT_BACKEND_REDIS_TLS
           value: "true"
+
+  - it: should set NEXTFLOW_DOCS_USE_REDIS_INDEX to false by default
+    set:
+      global.platformExternalDomain: test.example.com
+      global.mcpDomain: mcp.test.example.com
+      database.host: mysql
+      database.name: db
+      database.username: user
+    asserts:
+      - equal:
+          path: data.NEXTFLOW_DOCS_USE_REDIS_INDEX
+          value: "false"
+
+  - it: should set NEXTFLOW_DOCS_USE_REDIS_INDEX when enabled
+    set:
+      global.platformExternalDomain: test.example.com
+      global.mcpDomain: mcp.test.example.com
+      database.host: mysql
+      database.name: db
+      database.username: user
+      nextflowDocs.useRedisIndex: true
+    asserts:
+      - equal:
+          path: data.NEXTFLOW_DOCS_USE_REDIS_INDEX
+          value: "true"
+
+  - it: should not set AWS_BEDROCK_SERVICES_DEFAULT_ASSUME_ROLE_ARN by default
+    set:
+      global.platformExternalDomain: test.example.com
+      global.mcpDomain: mcp.test.example.com
+      database.host: mysql
+      database.name: db
+      database.username: user
+    asserts:
+      - notExists:
+          path: data.AWS_BEDROCK_SERVICES_DEFAULT_ASSUME_ROLE_ARN
+
+  - it: should set AWS_BEDROCK_SERVICES_DEFAULT_ASSUME_ROLE_ARN when provided
+    set:
+      global.platformExternalDomain: test.example.com
+      global.mcpDomain: mcp.test.example.com
+      database.host: mysql
+      database.name: db
+      database.username: user
+      bedrockAssumeRoleArn: arn:aws:iam::123456789012:role/bedrock-cross-account
+    asserts:
+      - equal:
+          path: data.AWS_BEDROCK_SERVICES_DEFAULT_ASSUME_ROLE_ARN
+          value: arn:aws:iam::123456789012:role/bedrock-cross-account
+
+  - it: should not set BEDROCK_ANTHROPIC_MODEL by default
+    set:
+      global.platformExternalDomain: test.example.com
+      global.mcpDomain: mcp.test.example.com
+      database.host: mysql
+      database.name: db
+      database.username: user
+    asserts:
+      - notExists:
+          path: data.BEDROCK_ANTHROPIC_MODEL
+
+  - it: should set BEDROCK_ANTHROPIC_MODEL when provided
+    set:
+      global.platformExternalDomain: test.example.com
+      global.mcpDomain: mcp.test.example.com
+      database.host: mysql
+      database.name: db
+      database.username: user
+      bedrockAnthropicModel: anthropic.claude-sonnet-4-6
+    asserts:
+      - equal:
+          path: data.BEDROCK_ANTHROPIC_MODEL
+          value: anthropic.claude-sonnet-4-6
 
   - it: should include AgentCore runtime ARN when provided
     set:

--- a/charts/platform/charts/agent-backend/values.yaml
+++ b/charts/platform/charts/agent-backend/values.yaml
@@ -21,6 +21,12 @@ global:
   # -- Domain where Seqera Platform listens
   platformExternalDomain: example.com
 
+  # -- Seqera Platform Service name: can be the internal Kubernetes hostname or an external ingress
+  # hostname. Evaluated as a template
+  platformServiceAddress: '{{ printf "%s-platform-backend" .Release.Name | lower }}'
+  # -- Seqera Platform Service port
+  platformServicePort: 8080
+
   # -- Domain where the Agent Backend service listens. Evaluated as a template
   agentBackendDomain: '{{ printf "ai-api.%s" .Values.global.platformExternalDomain }}'
 

--- a/charts/platform/charts/agent-backend/values.yaml
+++ b/charts/platform/charts/agent-backend/values.yaml
@@ -100,6 +100,17 @@ redis:
 # -- AWS Bedrock AgentCore runtime ARN for sandbox sessions
 bedrockAgentCoreArn: ""
 
+# -- Optional IAM role ARN that the Agent Backend assumes for cross-account Bedrock access.
+# Leave empty to let the pod directly use the AWS credentials provided to it (single-account setup).
+bedrockAssumeRoleArn: ""
+
+# -- Override the Anthropic model used on Bedrock by specifying an inference profile ARN. You can
+# create a custom inference profile that uses the Anthropic model you want or use the default
+# inference profile for the model provided by AWS. When doing cross-account access with
+# `bedrockAssumeRoleArn`, you may want to specify an inference profile ARN on the account where the
+# hop role is defined
+bedrockAnthropicModel: ""
+
 embeddings:
   bedrock:
     # -- AWS region where the Bedrock model is hosted
@@ -108,6 +119,11 @@ embeddings:
     modelId: "amazon.titan-embed-text-v2:0"
     # -- Embedding vector dimensions expected from the configured Bedrock model
     dimensions: "1024"
+
+nextflowDocs:
+  # -- Use a Redis-backed vector index for the Nextflow documentation knowledge base.
+  # Disabled by default.
+  useRedisIndex: false
 
 # -- Anthropic API key. Define the value as a String or a Secret, not both at the same time
 anthropicApiKey: ""


### PR DESCRIPTION
(I'm targeting #122 to push out a single release with multiple fixes)

This makes `SEQERA_PLATFORM_URL` point to the external domain and points `SEQERA_PLATFORM_API_URL` to the internal backend service name.
Tested with an enterprise installation on the dev cluster