### PR TITLE
feat(ci): publish chart index.yaml to gh-pages for helm repo add

### DIFF
--- a/.github/workflows/build-helm-charts.yaml
+++ b/.github/workflows/build-helm-charts.yaml
@@ -10,6 +10,8 @@ jobs:
     name: 'Update Helm chart'
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: write
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -152,3 +154,42 @@ jobs:
 
             echo "Created release ${release_tag}"
           done
+
+      - name: 'Install chart-releaser'
+        if: github.ref_name == 'master' && env.charts_to_package != ''
+        run: |
+          curl -fsSL -o cr.tar.gz https://github.com/helm/chart-releaser/releases/download/v1.8.1/chart-releaser_1.8.1_linux_amd64.tar.gz
+          echo "834046b27b00cd6ba451326875c1937d4f2b671063c2053e031434ade73002b5  cr.tar.gz" | sha256sum -c
+          tar -xzf cr.tar.gz cr
+          sudo mv cr /usr/local/bin/cr
+
+      - name: 'Update GitHub Pages Helm repo index'
+        if: github.ref_name == 'master' && env.charts_to_package != ''
+        shell: bash
+        env:
+          CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          # Stage the freshly packaged .tgz files for cr index. The .tgz themselves
+          # are hosted as GitHub Release assets (uploaded in the previous step);
+          # cr uses this directory to discover which charts to include and queries
+          # the GitHub API to resolve each one to its release-asset URL.
+          mkdir -p .cr-release-packages
+          for chart in $charts_to_package; do
+            chart_name=$(yq -r '.name' ${chart}/Chart.yaml)
+            chart_version=$(yq -r '.version' ${chart}/Chart.yaml)
+            mv "${chart_name}-${chart_version}.tgz" .cr-release-packages/
+          done
+
+          owner="${GITHUB_REPOSITORY%%/*}"
+          repo="${GITHUB_REPOSITORY##*/}"
+
+          cr index \
+            --owner "${owner}" \
+            --git-repo "${repo}" \
+            --token "${CR_TOKEN}" \
+            --package-path .cr-release-packages \
+            --index-path .cr-index \
+            --pages-branch gh-pages \
+            --push

--- a/README.md
+++ b/README.md
@@ -23,6 +23,26 @@ Each chart comes with its own README file containing specific instructions and d
 scenarios are also provided in the `examples/` directory to help you configure and deploy the
 charts in different environments.
 
+## Installing the charts
+
+Charts are published two ways. Pick whichever fits your tooling.
+
+### As a Helm repository (HTTPS)
+
+```bash
+helm repo add seqera https://seqeralabs.github.io/helm-charts
+helm repo update
+helm search repo seqera
+helm install my-platform seqera/platform --version <version>
+```
+
+### From the OCI registry
+
+```bash
+helm pull oci://public.cr.seqera.io/charts/platform --version <version>
+helm install my-platform oci://public.cr.seqera.io/charts/platform --version <version>
+```
+
 ## Vendoring Seqera container images and charts
 
 Refer to the [vendoring documentation](./VENDORING.md) for instructions on how to vendor Seqera


### PR DESCRIPTION
## Summary

Layers the GitHub Pages Helm-repo publishing flow on top of [PR #118](https://github.com/seqeralabs/helm-charts/pull/118)'s release-asset attachment. After this lands, users can install charts the standard way:

```bash
helm repo add seqera https://seqeralabs.github.io/helm-charts
helm repo update
helm install my-platform seqera/platform --version <version>
```

## What changed

`.github/workflows/build-helm-charts.yaml` — three steps appended after the existing release-creation step (master only, only when there are charts to package):

1. **`permissions: contents: write`** at job level — required so `cr index --push` can write to `gh-pages`.
2. **Install chart-releaser** v1.8.1 (SHA-pinned).
3. **`cr index --push`** — looks up each release-asset URL via the GitHub API and merges new entries into `gh-pages/index.yaml`.

`README.md` — adds an "Installing the charts" section documenting both the new HTTPS path and the existing OCI path.

## Pre-PR setup already done

- `gh-pages` branch created on origin with `.nojekyll`.
- `gh-pages/index.yaml` seeded with all 9 currently-attached release assets (one per chart, plus `platform-0.32.2`/`platform-0.32.3`). Generated locally with `cr index` and verified before pushing.

This means the very first chart-version bump on master after this PR merges will append to a real index, not start from scratch with a single entry.

## Manual one-time follow-up after merge

In repo Settings → Pages, set the source to `gh-pages` / `(root)`. Pages serving cannot be configured from CI.

## Test plan

- [ ] Merge to master and verify the next chart-version-bump push runs `cr index --push` cleanly
- [ ] Confirm `gh-pages/index.yaml` gains the new chart version after that run
- [ ] Once Pages is enabled, run `helm repo add seqera https://seqeralabs.github.io/helm-charts && helm repo update && helm search repo seqera` from a clean machine — every existing chart should be discoverable
- [ ] `helm pull seqera/platform --version 0.32.3` should download the `.tgz` from the GitHub Release asset URL

## Pattern reference

Mirrors [grafana/helm-charts](https://github.com/grafana/helm-charts/tree/gh-pages): `gh-pages` holds only `index.yaml` (+ `.nojekyll`), `.tgz` files live as GitHub Release assets, `cr index` keeps both in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)