### PR TITLE
chore: Update all platform subcharts to require platformServiceAddress to be provided

### DIFF
--- a/.github/scripts/run_chart_tests.py
+++ b/.github/scripts/run_chart_tests.py
@@ -23,9 +23,11 @@ BEHAVIOR:
   - Checks if helm-unittest plugin is installed
   - If not installed, runs: helm plugin install (does not require Makefile)
   - Finds all directories under charts/ containing Chart.yaml
-  - For each chart directory with a Makefile, runs: make -C <chart_dir> tests
+  - For each chart directory with a Makefile, runs: make -C <chart_dir> test-all
+    (when defined) or `make tests` (legacy fallback) — `test-all` exercises the
+    parent-recursive suite AND each subchart standalone, catching helper/value
+    divergence that the parent-only run masks
   - Skips charts without a Makefile (e.g., library charts with no tests)
-  - Subcharts are tested through their parent chart's test suite
 
 REQUIREMENTS:
   - helm CLI must be installed
@@ -91,8 +93,15 @@ def main():
             skipped_charts.append(chart_dir)
             continue
 
-        print(f"Running helm chart tests in {chart_dir}...")
-        test_result = subprocess.run(["make", "-C", chart_dir, "tests"])
+        # Prefer `test-all` (parent + standalone subcharts) when the chart's Makefile defines
+        # it; fall back to legacy `tests` target for charts that haven't adopted it yet.
+        makefile_targets = subprocess.run(
+            ["make", "-C", chart_dir, "-pn"], capture_output=True, text=True
+        ).stdout
+        target = "test-all" if "\ntest-all:" in makefile_targets else "tests"
+
+        print(f"Running helm chart tests in {chart_dir} (target: {target})...")
+        test_result = subprocess.run(["make", "-C", chart_dir, target])
         if test_result.returncode != 0:
             print(f"Helm chart tests failed in {chart_dir}.")
             failed_charts.append(chart_dir)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,8 @@ repos:
       - id: helm-docs
         args:
           - --sort-values-order=file
+          - --chart-search-root=charts
+        exclude: ^\.claude/
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0

--- a/charts/platform/CHANGELOG.md
+++ b/charts/platform/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.32.6] - 2026-04-30
+
+### Changed
+
+- Clear default values for `global.platformServiceAddress` and `global.platformServicePort` in subcharts that require Seqera Platform (`agent-backend`, `mcp`, `portal-web`, `studios`). These values are still defined with defaults in the parent `platform` chart and inherited automatically by subcharts when deployed together. When deploying a subchart standalone, users must now explicitly set these values. Each subchart now validates that both values are set at install/upgrade time
+- Bump `agent-backend` to 0.4.10, `mcp` to 0.3.5, `portal-web` to 0.2.7, `studios` to 1.2.14
+
 ## [0.32.5] - 2026-04-30
 
 ### Changed

--- a/charts/platform/CHANGELOG.md
+++ b/charts/platform/CHANGELOG.md
@@ -5,11 +5,31 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.33.0] - 2026-04-30
+
+### Added
+
+- **Enhancement**: allow global configuration of Ingress options. A new `global.ingress` block (`enabled`, `path`, `defaultPathType`, `ingressClassName`, `annotations`, `extraLabels`, `tls`) lets cluster-wide Ingress defaults be set once at the parent and propagate to every subchart, removing the need to repeat controller-wide config per subchart. `enabled` is OR-merged; scalar fields fall back to global when local is unset; `annotations` and `extraLabels` are merged with local winning on key collision; `tls` is concatenated (useful for a single wildcard certificate across all services).
+- Add `seqera.ingress.host` template helper in each chart's `_helpers.tpl` returning that chart's primary domain. Lets users write `external-dns.alpha.kubernetes.io/hostname: '{{ include "seqera.ingress.host" . }}'` once in `global.ingress.annotations` and have it resolve to the correct host per chart at render time, without hard-coding hostnames.
+- Add `docs/conventions/ingress.md` documenting the Ingress conventions used across charts.
+
+### Changed
+
+- Update bitnami/common to 2.39.0
+- **BREAKING**: Default `ingress.defaultPathType` is now `Prefix` (was `ImplementationSpecific`). With the previous default and the chart's default `path: "/"`, routing behavior depended on the ingress controller — NGINX treated it as a prefix match, AWS ALB required `/*` for the same effect, GKE applied its own interpretation. The result was the same chart and values producing different routing across clusters. `Prefix` is part of the Kubernetes Ingress spec and produces consistent prefix-match semantics across NGINX, Traefik, AWS ALB, and most modern controllers, giving users a predictable out-of-the-box experience. Users whose controller still requires `ImplementationSpecific` (e.g. older GKE) can set `global.ingress.defaultPathType: ImplementationSpecific` once at the parent.
+- Update `examples/ingress-configurations/*` to drop now-redundant `defaultPathType: Prefix` overrides and showcase `global.ingress.ingressClassName` in `nginx-cert-manager.yaml`.
+
 ## [0.32.7] - 2026-04-30
 
 ### Changed
 
 - Bump `seqera-common` to 2.1.2, `wave` to 0.1.2, `agent-backend` to 0.4.11, `mcp` to 0.3.6, `pipeline-optimization` to 2.0.5, `portal-web` to 0.2.8, `studios` to 1.2.15 (Redis init container log message now reports `auth set` or `auth not set`)
+
+## [0.32.5] - 2026-04-30
+
+### Changed
+
+- Bump `seqera-common` dependency to 2.1.1, `wave` subchart to 0.1.1, `agent-backend` to 0.4.9, `mcp` to 0.3.4, `pipeline-optimization` to 2.0.4, `portal-web` to 0.2.6, `studios` to 1.2.13 to pick up the Redis init container fix that no longer logs the password
 
 ## [0.32.6] - 2026-04-30
 

--- a/charts/platform/CHANGELOG.md
+++ b/charts/platform/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.32.7] - 2026-04-30
+
+### Changed
+
+- Bump `seqera-common` to 2.1.2, `wave` to 0.1.2, `agent-backend` to 0.4.11, `mcp` to 0.3.6, `pipeline-optimization` to 2.0.5, `portal-web` to 0.2.8, `studios` to 1.2.15 (Redis init container log message now reports `auth set` or `auth not set`)
+
 ## [0.32.6] - 2026-04-30
 
 ### Changed

--- a/charts/platform/Chart.lock
+++ b/charts/platform/Chart.lock
@@ -1,27 +1,27 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.38.0
+  version: 2.39.0
 - name: seqera-common
   repository: file://../seqera-common
   version: 2.1.2
 - name: pipeline-optimization
   repository: file://charts/pipeline-optimization
-  version: 2.0.5
+  version: 2.0.6
 - name: studios
   repository: file://charts/studios
-  version: 1.2.15
+  version: 1.3.0
 - name: wave
   repository: file://charts/wave
-  version: 0.1.2
+  version: 0.2.0
 - name: mcp
   repository: file://charts/mcp
-  version: 0.3.6
+  version: 0.4.0
 - name: agent-backend
   repository: file://charts/agent-backend
-  version: 0.4.11
+  version: 0.5.0
 - name: portal-web
   repository: file://charts/portal-web
-  version: 0.2.8
-digest: sha256:27521223337ca1b5d2afbb18b9cd356f53e6693e30ce7e0cc70cf35c5ae3c569
-generated: "2026-04-30T17:17:57.223873+02:00"
+  version: 0.3.0
+digest: sha256:91713efc8b064ff4d302d405bf0f27ead8297706ebfada779ef5d15fd7419a6b
+generated: "2026-05-05T14:25:51.292458674+02:00"

--- a/charts/platform/Chart.lock
+++ b/charts/platform/Chart.lock
@@ -4,24 +4,24 @@ dependencies:
   version: 2.38.0
 - name: seqera-common
   repository: file://../seqera-common
-  version: 2.1.1
+  version: 2.1.2
 - name: pipeline-optimization
   repository: file://charts/pipeline-optimization
-  version: 2.0.4
+  version: 2.0.5
 - name: studios
   repository: file://charts/studios
-  version: 1.2.14
+  version: 1.2.15
 - name: wave
   repository: file://charts/wave
-  version: 0.1.1
+  version: 0.1.2
 - name: mcp
   repository: file://charts/mcp
-  version: 0.3.5
+  version: 0.3.6
 - name: agent-backend
   repository: file://charts/agent-backend
-  version: 0.4.10
+  version: 0.4.11
 - name: portal-web
   repository: file://charts/portal-web
-  version: 0.2.7
-digest: sha256:4a6dd5e974677c8fccf8a1c408a8feb1c0e78bb60303a39b0080cc76fe5fa773
-generated: "2026-04-30T16:28:18.95822714+02:00"
+  version: 0.2.8
+digest: sha256:27521223337ca1b5d2afbb18b9cd356f53e6693e30ce7e0cc70cf35c5ae3c569
+generated: "2026-04-30T17:17:57.223873+02:00"

--- a/charts/platform/Chart.lock
+++ b/charts/platform/Chart.lock
@@ -10,18 +10,18 @@ dependencies:
   version: 2.0.4
 - name: studios
   repository: file://charts/studios
-  version: 1.2.13
+  version: 1.2.14
 - name: wave
   repository: file://charts/wave
   version: 0.1.1
 - name: mcp
   repository: file://charts/mcp
-  version: 0.3.4
+  version: 0.3.5
 - name: agent-backend
   repository: file://charts/agent-backend
-  version: 0.4.9
+  version: 0.4.10
 - name: portal-web
   repository: file://charts/portal-web
-  version: 0.2.6
-digest: sha256:c6e3d564bed99f7414c831a0577e9b6b4b142a9a6c772ffdaedd13b29e16056a
-generated: "2026-04-30T15:50:33.840203878+02:00"
+  version: 0.2.7
+digest: sha256:4a6dd5e974677c8fccf8a1c408a8feb1c0e78bb60303a39b0080cc76fe5fa773
+generated: "2026-04-30T16:28:18.95822714+02:00"

--- a/charts/platform/Chart.yaml
+++ b/charts/platform/Chart.yaml
@@ -37,7 +37,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.32.6
+version: 0.32.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/platform/Chart.yaml
+++ b/charts/platform/Chart.yaml
@@ -37,7 +37,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.32.5
+version: 0.32.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/platform/Chart.yaml
+++ b/charts/platform/Chart.yaml
@@ -37,7 +37,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.32.7
+version: 0.33.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -69,25 +69,25 @@ dependencies:
       - studios
     condition: studios.enabled
   - name: wave
-    version: "0.1.x"
+    version: "0.2.x"
     repository: "file://charts/wave"
     tags:
       - wave
     condition: wave.enabled
   - name: mcp
-    version: "0.3.x"
+    version: "0.4.x"
     repository: "file://charts/mcp"
     tags:
       - mcp
     condition: mcp.enabled
   - name: agent-backend
-    version: "0.4.x"
+    version: "0.5.x"
     repository: "file://charts/agent-backend"
     tags:
       - agent-backend
     condition: agent-backend.enabled
   - name: portal-web
-    version: "0.2.x"
+    version: "0.3.x"
     repository: "file://charts/portal-web"
     tags:
       - portal-web

--- a/charts/platform/Makefile
+++ b/charts/platform/Makefile
@@ -1,7 +1,7 @@
 .PHONY: test tests unittests unittests-no-build debug check-unittest-plugin install-unittest-plugin clean-deps clean-subchart-packages rebuild-deps rebuild-deps-and-unpack rebuild-deps-force unittests-standalone test-all help
 
 # Run tests (with external dependencies rebuild) - DEFAULT behavior
-test: unittests
+test: test-all
 tests: test
 test-no-build: unittests-no-build
 tests-no-build: test-no-build

--- a/charts/platform/Makefile
+++ b/charts/platform/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test tests unittests unittests-no-build debug check-unittest-plugin install-unittest-plugin clean-deps clean-subchart-packages rebuild-deps rebuild-deps-and-unpack rebuild-deps-force help
+.PHONY: test tests unittests unittests-no-build debug check-unittest-plugin install-unittest-plugin clean-deps clean-subchart-packages rebuild-deps rebuild-deps-and-unpack rebuild-deps-force unittests-standalone test-all help
 
 # Run tests (with external dependencies rebuild) - DEFAULT behavior
 test: unittests
@@ -6,12 +6,20 @@ tests: test
 test-no-build: unittests-no-build
 tests-no-build: test-no-build
 
+# Run BOTH the parent's recursive test suite AND each standalone-installable subchart's
+# tests rendered with that subchart's own values/helpers (matching how a customer would
+# install it on its own). Catches helper / values divergence that the parent-recursive
+# run silently masks.
+test-all: unittests unittests-standalone
+
 help:
 	@echo "Seqera Platform Helm Chart - Available Make Targets"
 	@echo ""
 	@echo "Testing:"
 	@echo "  make test                        - Rebuild all Platform dependencies and run tests (DEFAULT)"
 	@echo "  make test-no-build               - Run tests without rebuilding dependencies"
+	@echo "  make test-all                    - Run parent-recursive tests AND each subchart standalone"
+	@echo "  make unittests-standalone        - Run each subchart's tests standalone (no parent context)"
 	@echo "  make debug                       - Run tests in debug mode"
 	@echo "  make unittests-update-snapshots  - Rebuild all Platform dependencies and update snapshots"
 	@echo ""
@@ -118,6 +126,34 @@ unittests-no-build:
 unittests: rebuild-deps
 	@echo "Running unit tests..."
 	@helm unittest .
+
+# Run each subchart's unit tests STANDALONE — i.e. invoke `helm unittest` from inside the
+# subchart directory so its templates render with its own values.yaml / helpers, not under
+# the parent's merged context. A subchart is considered "standalone-installable" if it ships
+# its own `tests/` directory.
+#
+# This complements `unittests`: the parent-recursive run exercises the full integrated
+# deployment, this target exercises each subchart as if a customer installed it on its own.
+unittests-standalone: rebuild-deps
+	@echo "Running unit tests for each standalone-installable subchart..."
+	@failed=""; \
+	for subchart_dir in charts/*/; do \
+		subchart=$$(basename $$subchart_dir); \
+		if [ ! -d "$$subchart_dir/tests" ]; then \
+			echo "→ skipping $$subchart (no tests/ directory)"; \
+			continue; \
+		fi; \
+		echo ""; \
+		echo "→ $$subchart (standalone)"; \
+		(cd "$$subchart_dir" && helm unittest .) || failed="$$failed $$subchart"; \
+	done; \
+	if [ -n "$$failed" ]; then \
+		echo ""; \
+		echo "✗ standalone tests failed for:$$failed"; \
+		exit 1; \
+	fi; \
+	echo ""; \
+	echo "✓ all standalone subchart tests passed"
 
 unittests-update-snapshots: rebuild-deps
 	@echo "Running unit tests and updating snapshots..."

--- a/charts/platform/README.md
+++ b/charts/platform/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart to deploy Seqera Platform (also referred to as Tower) on Kubernetes.
 
-![Version: 0.32.7](https://img.shields.io/badge/Version-0.32.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v25.3.4](https://img.shields.io/badge/AppVersion-v25.3.4-informational?style=flat-square)
+![Version: 0.33.0](https://img.shields.io/badge/Version-0.33.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v25.3.4](https://img.shields.io/badge/AppVersion-v25.3.4-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -41,7 +41,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/platform \
-  --version 0.32.7 \
+  --version 0.33.0 \
   --namespace my-namespace \
   --create-namespace
 ```
@@ -63,12 +63,12 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | Repository | Name | Version |
 |------------|------|---------|
 | file://../seqera-common | seqera-common | 2.x.x |
-| file://charts/agent-backend | agent-backend | 0.4.x |
-| file://charts/mcp | mcp | 0.3.x |
+| file://charts/agent-backend | agent-backend | 0.5.x |
+| file://charts/mcp | mcp | 0.4.x |
 | file://charts/pipeline-optimization | pipeline-optimization | 2.x.x |
-| file://charts/portal-web | portal-web | 0.2.x |
+| file://charts/portal-web | portal-web | 0.3.x |
 | file://charts/studios | studios | 1.x.x |
-| file://charts/wave | wave | 0.1.x |
+| file://charts/wave | wave | 0.2.x |
 | oci://registry-1.docker.io/bitnamicharts | common | 2.x.x |
 
 ## Values
@@ -85,6 +85,13 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | global.mcpDomain | string | `"{{ printf \"mcp.%s\" .Values.global.platformExternalDomain }}"` | Domain where Seqera MCP listens. Evaluated as a template |
 | global.agentBackendDomain | string | `"{{ printf \"ai-api.%s\" .Values.global.platformExternalDomain }}"` | Domain where the Agent Backend service listens. Evaluated as a template |
 | global.portalWebDomain | string | `"{{ printf \"ai.%s\" .Values.global.platformExternalDomain }}"` | Domain where the Portal Web frontend listens. Evaluated as a template |
+| global.ingress.enabled | bool | `false` | Enable Ingress for the parent chart and every subchart that exposes one. Each chart's local `ingress.enabled` is OR'd with this — set this to `true` to turn on all Ingresses in one switch |
+| global.ingress.path | string | `"/"` | Default path applied to ingress rules when a chart's local `ingress.path` is not set. AWS ALB users should override to `/*`. |
+| global.ingress.defaultPathType | string | `"Prefix"` | Default path type applied to ingress rules when a chart's local `ingress.defaultPathType` is not set. `Prefix` works for nginx, traefik, AWS ALB, and most modern controllers. Override to `ImplementationSpecific` only if your controller requires it (e.g. older GKE). |
+| global.ingress.ingressClassName | string | `""` | Default ingress class name applied to ingress rules when a chart's local `ingress.ingressClassName` is not set. Replaces the deprecated `kubernetes.io/ingress.class` annotation |
+| global.ingress.annotations | object | `{}` | Annotations merged into every chart's Ingress (e.g. cert-manager issuer, NGINX `proxy-body-size`, ALB SSL config). Local `ingress.annotations` wins on key collision. Evaluated as a template |
+| global.ingress.extraLabels | object | `{}` | Extra labels merged into every chart's Ingress. Local `ingress.extraLabels` wins on key collision. Evaluated as a template |
+| global.ingress.tls | list | `[]` | TLS entries concatenated with each chart's local `ingress.tls`. Useful for a single wildcard cert that covers all services. Evaluated as a template |
 | global.imageCredentials | list | `[]` | Optional credentials to log in and fetch images from a private registry. These credentials are shared with all the subcharts automatically |
 | global.imageCredentialsSecrets | list | `[]` | Optional list of existing Secrets containing image pull credentials to use for pulling images from private registries. These Secrets are shared with all the subcharts automatically |
 | global.azure.images.platformBackend.registry | string | `nil` | Image registry for the Platform backend image deployed on Azure. Example: `myregistry.azurecr.io`. Evaluated as a template |
@@ -426,14 +433,14 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | serviceAccount.imagePullSecretNames | list | `[]` | Names of Secrets containing credentials to pull images from registries |
 | serviceAccount.automountServiceAccountToken | bool | `false` | Automount service account token when the service account is generated |
 | ingress.enabled | bool | `false` | Enable ingress for Platform |
-| ingress.path | string | `"/"` | Path for the main ingress rule Note: this needs to be set to '/*' to be used with AWS ALB ingress controller |
-| ingress.contentPath | string | `"/"` | Path for the content domain ingress rule Note: this needs to be set to '/*' to be used with AWS ALB ingress controller |
-| ingress.defaultPathType | string | `"ImplementationSpecific"` | Default path type for the Ingress |
+| ingress.path | string | `""` | Path for the main ingress rule. When empty, falls back to `global.ingress.path` |
+| ingress.contentPath | string | `"/"` | Path for the content domain ingress rule |
+| ingress.defaultPathType | string | `""` | Default path type for the Ingress. When empty, falls back to `global.ingress.defaultPathType` |
 | ingress.defaultBackend | object | `{}` | Configure the default service for the ingress (evaluated as template) Important: make sure only one defaultBackend is defined across the k8s cluster: if the ingress doesn't reconcile successfully, 'describe ingress <name>' will report problems |
 | ingress.extraHosts | list | `[]` | Additional hosts you want to include. Evaluated as a template |
 | ingress.annotations | object | `{}` | Ingress annotations specific to your load balancer. Evaluated as a template |
 | ingress.extraLabels | object | `{}` | Additional labels for the ingress object. Evaluated as a template |
-| ingress.ingressClassName | string | `""` | Name of the ingress class (replaces the deprecated annotation `kubernetes.io/ingress.class`) |
+| ingress.ingressClassName | string | `""` | Name of the ingress class (replaces the deprecated annotation `kubernetes.io/ingress.class`). When empty, falls back to `global.ingress.ingressClassName` |
 | ingress.tls | list | `[]` | TLS configuration. Evaluated as a template |
 | extraDeploy | list | `[]` | Array of extra objects to deploy with the release |
 | commonAnnotations | object | `{}` | Annotations to add to all deployed objects |

--- a/charts/platform/README.md
+++ b/charts/platform/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart to deploy Seqera Platform (also referred to as Tower) on Kubernetes.
 
-![Version: 0.32.6](https://img.shields.io/badge/Version-0.32.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v25.3.4](https://img.shields.io/badge/AppVersion-v25.3.4-informational?style=flat-square)
+![Version: 0.32.7](https://img.shields.io/badge/Version-0.32.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v25.3.4](https://img.shields.io/badge/AppVersion-v25.3.4-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -41,7 +41,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/platform \
-  --version 0.32.6 \
+  --version 0.32.7 \
   --namespace my-namespace \
   --create-namespace
 ```

--- a/charts/platform/README.md
+++ b/charts/platform/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart to deploy Seqera Platform (also referred to as Tower) on Kubernetes.
 
-![Version: 0.32.5](https://img.shields.io/badge/Version-0.32.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v25.3.4](https://img.shields.io/badge/AppVersion-v25.3.4-informational?style=flat-square)
+![Version: 0.32.6](https://img.shields.io/badge/Version-0.32.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v25.3.4](https://img.shields.io/badge/AppVersion-v25.3.4-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -41,7 +41,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/platform \
-  --version 0.32.5 \
+  --version 0.32.6 \
   --namespace my-namespace \
   --create-namespace
 ```

--- a/charts/platform/charts/agent-backend/CHANGELOG.md
+++ b/charts/platform/charts/agent-backend/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.10] - 2026-04-30
+
+### Changed
+
+- Clear the default values for `global.platformServiceAddress` and `global.platformServicePort` so they must be explicitly set when deploying this subchart standalone. They point to the Seqera Platform backend service. When deploying as part of the parent `platform` umbrella chart, these values are inherited automatically from the parent chart's `global` section
+- Add `NOTES.txt` validation that fails the installation when `global.platformServiceAddress` or `global.platformServicePort` are not set
+- Document the Platform Service connection details as a required configuration in the README
+
 ## [0.4.9] - 2026-04-30
 
 ### Changed

--- a/charts/platform/charts/agent-backend/CHANGELOG.md
+++ b/charts/platform/charts/agent-backend/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-05-05
+
+- **Enhancement**: allow global configuration of Ingress options. A new `global.ingress` block (`enabled`, `path`, `defaultPathType`, `ingressClassName`, `annotations`, `extraLabels`, `tls`) lets cluster-wide Ingress defaults be set once at the parent and propagate to every subchart, removing the need to repeat controller-wide config per subchart. `enabled` is OR-merged; scalar fields fall back to global when local is unset; `annotations` and `extraLabels` are merged with local winning on key collision; `tls` is concatenated (useful for a single wildcard certificate across all services).
+- Add `seqera.ingress.host` template helper in each chart's `_helpers.tpl` returning that chart's primary domain. Lets users write `external-dns.alpha.kubernetes.io/hostname: '{{ include "seqera.ingress.host" . }}'` once in `global.ingress.annotations` and have it resolve to the correct host per chart at render time, without hard-coding hostnames.
+- Add `docs/conventions/ingress.md` documenting the Ingress conventions used across charts.
+
+### Changed
+
+- Update bitnami/common to 2.39.0
+- **BREAKING**: Default `ingress.defaultPathType` is now `Prefix` (was `ImplementationSpecific`). With the previous default and the chart's default `path: "/"`, routing behavior depended on the ingress controller — NGINX treated it as a prefix match, AWS ALB required `/*` for the same effect, GKE applied its own interpretation. The result was the same chart and values producing different routing across clusters. `Prefix` is part of the Kubernetes Ingress spec and produces consistent prefix-match semantics across NGINX, Traefik, AWS ALB, and most modern controllers, giving users a predictable out-of-the-box experience. Users whose controller still requires `ImplementationSpecific` (e.g. older GKE) can set `global.ingress.defaultPathType: ImplementationSpecific` once at the parent.
+
 ## [0.4.11] - 2026-04-30
 
 ### Changed

--- a/charts/platform/charts/agent-backend/CHANGELOG.md
+++ b/charts/platform/charts/agent-backend/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.11] - 2026-04-30
+
+### Changed
+
+- Bump `seqera-common` dependency to 2.1.2 (Redis init container log message now reports `auth set` or `auth not set`)
+
 ## [0.4.10] - 2026-04-30
 
 ### Changed

--- a/charts/platform/charts/agent-backend/Chart.lock
+++ b/charts/platform/charts/agent-backend/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.38.0
+  version: 2.39.0
 - name: seqera-common
   repository: file://../../../seqera-common
   version: 2.1.2
-digest: sha256:4d1319075460f2901b92a5aa964db5992673e65275005b33671b597179c47c83
-generated: "2026-04-30T17:18:03.74270588+02:00"
+digest: sha256:3eac4511073f329f614981ce9b91e6cdda035aa007a3aeecd7069958c9ede539
+generated: "2026-05-05T14:17:14.074321992+02:00"

--- a/charts/platform/charts/agent-backend/Chart.lock
+++ b/charts/platform/charts/agent-backend/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 2.38.0
 - name: seqera-common
   repository: file://../../../seqera-common
-  version: 2.1.1
-digest: sha256:da56f594fa5462d454cf272386947bb8a4797df50c287d0130790b1a8b846f86
-generated: "2026-04-30T15:38:32.35183224+02:00"
+  version: 2.1.2
+digest: sha256:4d1319075460f2901b92a5aa964db5992673e65275005b33671b597179c47c83
+generated: "2026-04-30T17:18:03.74270588+02:00"

--- a/charts/platform/charts/agent-backend/Chart.yaml
+++ b/charts/platform/charts/agent-backend/Chart.yaml
@@ -19,7 +19,7 @@ apiVersion: v2
 name: agent-backend
 description: Backend service for Seqera CLI AI capabilities
 type: application
-version: 0.4.11
+version: 0.5.0
 appVersion: "2.0.0"
 maintainers:
   - name: Seqera Labs

--- a/charts/platform/charts/agent-backend/Chart.yaml
+++ b/charts/platform/charts/agent-backend/Chart.yaml
@@ -19,7 +19,7 @@ apiVersion: v2
 name: agent-backend
 description: Backend service for Seqera CLI AI capabilities
 type: application
-version: 0.4.10
+version: 0.4.11
 appVersion: "2.0.0"
 maintainers:
   - name: Seqera Labs

--- a/charts/platform/charts/agent-backend/Chart.yaml
+++ b/charts/platform/charts/agent-backend/Chart.yaml
@@ -19,7 +19,7 @@ apiVersion: v2
 name: agent-backend
 description: Backend service for Seqera CLI AI capabilities
 type: application
-version: 0.4.9
+version: 0.4.10
 appVersion: "2.0.0"
 maintainers:
   - name: Seqera Labs

--- a/charts/platform/charts/agent-backend/README.md
+++ b/charts/platform/charts/agent-backend/README.md
@@ -2,7 +2,7 @@
 
 Backend service for Seqera CLI AI capabilities
 
-![Version: 0.4.11](https://img.shields.io/badge/Version-0.4.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -39,7 +39,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/agent-backend \
-  --version 0.4.11 \
+  --version 0.5.0 \
   --namespace my-namespace \
   --create-namespace
 ```
@@ -66,6 +66,13 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | global.platformServicePort | string | `""` | Seqera Platform Service port. Required when deploying this subchart standalone. When deploying as part of the parent `platform` umbrella chart, this value is inherited from the parent chart's `global` section |
 | global.agentBackendDomain | string | `"{{ printf \"ai-api.%s\" .Values.global.platformExternalDomain }}"` | Domain where the Agent Backend service listens. Evaluated as a template |
 | global.mcpDomain | string | `"{{ printf \"mcp.%s\" .Values.global.platformExternalDomain }}"` | Domain where Seqera MCP listens. Evaluated as a template |
+| global.ingress.enabled | bool | `false` | Enable Ingress for this chart. OR'd with the chart's local `ingress.enabled` so setting this once at the parent enables all subchart Ingresses. |
+| global.ingress.path | string | `"/"` | Default path applied to ingress rules when `ingress.path` is not set. AWS ALB users should override to `/*`. |
+| global.ingress.defaultPathType | string | `"Prefix"` | Default path type applied to ingress rules when `ingress.defaultPathType` is not set. `Prefix` works for nginx, traefik, AWS ALB, and most modern controllers. |
+| global.ingress.ingressClassName | string | `""` | Default ingress class name applied when `ingress.ingressClassName` is not set |
+| global.ingress.annotations | object | `{}` | Annotations merged into the Ingress. Local `ingress.annotations` wins on key collision. Evaluated as a template |
+| global.ingress.extraLabels | object | `{}` | Extra labels merged into the Ingress. Local `ingress.extraLabels` wins on key collision. Evaluated as a template |
+| global.ingress.tls | list | `[]` | TLS entries concatenated with the local `ingress.tls`. Evaluated as a template |
 | global.imageCredentials | list | `[]` | Optional credentials to log in and fetch images from a private registry. These credentials are shared with all the subcharts automatically |
 | global.imageCredentialsSecrets | list | `[]` | Optional list of existing Secrets containing image pull credentials to use for pulling images from private registries. These Secrets are shared with all the subcharts automatically |
 | database.host | string | `""` | MySQL database hostname |
@@ -196,13 +203,13 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | serviceAccount.imagePullSecretNames | list | `[]` | Names of Secrets containing credentials to pull images from registries |
 | serviceAccount.automountServiceAccountToken | bool | `true` | Automatically mount service account token |
 | ingress.enabled | bool | `false` | Enable ingress for Agent Backend |
-| ingress.path | string | `"/"` | Path for the main ingress rule Note: this needs to be set to '/*' to be used with AWS ALB ingress controller |
-| ingress.defaultPathType | string | `"ImplementationSpecific"` | Default path type for the Ingress |
+| ingress.path | string | `""` | Path for the main ingress rule. When empty, falls back to `global.ingress.path` |
+| ingress.defaultPathType | string | `""` | Default path type for the Ingress. When empty, falls back to `global.ingress.defaultPathType` |
 | ingress.defaultBackend | object | `{}` | Configure the default service for the ingress (evaluated as template) Important: make sure only one defaultBackend is defined across the k8s cluster: if the ingress doesn't reconcile successfully, 'describe ingress <name>' will report problems |
 | ingress.extraHosts | list | `[]` | Additional hosts you want to include. Evaluated as a template |
 | ingress.annotations | object | `{}` | Ingress annotations specific to your load balancer. Evaluated as a template |
 | ingress.extraLabels | object | `{}` | Additional labels for the ingress object. Evaluated as a template |
-| ingress.ingressClassName | string | `""` | Name of the ingress class (replaces the deprecated annotation `kubernetes.io/ingress.class`) |
+| ingress.ingressClassName | string | `""` | Name of the ingress class (replaces the deprecated annotation `kubernetes.io/ingress.class`). When empty, falls back to `global.ingress.ingressClassName` |
 | ingress.tls | list | `[]` | TLS configuration. Evaluated as a template |
 | extraDeploy | list | `[]` | Array of extra objects to deploy with the release |
 | commonAnnotations | object | `{}` | Annotations to add to all deployed objects |

--- a/charts/platform/charts/agent-backend/README.md
+++ b/charts/platform/charts/agent-backend/README.md
@@ -2,7 +2,7 @@
 
 Backend service for Seqera CLI AI capabilities
 
-![Version: 0.4.9](https://img.shields.io/badge/Version-0.4.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 0.4.10](https://img.shields.io/badge/Version-0.4.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -14,6 +14,7 @@ The chart does not automatically define `cr.seqera.io` as the registry where to 
 
 The required values to set in order to have a working installation are:
 - The `.image` section to point to your container registry.
+- The Seqera Platform Service connection details under `.global.platformServiceAddress` and `.global.platformServicePort`. These point to the Platform backend service that the Agent Backend communicates with. When deploying this subchart as part of the parent `platform` umbrella chart, these values are inherited automatically from the parent chart's `global` section.
 - The database connection details for the MySQL database under the `.database` section.
 - The redis connection details under the `.redis` section.
 - The Bedrock AgentCore runtime ARN under the `.bedrockAgentCoreArn` section.
@@ -38,7 +39,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/agent-backend \
-  --version 0.4.9 \
+  --version 0.4.10 \
   --namespace my-namespace \
   --create-namespace
 ```
@@ -61,8 +62,8 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | global.platformExternalDomain | string | `"example.com"` | Domain where Seqera Platform listens |
-| global.platformServiceAddress | string | `"{{ printf \"%s-platform-backend\" .Release.Name | lower }}"` | Seqera Platform Service name: can be the internal Kubernetes hostname or an external ingress hostname. Evaluated as a template |
-| global.platformServicePort | int | `8080` | Seqera Platform Service port |
+| global.platformServiceAddress | string | `""` | Seqera Platform Service name: can be the internal Kubernetes hostname or an external ingress hostname. Evaluated as a template. Required when deploying this subchart standalone. When deploying as part of the parent `platform` umbrella chart, this value is inherited from the parent chart's `global` section |
+| global.platformServicePort | string | `""` | Seqera Platform Service port. Required when deploying this subchart standalone. When deploying as part of the parent `platform` umbrella chart, this value is inherited from the parent chart's `global` section |
 | global.agentBackendDomain | string | `"{{ printf \"ai-api.%s\" .Values.global.platformExternalDomain }}"` | Domain where the Agent Backend service listens. Evaluated as a template |
 | global.mcpDomain | string | `"{{ printf \"mcp.%s\" .Values.global.platformExternalDomain }}"` | Domain where Seqera MCP listens. Evaluated as a template |
 | global.imageCredentials | list | `[]` | Optional credentials to log in and fetch images from a private registry. These credentials are shared with all the subcharts automatically |

--- a/charts/platform/charts/agent-backend/README.md
+++ b/charts/platform/charts/agent-backend/README.md
@@ -2,7 +2,7 @@
 
 Backend service for Seqera CLI AI capabilities
 
-![Version: 0.4.10](https://img.shields.io/badge/Version-0.4.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 0.4.11](https://img.shields.io/badge/Version-0.4.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -39,7 +39,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/agent-backend \
-  --version 0.4.10 \
+  --version 0.4.11 \
   --namespace my-namespace \
   --create-namespace
 ```

--- a/charts/platform/charts/agent-backend/README.md.gotmpl
+++ b/charts/platform/charts/agent-backend/README.md.gotmpl
@@ -13,6 +13,7 @@ The chart does not automatically define `cr.seqera.io` as the registry where to 
 
 The required values to set in order to have a working installation are:
 - The `.image` section to point to your container registry.
+- The Seqera Platform Service connection details under `.global.platformServiceAddress` and `.global.platformServicePort`. These point to the Platform backend service that the Agent Backend communicates with. When deploying this subchart as part of the parent `platform` umbrella chart, these values are inherited automatically from the parent chart's `global` section.
 - The database connection details for the MySQL database under the `.database` section.
 - The redis connection details under the `.redis` section.
 - The Bedrock AgentCore runtime ARN under the `.bedrockAgentCoreArn` section.

--- a/charts/platform/charts/agent-backend/templates/NOTES.txt
+++ b/charts/platform/charts/agent-backend/templates/NOTES.txt
@@ -19,6 +19,16 @@
 
 {{/* We can't put checks in _helpers.tpl, it doesn't make installation fail. */}}
 
+{{- if not .Values.global.platformServiceAddress -}}
+{{- $message := "Define the Seqera Platform Service address at 'global.platformServiceAddress'. This must point to the Platform backend service (Kubernetes hostname or external ingress)." -}}
+{{- printf "\nVALUES VALIDATION:\n%s" $message | fail -}}
+{{- end -}}
+
+{{- if not .Values.global.platformServicePort -}}
+{{- $message := "Define the Seqera Platform Service port at 'global.platformServicePort'." -}}
+{{- printf "\nVALUES VALIDATION:\n%s" $message | fail -}}
+{{- end -}}
+
 {{- if not .Values.database.host -}}
 {{- $message := "Define the Agent Backend database host at 'database.host'." -}}
 {{- printf "\nVALUES VALIDATION:\n%s" $message | fail -}}

--- a/charts/platform/charts/agent-backend/templates/_helpers.tpl
+++ b/charts/platform/charts/agent-backend/templates/_helpers.tpl
@@ -126,3 +126,12 @@ Result is base64-encoded (for use in Secret data).
     {{- end -}}
   {{- end -}}
 {{- end -}}
+
+{{/*
+Return this chart's primary ingress hostname. See parent platform chart's `_helpers.tpl` for
+usage notes — `'{{ include "seqera.ingress.host" . }}'` in `global.ingress.annotations` resolves
+to each chart's own domain at render time.
+*/}}
+{{- define "seqera.ingress.host" -}}
+{{- tpl .Values.global.agentBackendDomain . -}}
+{{- end -}}

--- a/charts/platform/charts/agent-backend/templates/ingress.yaml
+++ b/charts/platform/charts/agent-backend/templates/ingress.yaml
@@ -17,12 +17,16 @@
  limitations under the License.
 */}}
 
-{{ if .Values.ingress.enabled }}
+{{ if or .Values.ingress.enabled .Values.global.ingress.enabled }}
   {{- $commonLabels := include "common.labels.standard" (dict "customLabels" .Values.commonLabels "context" $) | fromYaml -}}
-  {{- $mergedlabels := include "common.tplvalues.merge" (dict "values" (list .Values.ingress.extraLabels $commonLabels) "context" .) -}}
+  {{- $mergedlabels := include "common.tplvalues.merge" (dict "values" (list .Values.ingress.extraLabels .Values.global.ingress.extraLabels $commonLabels) "context" .) -}}
   {{- $labels := include "common.tplvalues.render" (dict "value" $mergedlabels "context" $) -}}
-  {{- $mergedAnnotations := include "common.tplvalues.merge" (dict "values" (list .Values.ingress.annotations .Values.commonAnnotations) "context" .) -}}
+  {{- $mergedAnnotations := include "common.tplvalues.merge" (dict "values" (list .Values.ingress.annotations .Values.global.ingress.annotations .Values.commonAnnotations) "context" .) -}}
   {{- $annotations := include "common.tplvalues.render" (dict "value" $mergedAnnotations "context" $) -}}
+  {{- $defaultPathType := default .Values.global.ingress.defaultPathType .Values.ingress.defaultPathType -}}
+  {{- $path := default .Values.global.ingress.path .Values.ingress.path -}}
+  {{- $ingressClassName := default .Values.global.ingress.ingressClassName .Values.ingress.ingressClassName -}}
+  {{- $tls := concat (default (list) .Values.ingress.tls) (default (list) .Values.global.ingress.tls) -}}
 
 apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress
@@ -36,11 +40,11 @@ spec:
   defaultBackend: {{- include "seqera.tplvalues.render" (dict "value" . "context" $) | nindent 4 }}
   {{- end }}
 
-  {{- if .Values.ingress.ingressClassName }}
-  ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
+  {{- if $ingressClassName }}
+  ingressClassName: {{ $ingressClassName | quote }}
   {{- end }}
 
-  {{- with .Values.ingress.tls }}
+  {{- with $tls }}
   tls: {{- include "common.tplvalues.render" (dict "value" . "context" $) | nindent 4 }}
   {{- end }}
 
@@ -49,8 +53,8 @@ spec:
     - host: {{ tpl .Values.global.agentBackendDomain . | quote }}
       http:
         paths:
-          - path: {{ .Values.ingress.path | quote }}
-            pathType: {{ .Values.ingress.defaultPathType }}
+          - path: {{ $path | quote }}
+            pathType: {{ $defaultPathType }}
             backend:
               service:
                 name: {{ (include "common.names.fullname" .) | quote }}
@@ -62,7 +66,7 @@ spec:
         paths:
     {{- range .paths }}
           - path: {{ .path }}
-            pathType: {{ .pathType | default $.Values.ingress.defaultPathType }}
+            pathType: {{ .pathType | default $defaultPathType }}
             backend:
               service:
                 name: {{ tpl .serviceName $ | quote }}

--- a/charts/platform/charts/agent-backend/tests/NOTES_test.yaml
+++ b/charts/platform/charts/agent-backend/tests/NOTES_test.yaml
@@ -24,9 +24,43 @@ chart:
   version: 1.0.0
   appVersion: "v1.0.0"
 tests:
+  # Platform Service connection tests
+  - it: should fail when global.platformServiceAddress is not defined
+    set:
+      global:
+        platformServiceAddress: ""
+        platformServicePort: 8080
+      database:
+        host: "database.example.com"
+        name: "agent_backend"
+        username: "agent"
+        password: "test-password"
+      anthropicApiKey: "test-anthropic-key"
+    asserts:
+      - failedTemplate:
+          errorPattern: "Define the Seqera Platform Service address at 'global.platformServiceAddress'"
+
+  - it: should fail when global.platformServicePort is not defined
+    set:
+      global:
+        platformServiceAddress: "platform-backend"
+        platformServicePort: ""
+      database:
+        host: "database.example.com"
+        name: "agent_backend"
+        username: "agent"
+        password: "test-password"
+      anthropicApiKey: "test-anthropic-key"
+    asserts:
+      - failedTemplate:
+          errorPattern: "Define the Seqera Platform Service port at 'global.platformServicePort'"
+
   # Database host tests
   - it: should fail when database.host is not defined
     set:
+      global:
+        platformServiceAddress: "platform-backend"
+        platformServicePort: 8080
       database:
         host: ""
         name: "agent_backend"
@@ -39,6 +73,9 @@ tests:
 
   - it: should fail when database.host is missing
     set:
+      global:
+        platformServiceAddress: "platform-backend"
+        platformServicePort: 8080
       database:
         name: "agent_backend"
         username: "agent"
@@ -51,6 +88,9 @@ tests:
   # Database name tests
   - it: should fail when database.name is not defined
     set:
+      global:
+        platformServiceAddress: "platform-backend"
+        platformServicePort: 8080
       database:
         host: "database.example.com"
         name: ""
@@ -63,6 +103,9 @@ tests:
 
   - it: should fail when database.name is missing
     set:
+      global:
+        platformServiceAddress: "platform-backend"
+        platformServicePort: 8080
       database:
         host: "database.example.com"
         username: "agent"
@@ -75,6 +118,9 @@ tests:
   # Database username tests
   - it: should fail when database.username is not defined
     set:
+      global:
+        platformServiceAddress: "platform-backend"
+        platformServicePort: 8080
       database:
         host: "database.example.com"
         name: "agent_backend"
@@ -87,6 +133,9 @@ tests:
 
   - it: should fail when database.username is missing
     set:
+      global:
+        platformServiceAddress: "platform-backend"
+        platformServicePort: 8080
       database:
         host: "database.example.com"
         name: "agent_backend"
@@ -99,6 +148,9 @@ tests:
   # Database password tests
   - it: should fail when database.password is not defined and no existingSecretName
     set:
+      global:
+        platformServiceAddress: "platform-backend"
+        platformServicePort: 8080
       database:
         host: "database.example.com"
         name: "agent_backend"
@@ -112,6 +164,9 @@ tests:
 
   - it: should fail when both database.password and database.existingSecretName are defined
     set:
+      global:
+        platformServiceAddress: "platform-backend"
+        platformServicePort: 8080
       database:
         host: "database.example.com"
         name: "agent_backend"
@@ -125,6 +180,9 @@ tests:
 
   - it: should pass when only database.password is set
     set:
+      global:
+        platformServiceAddress: "platform-backend"
+        platformServicePort: 8080
       database:
         host: "database.example.com"
         name: "agent_backend"
@@ -140,6 +198,9 @@ tests:
 
   - it: should pass when only database.existingSecretName is set
     set:
+      global:
+        platformServiceAddress: "platform-backend"
+        platformServicePort: 8080
       database:
         host: "database.example.com"
         name: "agent_backend"
@@ -156,6 +217,9 @@ tests:
   # Anthropic API key tests
   - it: should fail when anthropicApiKey is not defined and no existingSecretName
     set:
+      global:
+        platformServiceAddress: "platform-backend"
+        platformServicePort: 8080
       database:
         host: "database.example.com"
         name: "agent_backend"
@@ -169,6 +233,9 @@ tests:
 
   - it: should fail when both anthropicApiKey and anthropicApiKeyExistingSecretName are defined
     set:
+      global:
+        platformServiceAddress: "platform-backend"
+        platformServicePort: 8080
       database:
         host: "database.example.com"
         name: "agent_backend"
@@ -182,6 +249,9 @@ tests:
 
   - it: should pass when only anthropicApiKey is set
     set:
+      global:
+        platformServiceAddress: "platform-backend"
+        platformServicePort: 8080
       database:
         host: "database.example.com"
         name: "agent_backend"
@@ -197,6 +267,9 @@ tests:
 
   - it: should pass when only anthropicApiKeyExistingSecretName is set
     set:
+      global:
+        platformServiceAddress: "platform-backend"
+        platformServicePort: 8080
       database:
         host: "database.example.com"
         name: "agent_backend"
@@ -213,6 +286,9 @@ tests:
   # Redis host tests
   - it: should fail when redis.host is not defined
     set:
+      global:
+        platformServiceAddress: "platform-backend"
+        platformServicePort: 8080
       database:
         host: "database.example.com"
         name: "agent_backend"
@@ -227,6 +303,9 @@ tests:
 
   - it: should fail when both redis.password and redis.existingSecretName are defined
     set:
+      global:
+        platformServiceAddress: "platform-backend"
+        platformServicePort: 8080
       database:
         host: "database.example.com"
         name: "agent_backend"
@@ -244,6 +323,9 @@ tests:
   # Bedrock AgentCore ARN tests
   - it: should fail when bedrockAgentCoreArn is not defined
     set:
+      global:
+        platformServiceAddress: "platform-backend"
+        platformServicePort: 8080
       database:
         host: "database.example.com"
         name: "agent_backend"
@@ -258,6 +340,9 @@ tests:
 
   - it: should fail when bedrockAgentCoreArn is missing
     set:
+      global:
+        platformServiceAddress: "platform-backend"
+        platformServicePort: 8080
       database:
         host: "database.example.com"
         name: "agent_backend"
@@ -272,6 +357,9 @@ tests:
   # Bedrock embeddings configuration tests
   - it: should fail when embeddings.bedrock.region is not defined
     set:
+      global:
+        platformServiceAddress: "platform-backend"
+        platformServicePort: 8080
       database:
         host: "database.example.com"
         name: "agent_backend"
@@ -287,6 +375,9 @@ tests:
 
   - it: should fail when embeddings.bedrock.modelId is not defined
     set:
+      global:
+        platformServiceAddress: "platform-backend"
+        platformServicePort: 8080
       database:
         host: "database.example.com"
         name: "agent_backend"
@@ -303,6 +394,9 @@ tests:
 
   - it: should fail when embeddings.bedrock.dimensions is not defined
     set:
+      global:
+        platformServiceAddress: "platform-backend"
+        platformServicePort: 8080
       database:
         host: "database.example.com"
         name: "agent_backend"
@@ -319,6 +413,9 @@ tests:
 
   - it: should pass when all embeddings.bedrock values are set
     set:
+      global:
+        platformServiceAddress: "platform-backend"
+        platformServicePort: 8080
       database:
         host: "database.example.com"
         name: "agent_backend"
@@ -337,6 +434,9 @@ tests:
   # Complete valid configuration test
   - it: should pass with all required values properly set
     set:
+      global:
+        platformServiceAddress: "platform-backend"
+        platformServicePort: 8080
       database:
         host: "database.example.com"
         name: "agent_backend"
@@ -353,6 +453,9 @@ tests:
   # Valid configuration with external secrets
   - it: should pass with all required values using external secrets
     set:
+      global:
+        platformServiceAddress: "platform-backend"
+        platformServicePort: 8080
       database:
         host: "database.example.com"
         name: "agent_backend"

--- a/charts/platform/charts/agent-backend/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/platform/charts/agent-backend/tests/__snapshot__/deployment_test.yaml.snap
@@ -129,7 +129,7 @@ should render a Deployment with default values:
                 - sh
                 - -c
                 - |
-                  echo "$(date): starting check redis '$REDIS_URI' (auth ${REDISCLI_AUTH:+set})"
+                  if [ -n "$REDISCLI_AUTH" ]; then echo "$(date): starting check redis '$REDIS_URI' (auth set)"; else echo "$(date): starting check redis '$REDIS_URI' (auth not set)"; fi
                   until redis-cli -u "$REDIS_URI" get hello; do
                     echo "$(date): see you in $SLEEP_PERIOD_SECONDS seconds"
                     sleep $SLEEP_PERIOD_SECONDS

--- a/charts/platform/charts/agent-backend/tests/__snapshot__/ingress_test.yaml.snap
+++ b/charts/platform/charts/agent-backend/tests/__snapshot__/ingress_test.yaml.snap
@@ -23,7 +23,7 @@ should render when ingress.enabled is true:
                     port:
                       number: 80
                 path: /
-                pathType: ImplementationSpecific
+                pathType: Prefix
         - host: agent.example.com
           http:
             paths:
@@ -33,4 +33,4 @@ should render when ingress.enabled is true:
                     port:
                       number: 8002
                 path: /
-                pathType: ImplementationSpecific
+                pathType: Prefix

--- a/charts/platform/charts/agent-backend/tests/configmap_test.yaml
+++ b/charts/platform/charts/agent-backend/tests/configmap_test.yaml
@@ -27,6 +27,8 @@ tests:
   - it: should render a ConfigMap with default values
     set:
       global.platformExternalDomain: test.example.com
+      global.platformServiceAddress: '{{ printf "%s-platform-backend" .Release.Name | lower }}'
+      global.platformServicePort: 8080
       global.mcpDomain: mcp.test.example.com
       database.host: mysql.default.svc.cluster.local
       database.name: agentdb

--- a/charts/platform/charts/agent-backend/tests/deployment_test.yaml
+++ b/charts/platform/charts/agent-backend/tests/deployment_test.yaml
@@ -29,6 +29,8 @@ tests:
   - it: should render a Deployment with default values
     template: deployment.yaml
     set:
+      global.platformServiceAddress: '{{ printf "%s-platform-backend" .Release.Name | lower }}'
+      global.platformServicePort: 8080
       database.password: test-db-password
       anthropicApiKey: test-anthropic-key
       tokenEncryptionKey: test-token-encryption-key

--- a/charts/platform/charts/agent-backend/values.yaml
+++ b/charts/platform/charts/agent-backend/values.yaml
@@ -22,10 +22,14 @@ global:
   platformExternalDomain: example.com
 
   # -- Seqera Platform Service name: can be the internal Kubernetes hostname or an external ingress
-  # hostname. Evaluated as a template
-  platformServiceAddress: '{{ printf "%s-platform-backend" .Release.Name | lower }}'
-  # -- Seqera Platform Service port
-  platformServicePort: 8080
+  # hostname. Evaluated as a template.
+  # Required when deploying this subchart standalone. When deploying as part of the parent
+  # `platform` umbrella chart, this value is inherited from the parent chart's `global` section
+  platformServiceAddress: ""
+  # -- Seqera Platform Service port.
+  # Required when deploying this subchart standalone. When deploying as part of the parent
+  # `platform` umbrella chart, this value is inherited from the parent chart's `global` section
+  platformServicePort: ""
 
   # -- Domain where the Agent Backend service listens. Evaluated as a template
   agentBackendDomain: '{{ printf "ai-api.%s" .Values.global.platformExternalDomain }}'

--- a/charts/platform/charts/agent-backend/values.yaml
+++ b/charts/platform/charts/agent-backend/values.yaml
@@ -37,6 +37,29 @@ global:
   # -- Domain where Seqera MCP listens. Evaluated as a template
   mcpDomain: '{{ printf "mcp.%s" .Values.global.platformExternalDomain }}'
 
+  # Ingress defaults shared across the parent chart and all subcharts. Each subchart's local
+  # `ingress.*` value takes precedence when set; otherwise the global is used.
+  ingress:
+    # -- Enable Ingress for this chart. OR'd with the chart's local `ingress.enabled` so
+    # setting this once at the parent enables all subchart Ingresses.
+    enabled: false
+    # -- Default path applied to ingress rules when `ingress.path` is not set.
+    # AWS ALB users should override to `/*`.
+    path: "/"
+    # -- Default path type applied to ingress rules when `ingress.defaultPathType` is not set.
+    # `Prefix` works for nginx, traefik, AWS ALB, and most modern controllers.
+    defaultPathType: "Prefix"
+    # -- Default ingress class name applied when `ingress.ingressClassName` is not set
+    ingressClassName: ""
+    # -- Annotations merged into the Ingress. Local `ingress.annotations` wins on key collision.
+    # Evaluated as a template
+    annotations: {}
+    # -- Extra labels merged into the Ingress. Local `ingress.extraLabels` wins on key collision.
+    # Evaluated as a template
+    extraLabels: {}
+    # -- TLS entries concatenated with the local `ingress.tls`. Evaluated as a template
+    tls: []
+
   # -- Optional credentials to log in and fetch images from a private registry. These credentials
   # are shared with all the subcharts automatically
   imageCredentials: []
@@ -486,12 +509,11 @@ ingress:
   # -- Enable ingress for Agent Backend
   enabled: false
 
-  # -- Path for the main ingress rule
-  # Note: this needs to be set to '/*' to be used with AWS ALB ingress controller
-  path: "/"
+  # -- Path for the main ingress rule. When empty, falls back to `global.ingress.path`
+  path: ""
 
-  # -- Default path type for the Ingress
-  defaultPathType: "ImplementationSpecific"
+  # -- Default path type for the Ingress. When empty, falls back to `global.ingress.defaultPathType`
+  defaultPathType: ""
 
   # -- Configure the default service for the ingress (evaluated as template)
   # Important: make sure only one defaultBackend is defined across the k8s cluster: if the
@@ -523,7 +545,8 @@ ingress:
   annotations: {}
   # -- Additional labels for the ingress object. Evaluated as a template
   extraLabels: {}
-  # -- Name of the ingress class (replaces the deprecated annotation `kubernetes.io/ingress.class`)
+  # -- Name of the ingress class (replaces the deprecated annotation `kubernetes.io/ingress.class`).
+  # When empty, falls back to `global.ingress.ingressClassName`
   ingressClassName: ""
   # -- TLS configuration. Evaluated as a template
   tls: []

--- a/charts/platform/charts/mcp/CHANGELOG.md
+++ b/charts/platform/charts/mcp/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.6] - 2026-04-30
+
+### Changed
+
+- Bump `seqera-common` dependency to 2.1.2 (Redis init container log message now reports `auth set` or `auth not set`)
+
 ## [0.3.5] - 2026-04-30
 
 ### Changed

--- a/charts/platform/charts/mcp/CHANGELOG.md
+++ b/charts/platform/charts/mcp/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.5] - 2026-04-30
+
+### Changed
+
+- Clear the default values for `global.platformServiceAddress` and `global.platformServicePort` so they must be explicitly set when deploying this subchart standalone. They point to the Seqera Platform backend service. When deploying as part of the parent `platform` umbrella chart, these values are inherited automatically from the parent chart's `global` section
+- Add `NOTES.txt` validation that fails the installation when `global.platformServiceAddress` or `global.platformServicePort` are not set
+- Document the Platform Service connection details as a required configuration in the README
+
 ## [0.3.4] - 2026-04-30
 
 ### Changed

--- a/charts/platform/charts/mcp/CHANGELOG.md
+++ b/charts/platform/charts/mcp/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-05-05
+
+- **Enhancement**: allow global configuration of Ingress options. A new `global.ingress` block (`enabled`, `path`, `defaultPathType`, `ingressClassName`, `annotations`, `extraLabels`, `tls`) lets cluster-wide Ingress defaults be set once at the parent and propagate to every subchart, removing the need to repeat controller-wide config per subchart. `enabled` is OR-merged; scalar fields fall back to global when local is unset; `annotations` and `extraLabels` are merged with local winning on key collision; `tls` is concatenated (useful for a single wildcard certificate across all services).
+- Add `seqera.ingress.host` template helper in each chart's `_helpers.tpl` returning that chart's primary domain. Lets users write `external-dns.alpha.kubernetes.io/hostname: '{{ include "seqera.ingress.host" . }}'` once in `global.ingress.annotations` and have it resolve to the correct host per chart at render time, without hard-coding hostnames.
+- Add `docs/conventions/ingress.md` documenting the Ingress conventions used across charts.
+
+### Changed
+
+- Update bitnami/common to 2.39.0
+- **BREAKING**: Default `ingress.defaultPathType` is now `Prefix` (was `ImplementationSpecific`). With the previous default and the chart's default `path: "/"`, routing behavior depended on the ingress controller — NGINX treated it as a prefix match, AWS ALB required `/*` for the same effect, GKE applied its own interpretation. The result was the same chart and values producing different routing across clusters. `Prefix` is part of the Kubernetes Ingress spec and produces consistent prefix-match semantics across NGINX, Traefik, AWS ALB, and most modern controllers, giving users a predictable out-of-the-box experience. Users whose controller still requires `ImplementationSpecific` (e.g. older GKE) can set `global.ingress.defaultPathType: ImplementationSpecific` once at the parent.
+
 ## [0.3.6] - 2026-04-30
 
 ### Changed

--- a/charts/platform/charts/mcp/Chart.lock
+++ b/charts/platform/charts/mcp/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.38.0
+  version: 2.39.0
 - name: seqera-common
   repository: file://../../../seqera-common
   version: 2.1.2
-digest: sha256:66f5f1fb1ad2a6fd814da84d51f11c2a3f10633e1ba8d23f72eab6294ab68d49
-generated: "2026-04-30T17:18:10.359219514+02:00"
+digest: sha256:b66829bad11b646116b1ac6fc712849c4231dfbb6641380100f3282e06ab9a39
+generated: "2026-05-05T14:17:42.984593108+02:00"

--- a/charts/platform/charts/mcp/Chart.lock
+++ b/charts/platform/charts/mcp/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 2.38.0
 - name: seqera-common
   repository: file://../../../seqera-common
-  version: 2.1.1
-digest: sha256:ce02e7a0f1f7ded086daa13cd2fd8d6850f75f7984f14d06dfe35d729924ff2d
-generated: "2026-04-30T15:38:40.11341971+02:00"
+  version: 2.1.2
+digest: sha256:66f5f1fb1ad2a6fd814da84d51f11c2a3f10633e1ba8d23f72eab6294ab68d49
+generated: "2026-04-30T17:18:10.359219514+02:00"

--- a/charts/platform/charts/mcp/Chart.yaml
+++ b/charts/platform/charts/mcp/Chart.yaml
@@ -22,7 +22,7 @@ description: |
   Wave container provisioning, bioinformatics data, and nf-core modules through intelligent
   RAG-based natural language interactions.
 type: application
-version: 0.3.6
+version: 0.4.0
 appVersion: "1.1.0"
 maintainers:
   - name: Seqera Labs

--- a/charts/platform/charts/mcp/Chart.yaml
+++ b/charts/platform/charts/mcp/Chart.yaml
@@ -22,7 +22,7 @@ description: |
   Wave container provisioning, bioinformatics data, and nf-core modules through intelligent
   RAG-based natural language interactions.
 type: application
-version: 0.3.4
+version: 0.3.5
 appVersion: "1.1.0"
 maintainers:
   - name: Seqera Labs

--- a/charts/platform/charts/mcp/Chart.yaml
+++ b/charts/platform/charts/mcp/Chart.yaml
@@ -22,7 +22,7 @@ description: |
   Wave container provisioning, bioinformatics data, and nf-core modules through intelligent
   RAG-based natural language interactions.
 type: application
-version: 0.3.5
+version: 0.3.6
 appVersion: "1.1.0"
 maintainers:
   - name: Seqera Labs

--- a/charts/platform/charts/mcp/README.md
+++ b/charts/platform/charts/mcp/README.md
@@ -4,7 +4,7 @@ A Model Context Protocol (MCP) server that provides comprehensive access to the 
 Wave container provisioning, bioinformatics data, and nf-core modules through intelligent
 RAG-based natural language interactions.
 
-![Version: 0.3.4](https://img.shields.io/badge/Version-0.3.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
+![Version: 0.3.5](https://img.shields.io/badge/Version-0.3.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -16,6 +16,7 @@ The chart does not automatically define `cr.seqera.io` as the registry where to 
 
 The required values to set in order to have a working installation are:
 - The domain where Seqera Platform is accessible, set under `.global.platformExternalDomain`. The MCP domain defaults to `mcp.<platformExternalDomain>` but can be overridden with `.global.mcpDomain`.
+- The Seqera Platform Service connection details under `.global.platformServiceAddress` and `.global.platformServicePort`. These point to the Platform backend service that MCP communicates with. When deploying this subchart as part of the parent `platform` umbrella chart, these values are inherited automatically from the parent chart's `global` section.
 - The OIDC client registration token under `.oidcToken.tokenString` (or reference an existing Secret with `.oidcToken.existingSecretName`). When deploying as part of the platform parent chart this is set automatically; when deploying standalone it must match the value configured in the platform backend.
 - A stable JWT seed for signing authentication tokens under `.oauth.jwtSeedString` (or reference an existing Secret with `.oauth.jwtSeedSecretName`). If not set a random value is generated, which is incompatible with Kustomize-based upgrades.
 - Container registry credentials under the `.global.imageCredentials` section (can be the credentials for cr.seqera.io or your private registry where you vendored the images to).
@@ -37,7 +38,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/mcp \
-  --version 0.3.4 \
+  --version 0.3.5 \
   --namespace my-namespace \
   --create-namespace
 ```
@@ -60,8 +61,8 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | global.platformExternalDomain | string | `"example.com"` | Domain where Seqera Platform listens |
-| global.platformServiceAddress | string | `"{{ printf \"%s-platform-backend\" .Release.Name | lower }}"` | Seqera Platform Service name: can be the internal Kubernetes hostname or an external ingress hostname. Evaluated as a template |
-| global.platformServicePort | int | `8080` | Seqera Platform Service port |
+| global.platformServiceAddress | string | `""` | Seqera Platform Service name: can be the internal Kubernetes hostname or an external ingress hostname. Evaluated as a template. Required when deploying this subchart standalone. When deploying as part of the parent `platform` umbrella chart, this value is inherited from the parent chart's `global` section |
+| global.platformServicePort | string | `""` | Seqera Platform Service port. Required when deploying this subchart standalone. When deploying as part of the parent `platform` umbrella chart, this value is inherited from the parent chart's `global` section |
 | global.mcpDomain | string | `"{{ printf \"mcp.%s\" .Values.global.platformExternalDomain }}"` | Domain where Seqera MCP listens. Evaluated as a template. Note: The OAuth redirect URL is automatically derived by appending /oauth/callback to the domain |
 | global.imageCredentials | list | `[]` | Optional credentials to log in and fetch images from a private registry. These credentials are shared with all the subcharts automatically |
 | global.imageCredentialsSecrets | list | `[]` | Optional list of existing Secrets containing image pull credentials to use for pulling images from private registries. These Secrets are shared with all the subcharts automatically |

--- a/charts/platform/charts/mcp/README.md
+++ b/charts/platform/charts/mcp/README.md
@@ -4,7 +4,7 @@ A Model Context Protocol (MCP) server that provides comprehensive access to the 
 Wave container provisioning, bioinformatics data, and nf-core modules through intelligent
 RAG-based natural language interactions.
 
-![Version: 0.3.5](https://img.shields.io/badge/Version-0.3.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
+![Version: 0.3.6](https://img.shields.io/badge/Version-0.3.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -38,7 +38,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/mcp \
-  --version 0.3.5 \
+  --version 0.3.6 \
   --namespace my-namespace \
   --create-namespace
 ```

--- a/charts/platform/charts/mcp/README.md
+++ b/charts/platform/charts/mcp/README.md
@@ -4,7 +4,7 @@ A Model Context Protocol (MCP) server that provides comprehensive access to the 
 Wave container provisioning, bioinformatics data, and nf-core modules through intelligent
 RAG-based natural language interactions.
 
-![Version: 0.3.6](https://img.shields.io/badge/Version-0.3.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
+![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -38,7 +38,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/mcp \
-  --version 0.3.6 \
+  --version 0.4.0 \
   --namespace my-namespace \
   --create-namespace
 ```
@@ -64,6 +64,13 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | global.platformServiceAddress | string | `""` | Seqera Platform Service name: can be the internal Kubernetes hostname or an external ingress hostname. Evaluated as a template. Required when deploying this subchart standalone. When deploying as part of the parent `platform` umbrella chart, this value is inherited from the parent chart's `global` section |
 | global.platformServicePort | string | `""` | Seqera Platform Service port. Required when deploying this subchart standalone. When deploying as part of the parent `platform` umbrella chart, this value is inherited from the parent chart's `global` section |
 | global.mcpDomain | string | `"{{ printf \"mcp.%s\" .Values.global.platformExternalDomain }}"` | Domain where Seqera MCP listens. Evaluated as a template. Note: The OAuth redirect URL is automatically derived by appending /oauth/callback to the domain |
+| global.ingress.enabled | bool | `false` | Enable Ingress for this chart. OR'd with the chart's local `ingress.enabled` so setting this once at the parent enables all subchart Ingresses. |
+| global.ingress.path | string | `"/"` | Default path applied to ingress rules when `ingress.path` is not set. AWS ALB users should override to `/*`. |
+| global.ingress.defaultPathType | string | `"Prefix"` | Default path type applied to ingress rules when `ingress.defaultPathType` is not set. `Prefix` works for nginx, traefik, AWS ALB, and most modern controllers. |
+| global.ingress.ingressClassName | string | `""` | Default ingress class name applied when `ingress.ingressClassName` is not set |
+| global.ingress.annotations | object | `{}` | Annotations merged into the Ingress. Local `ingress.annotations` wins on key collision. Evaluated as a template |
+| global.ingress.extraLabels | object | `{}` | Extra labels merged into the Ingress. Local `ingress.extraLabels` wins on key collision. Evaluated as a template |
+| global.ingress.tls | list | `[]` | TLS entries concatenated with the local `ingress.tls`. Evaluated as a template |
 | global.imageCredentials | list | `[]` | Optional credentials to log in and fetch images from a private registry. These credentials are shared with all the subcharts automatically |
 | global.imageCredentialsSecrets | list | `[]` | Optional list of existing Secrets containing image pull credentials to use for pulling images from private registries. These Secrets are shared with all the subcharts automatically |
 | micronautEnvironments | list | `["oauth-platform"]` | List of Micronaut environments to enable. Evaluated as a template |
@@ -156,13 +163,13 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | serviceAccount.imagePullSecretNames | list | `[]` | Names of Secrets containing credentials to pull images from registries |
 | serviceAccount.automountServiceAccountToken | bool | `true` | Automatically mount service account token |
 | ingress.enabled | bool | `false` | Enable ingress for MCP |
-| ingress.path | string | `"/"` | Path for the main ingress rule Note: this needs to be set to '/*' to be used with AWS ALB ingress controller |
-| ingress.defaultPathType | string | `"ImplementationSpecific"` | Default path type for the Ingress |
+| ingress.path | string | `""` | Path for the main ingress rule. When empty, falls back to `global.ingress.path` |
+| ingress.defaultPathType | string | `""` | Default path type for the Ingress. When empty, falls back to `global.ingress.defaultPathType` |
 | ingress.defaultBackend | object | `{}` | Configure the default service for the ingress (evaluated as template) Important: make sure only one defaultBackend is defined across the k8s cluster: if the ingress doesn't reconcile successfully, 'describe ingress <name>' will report problems |
 | ingress.extraHosts | list | `[]` | Additional hosts you want to include. Evaluated as a template |
 | ingress.annotations | object | `{}` | Ingress annotations specific to your load balancer. Evaluated as a template |
 | ingress.extraLabels | object | `{}` | Additional labels for the ingress object. Evaluated as a template |
-| ingress.ingressClassName | string | `""` | Name of the ingress class (replaces the deprecated annotation `kubernetes.io/ingress.class`) |
+| ingress.ingressClassName | string | `""` | Name of the ingress class (replaces the deprecated annotation `kubernetes.io/ingress.class`). When empty, falls back to `global.ingress.ingressClassName` |
 | ingress.tls | list | `[]` | TLS configuration. Evaluated as a template |
 | extraDeploy | list | `[]` | Array of extra objects to deploy with the release |
 | commonAnnotations | object | `{}` | Annotations to add to all deployed objects |

--- a/charts/platform/charts/mcp/README.md.gotmpl
+++ b/charts/platform/charts/mcp/README.md.gotmpl
@@ -13,6 +13,7 @@ The chart does not automatically define `cr.seqera.io` as the registry where to 
 
 The required values to set in order to have a working installation are:
 - The domain where Seqera Platform is accessible, set under `.global.platformExternalDomain`. The MCP domain defaults to `mcp.<platformExternalDomain>` but can be overridden with `.global.mcpDomain`.
+- The Seqera Platform Service connection details under `.global.platformServiceAddress` and `.global.platformServicePort`. These point to the Platform backend service that MCP communicates with. When deploying this subchart as part of the parent `platform` umbrella chart, these values are inherited automatically from the parent chart's `global` section.
 - The OIDC client registration token under `.oidcToken.tokenString` (or reference an existing Secret with `.oidcToken.existingSecretName`). When deploying as part of the platform parent chart this is set automatically; when deploying standalone it must match the value configured in the platform backend.
 - A stable JWT seed for signing authentication tokens under `.oauth.jwtSeedString` (or reference an existing Secret with `.oauth.jwtSeedSecretName`). If not set a random value is generated, which is incompatible with Kustomize-based upgrades.
 - Container registry credentials under the `.global.imageCredentials` section (can be the credentials for cr.seqera.io or your private registry where you vendored the images to).

--- a/charts/platform/charts/mcp/templates/NOTES.txt
+++ b/charts/platform/charts/mcp/templates/NOTES.txt
@@ -19,6 +19,16 @@
 
 {{/* We can't put checks in _helpers.tpl, it doesn't make installation fail. */}}
 
+{{- if not .Values.global.platformServiceAddress -}}
+{{- $message := "Define the Seqera Platform Service address at 'global.platformServiceAddress'. This must point to the Platform backend service (Kubernetes hostname or external ingress)." -}}
+{{- printf "\nVALUES VALIDATION:\n%s" $message | fail -}}
+{{- end -}}
+
+{{- if not .Values.global.platformServicePort -}}
+{{- $message := "Define the Seqera Platform Service port at 'global.platformServicePort'." -}}
+{{- printf "\nVALUES VALIDATION:\n%s" $message | fail -}}
+{{- end -}}
+
 {{- if and .Values.oauth.jwtSeedString .Values.oauth.jwtSeedSecretName -}}
 {{- $message := "Either provide 'oauth.jwtSeedString' or an existing secret name in 'oauth.jwtSeedSecretName', but not both." -}}
 {{- printf "\nVALUES VALIDATION:\n%s" $message | fail -}}

--- a/charts/platform/charts/mcp/templates/_helpers.tpl
+++ b/charts/platform/charts/mcp/templates/_helpers.tpl
@@ -71,3 +71,12 @@ Return the name of the secret containing the OIDC client registration token.
     {{- printf "MCP_OAUTH_INITIAL_ACCESS_TOKEN" -}}
   {{- end -}}
 {{- end -}}
+
+{{/*
+Return this chart's primary ingress hostname. See parent platform chart's `_helpers.tpl` for
+usage notes — `'{{ include "seqera.ingress.host" . }}'` in `global.ingress.annotations` resolves
+to each chart's own domain at render time.
+*/}}
+{{- define "seqera.ingress.host" -}}
+{{- tpl .Values.global.mcpDomain . -}}
+{{- end -}}

--- a/charts/platform/charts/mcp/templates/ingress.yaml
+++ b/charts/platform/charts/mcp/templates/ingress.yaml
@@ -17,12 +17,16 @@
  limitations under the License.
 */}}
 
-{{ if .Values.ingress.enabled }}
+{{ if or .Values.ingress.enabled .Values.global.ingress.enabled }}
   {{- $commonLabels := include "common.labels.standard" (dict "customLabels" .Values.commonLabels "context" $) | fromYaml -}}
-  {{- $mergedlabels := include "common.tplvalues.merge" (dict "values" (list .Values.ingress.extraLabels $commonLabels) "context" .) -}}
+  {{- $mergedlabels := include "common.tplvalues.merge" (dict "values" (list .Values.ingress.extraLabels .Values.global.ingress.extraLabels $commonLabels) "context" .) -}}
   {{- $labels := include "common.tplvalues.render" (dict "value" $mergedlabels "context" $) -}}
-  {{- $mergedAnnotations := include "common.tplvalues.merge" (dict "values" (list .Values.ingress.annotations .Values.commonAnnotations) "context" .) -}}
+  {{- $mergedAnnotations := include "common.tplvalues.merge" (dict "values" (list .Values.ingress.annotations .Values.global.ingress.annotations .Values.commonAnnotations) "context" .) -}}
   {{- $annotations := include "common.tplvalues.render" (dict "value" $mergedAnnotations "context" $) -}}
+  {{- $defaultPathType := default .Values.global.ingress.defaultPathType .Values.ingress.defaultPathType -}}
+  {{- $path := default .Values.global.ingress.path .Values.ingress.path -}}
+  {{- $ingressClassName := default .Values.global.ingress.ingressClassName .Values.ingress.ingressClassName -}}
+  {{- $tls := concat (default (list) .Values.ingress.tls) (default (list) .Values.global.ingress.tls) -}}
 
 apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress
@@ -36,11 +40,11 @@ spec:
   defaultBackend: {{- include "seqera.tplvalues.render" (dict "value" . "context" $) | nindent 4 }}
   {{- end }}
 
-  {{- if .Values.ingress.ingressClassName }}
-  ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
+  {{- if $ingressClassName }}
+  ingressClassName: {{ $ingressClassName | quote }}
   {{- end }}
 
-  {{- with .Values.ingress.tls }}
+  {{- with $tls }}
   tls: {{- include "common.tplvalues.render" (dict "value" . "context" $) | nindent 4 }}
   {{- end }}
 
@@ -49,8 +53,8 @@ spec:
     - host: {{ tpl .Values.global.mcpDomain . | quote }}
       http:
         paths:
-          - path: {{ .Values.ingress.path | quote }}
-            pathType: {{ .Values.ingress.defaultPathType }}
+          - path: {{ $path | quote }}
+            pathType: {{ $defaultPathType }}
             backend:
               service:
                 name: {{ (include "common.names.fullname" .) | quote }}
@@ -62,7 +66,7 @@ spec:
         paths:
     {{- range .paths }}
           - path: {{ .path }}
-            pathType: {{ .pathType | default $.Values.ingress.defaultPathType }}
+            pathType: {{ .pathType | default $defaultPathType }}
             backend:
               service:
                 name: {{ tpl .serviceName $ | quote }}

--- a/charts/platform/charts/mcp/tests/NOTES_test.yaml
+++ b/charts/platform/charts/mcp/tests/NOTES_test.yaml
@@ -24,9 +24,37 @@ chart:
   version: 1.0.0
   appVersion: "v1.0.0"
 tests:
+  # Platform Service connection tests
+  - it: should fail when global.platformServiceAddress is not defined
+    set:
+      global:
+        platformServiceAddress: ""
+        platformServicePort: 8080
+      micronautEnvironments:
+        - oauth-platform
+      oidcToken.existingSecretName: "my-oidc-secret"
+    asserts:
+      - failedTemplate:
+          errorPattern: "Define the Seqera Platform Service address at 'global.platformServiceAddress'"
+
+  - it: should fail when global.platformServicePort is not defined
+    set:
+      global:
+        platformServiceAddress: "platform-backend"
+        platformServicePort: ""
+      micronautEnvironments:
+        - oauth-platform
+      oidcToken.existingSecretName: "my-oidc-secret"
+    asserts:
+      - failedTemplate:
+          errorPattern: "Define the Seqera Platform Service port at 'global.platformServicePort'"
+
   # JWT seed mutual exclusion
   - it: should fail when both oauth.jwtSeedString and oauth.jwtSeedSecretName are set
     set:
+      global:
+        platformServiceAddress: "platform-backend"
+        platformServicePort: 8080
       micronautEnvironments:
         - oauth-platform
       oidcToken.tokenString: ""
@@ -39,6 +67,9 @@ tests:
 
   - it: should pass when only oauth.jwtSeedString is set
     set:
+      global:
+        platformServiceAddress: "platform-backend"
+        platformServicePort: 8080
       micronautEnvironments:
         - oauth-platform
       oidcToken.tokenString: ""
@@ -50,6 +81,9 @@ tests:
 
   - it: should pass when only oauth.jwtSeedSecretName is set
     set:
+      global:
+        platformServiceAddress: "platform-backend"
+        platformServicePort: 8080
       micronautEnvironments:
         - oauth-platform
       oidcToken.tokenString: ""
@@ -61,6 +95,9 @@ tests:
 
   - it: should pass when neither jwt seed value is set
     set:
+      global:
+        platformServiceAddress: "platform-backend"
+        platformServicePort: 8080
       micronautEnvironments:
         - oauth-platform
       oidcToken.tokenString: ""
@@ -72,6 +109,9 @@ tests:
   # OIDC token mutual exclusion and requirement
   - it: should fail when both oidcToken.tokenString and oidcToken.existingSecretName are set
     set:
+      global:
+        platformServiceAddress: "platform-backend"
+        platformServicePort: 8080
       micronautEnvironments:
         - oauth-platform
       oidcToken.tokenString: "my-oidc-token"
@@ -82,6 +122,9 @@ tests:
 
   - it: should fail when neither oidcToken.tokenString nor oidcToken.existingSecretName are set
     set:
+      global:
+        platformServiceAddress: "platform-backend"
+        platformServicePort: 8080
       micronautEnvironments:
         - oauth-platform
       oidcToken.tokenString: ""
@@ -92,6 +135,9 @@ tests:
 
   - it: should pass when only oidcToken.tokenString is set
     set:
+      global:
+        platformServiceAddress: "platform-backend"
+        platformServicePort: 8080
       micronautEnvironments:
         - oauth-platform
       oidcToken.tokenString: "my-oidc-token"
@@ -102,6 +148,9 @@ tests:
 
   - it: should pass when only oidcToken.existingSecretName is set
     set:
+      global:
+        platformServiceAddress: "platform-backend"
+        platformServicePort: 8080
       micronautEnvironments:
         - oauth-platform
       oidcToken.tokenString: ""

--- a/charts/platform/charts/mcp/tests/__snapshot__/ingress_test.yaml.snap
+++ b/charts/platform/charts/mcp/tests/__snapshot__/ingress_test.yaml.snap
@@ -23,7 +23,7 @@ should render when ingress.enabled is true:
                     port:
                       number: 6010
                 path: /
-                pathType: ImplementationSpecific
+                pathType: Prefix
         - host: mcp2.example.com
           http:
             paths:
@@ -33,4 +33,4 @@ should render when ingress.enabled is true:
                     port:
                       number: 8002
                 path: /
-                pathType: ImplementationSpecific
+                pathType: Prefix

--- a/charts/platform/charts/mcp/tests/deployment_test.yaml
+++ b/charts/platform/charts/mcp/tests/deployment_test.yaml
@@ -29,6 +29,8 @@ tests:
   - it: should render a Deployment with default values
     template: deployment.yaml
     set:
+      global.platformServiceAddress: '{{ printf "%s-platform-backend" .Release.Name | lower }}'
+      global.platformServicePort: 8080
       oauth.jwtSeedSecretName: my-jwt-secret
       oauth.jwtSeedSecretKey: jwt-seed-key
       oidcToken.existingSecretName: my-oidc-secret
@@ -466,8 +468,11 @@ tests:
           path: spec.template.spec.initContainers[1].name
           value: wait-for-platform
 
-  - it: should use default platformServiceAddress for wait-for-platform env
+  - it: should template platformServiceAddress for wait-for-platform env
     template: deployment.yaml
+    set:
+      global.platformServiceAddress: '{{ printf "%s-platform-backend" .Release.Name | lower }}'
+      global.platformServicePort: 8080
     asserts:
       - contains:
           path: spec.template.spec.initContainers[0].env

--- a/charts/platform/charts/mcp/values.yaml
+++ b/charts/platform/charts/mcp/values.yaml
@@ -35,6 +35,29 @@ global:
   # Note: The OAuth redirect URL is automatically derived by appending /oauth/callback to the domain
   mcpDomain: '{{ printf "mcp.%s" .Values.global.platformExternalDomain }}'
 
+  # Ingress defaults shared across the parent chart and all subcharts. Each subchart's local
+  # `ingress.*` value takes precedence when set; otherwise the global is used.
+  ingress:
+    # -- Enable Ingress for this chart. OR'd with the chart's local `ingress.enabled` so
+    # setting this once at the parent enables all subchart Ingresses.
+    enabled: false
+    # -- Default path applied to ingress rules when `ingress.path` is not set.
+    # AWS ALB users should override to `/*`.
+    path: "/"
+    # -- Default path type applied to ingress rules when `ingress.defaultPathType` is not set.
+    # `Prefix` works for nginx, traefik, AWS ALB, and most modern controllers.
+    defaultPathType: "Prefix"
+    # -- Default ingress class name applied when `ingress.ingressClassName` is not set
+    ingressClassName: ""
+    # -- Annotations merged into the Ingress. Local `ingress.annotations` wins on key collision.
+    # Evaluated as a template
+    annotations: {}
+    # -- Extra labels merged into the Ingress. Local `ingress.extraLabels` wins on key collision.
+    # Evaluated as a template
+    extraLabels: {}
+    # -- TLS entries concatenated with the local `ingress.tls`. Evaluated as a template
+    tls: []
+
   # -- Optional credentials to log in and fetch images from a private registry. These credentials
   # are shared with all the subcharts automatically
   imageCredentials: []
@@ -379,12 +402,11 @@ ingress:
   # -- Enable ingress for MCP
   enabled: false
 
-  # -- Path for the main ingress rule
-  # Note: this needs to be set to '/*' to be used with AWS ALB ingress controller
-  path: "/"
+  # -- Path for the main ingress rule. When empty, falls back to `global.ingress.path`
+  path: ""
 
-  # -- Default path type for the Ingress
-  defaultPathType: "ImplementationSpecific"
+  # -- Default path type for the Ingress. When empty, falls back to `global.ingress.defaultPathType`
+  defaultPathType: ""
 
   # -- Configure the default service for the ingress (evaluated as template)
   # Important: make sure only one defaultBackend is defined across the k8s cluster: if the
@@ -416,7 +438,8 @@ ingress:
   annotations: {}
   # -- Additional labels for the ingress object. Evaluated as a template
   extraLabels: {}
-  # -- Name of the ingress class (replaces the deprecated annotation `kubernetes.io/ingress.class`)
+  # -- Name of the ingress class (replaces the deprecated annotation `kubernetes.io/ingress.class`).
+  # When empty, falls back to `global.ingress.ingressClassName`
   ingressClassName: ""
   # -- TLS configuration. Evaluated as a template
   tls: []

--- a/charts/platform/charts/mcp/values.yaml
+++ b/charts/platform/charts/mcp/values.yaml
@@ -22,10 +22,14 @@ global:
   platformExternalDomain: example.com
 
   # -- Seqera Platform Service name: can be the internal Kubernetes hostname or an external ingress
-  # hostname. Evaluated as a template
-  platformServiceAddress: '{{ printf "%s-platform-backend" .Release.Name | lower }}'
-  # -- Seqera Platform Service port
-  platformServicePort: 8080
+  # hostname. Evaluated as a template.
+  # Required when deploying this subchart standalone. When deploying as part of the parent
+  # `platform` umbrella chart, this value is inherited from the parent chart's `global` section
+  platformServiceAddress: ""
+  # -- Seqera Platform Service port.
+  # Required when deploying this subchart standalone. When deploying as part of the parent
+  # `platform` umbrella chart, this value is inherited from the parent chart's `global` section
+  platformServicePort: ""
 
   # -- Domain where Seqera MCP listens. Evaluated as a template.
   # Note: The OAuth redirect URL is automatically derived by appending /oauth/callback to the domain

--- a/charts/platform/charts/pipeline-optimization/CHANGELOG.md
+++ b/charts/platform/charts/pipeline-optimization/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.5] - 2026-04-30
+
+### Changed
+
+- Bump `seqera-common` dependency to 2.1.2 (Redis init container log message now reports `auth set` or `auth not set`)
+
 ## [2.0.4] - 2026-04-30
 
 ### Changed

--- a/charts/platform/charts/pipeline-optimization/CHANGELOG.md
+++ b/charts/platform/charts/pipeline-optimization/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.6] - 2026-05-05
+
+### Changed
+
+- Update bitnami/common to 2.39.0
+
 ## [2.0.5] - 2026-04-30
 
 ### Changed

--- a/charts/platform/charts/pipeline-optimization/Chart.lock
+++ b/charts/platform/charts/pipeline-optimization/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 2.38.0
 - name: seqera-common
   repository: file://../../../seqera-common
-  version: 2.1.1
-digest: sha256:da56f594fa5462d454cf272386947bb8a4797df50c287d0130790b1a8b846f86
-generated: "2026-04-30T15:38:47.655519629+02:00"
+  version: 2.1.2
+digest: sha256:4d1319075460f2901b92a5aa964db5992673e65275005b33671b597179c47c83
+generated: "2026-04-30T17:18:17.504134609+02:00"

--- a/charts/platform/charts/pipeline-optimization/Chart.lock
+++ b/charts/platform/charts/pipeline-optimization/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.38.0
+  version: 2.39.0
 - name: seqera-common
   repository: file://../../../seqera-common
   version: 2.1.2
-digest: sha256:4d1319075460f2901b92a5aa964db5992673e65275005b33671b597179c47c83
-generated: "2026-04-30T17:18:17.504134609+02:00"
+digest: sha256:3eac4511073f329f614981ce9b91e6cdda035aa007a3aeecd7069958c9ede539
+generated: "2026-05-05T14:18:13.372479516+02:00"

--- a/charts/platform/charts/pipeline-optimization/Chart.yaml
+++ b/charts/platform/charts/pipeline-optimization/Chart.yaml
@@ -23,7 +23,7 @@ maintainers:
     email: devops@seqera.io
     url: https://seqera.io
 type: application
-version: 2.0.5
+version: 2.0.6
 appVersion: "0.4.13"
 dependencies:
   - name: common

--- a/charts/platform/charts/pipeline-optimization/Chart.yaml
+++ b/charts/platform/charts/pipeline-optimization/Chart.yaml
@@ -23,7 +23,7 @@ maintainers:
     email: devops@seqera.io
     url: https://seqera.io
 type: application
-version: 2.0.4
+version: 2.0.5
 appVersion: "0.4.13"
 dependencies:
   - name: common

--- a/charts/platform/charts/pipeline-optimization/README.md
+++ b/charts/platform/charts/pipeline-optimization/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart to deploy the Seqera Pipeline Optimization service (referred to as Groundswell in Platform configuration files).
 
-![Version: 2.0.5](https://img.shields.io/badge/Version-2.0.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.13](https://img.shields.io/badge/AppVersion-0.4.13-informational?style=flat-square)
+![Version: 2.0.6](https://img.shields.io/badge/Version-2.0.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.13](https://img.shields.io/badge/AppVersion-0.4.13-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -37,7 +37,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/pipeline-optimization \
-  --version 2.0.5 \
+  --version 2.0.6 \
   --namespace my-namespace \
   --create-namespace
 ```

--- a/charts/platform/charts/pipeline-optimization/README.md
+++ b/charts/platform/charts/pipeline-optimization/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart to deploy the Seqera Pipeline Optimization service (referred to as Groundswell in Platform configuration files).
 
-![Version: 2.0.4](https://img.shields.io/badge/Version-2.0.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.13](https://img.shields.io/badge/AppVersion-0.4.13-informational?style=flat-square)
+![Version: 2.0.5](https://img.shields.io/badge/Version-2.0.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.13](https://img.shields.io/badge/AppVersion-0.4.13-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -37,7 +37,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/pipeline-optimization \
-  --version 2.0.4 \
+  --version 2.0.5 \
   --namespace my-namespace \
   --create-namespace
 ```

--- a/charts/platform/charts/portal-web/CHANGELOG.md
+++ b/charts/platform/charts/portal-web/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this chart will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.3.0] - 2026-05-05
+
+- **Enhancement**: allow global configuration of Ingress options. A new `global.ingress` block (`enabled`, `path`, `defaultPathType`, `ingressClassName`, `annotations`, `extraLabels`, `tls`) lets cluster-wide Ingress defaults be set once at the parent and propagate to every subchart, removing the need to repeat controller-wide config per subchart. `enabled` is OR-merged; scalar fields fall back to global when local is unset; `annotations` and `extraLabels` are merged with local winning on key collision; `tls` is concatenated (useful for a single wildcard certificate across all services).
+- Add `seqera.ingress.host` template helper in each chart's `_helpers.tpl` returning that chart's primary domain. Lets users write `external-dns.alpha.kubernetes.io/hostname: '{{ include "seqera.ingress.host" . }}'` once in `global.ingress.annotations` and have it resolve to the correct host per chart at render time, without hard-coding hostnames.
+- Add `docs/conventions/ingress.md` documenting the Ingress conventions used across charts.
+
+### Changed
+
+- Update bitnami/common to 2.39.0
+- **BREAKING**: Default `ingress.defaultPathType` is now `Prefix` (was `ImplementationSpecific`). With the previous default and the chart's default `path: "/"`, routing behavior depended on the ingress controller — NGINX treated it as a prefix match, AWS ALB required `/*` for the same effect, GKE applied its own interpretation. The result was the same chart and values producing different routing across clusters. `Prefix` is part of the Kubernetes Ingress spec and produces consistent prefix-match semantics across NGINX, Traefik, AWS ALB, and most modern controllers, giving users a predictable out-of-the-box experience. Users whose controller still requires `ImplementationSpecific` (e.g. older GKE) can set `global.ingress.defaultPathType: ImplementationSpecific` once at the parent.
+
 ## [0.2.8] - 2026-04-30
 
 ### Changed

--- a/charts/platform/charts/portal-web/CHANGELOG.md
+++ b/charts/platform/charts/portal-web/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this chart will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.2.8] - 2026-04-30
+
+### Changed
+
+- Bump `seqera-common` dependency to 2.1.2 (Redis init container log message now reports `auth set` or `auth not set`)
+
 ## [0.2.7] - 2026-04-30
 
 ### Changed

--- a/charts/platform/charts/portal-web/CHANGELOG.md
+++ b/charts/platform/charts/portal-web/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this chart will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.2.7] - 2026-04-30
+
+### Changed
+
+- Clear the default values for `global.platformServiceAddress` and `global.platformServicePort` so they must be explicitly set when deploying this subchart standalone. They point to the Seqera Platform backend service. When deploying as part of the parent `platform` umbrella chart, these values are inherited automatically from the parent chart's `global` section
+- Add `NOTES.txt` validation that fails the installation when `global.platformServiceAddress` or `global.platformServicePort` are not set
+- Document the Platform Service connection details as a required configuration in the README
+
 ## [0.2.6] - 2026-04-30
 
 ### Changed

--- a/charts/platform/charts/portal-web/Chart.lock
+++ b/charts/platform/charts/portal-web/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.38.0
+  version: 2.39.0
 - name: seqera-common
   repository: file://../../../seqera-common
   version: 2.1.2
-digest: sha256:66f5f1fb1ad2a6fd814da84d51f11c2a3f10633e1ba8d23f72eab6294ab68d49
-generated: "2026-04-30T17:18:24.090883307+02:00"
+digest: sha256:b66829bad11b646116b1ac6fc712849c4231dfbb6641380100f3282e06ab9a39
+generated: "2026-05-05T14:18:41.428348035+02:00"

--- a/charts/platform/charts/portal-web/Chart.lock
+++ b/charts/platform/charts/portal-web/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 2.38.0
 - name: seqera-common
   repository: file://../../../seqera-common
-  version: 2.1.1
-digest: sha256:ce02e7a0f1f7ded086daa13cd2fd8d6850f75f7984f14d06dfe35d729924ff2d
-generated: "2026-04-30T15:38:55.348142126+02:00"
+  version: 2.1.2
+digest: sha256:66f5f1fb1ad2a6fd814da84d51f11c2a3f10633e1ba8d23f72eab6294ab68d49
+generated: "2026-04-30T17:18:24.090883307+02:00"

--- a/charts/platform/charts/portal-web/Chart.yaml
+++ b/charts/platform/charts/portal-web/Chart.yaml
@@ -19,7 +19,7 @@ apiVersion: v2
 name: portal-web
 description: Portal web frontend for Seqera Platform
 type: application
-version: 0.2.7
+version: 0.2.8
 appVersion: "0.1.0"
 maintainers:
   - name: Seqera Labs

--- a/charts/platform/charts/portal-web/Chart.yaml
+++ b/charts/platform/charts/portal-web/Chart.yaml
@@ -19,7 +19,7 @@ apiVersion: v2
 name: portal-web
 description: Portal web frontend for Seqera Platform
 type: application
-version: 0.2.8
+version: 0.3.0
 appVersion: "0.1.0"
 maintainers:
   - name: Seqera Labs

--- a/charts/platform/charts/portal-web/Chart.yaml
+++ b/charts/platform/charts/portal-web/Chart.yaml
@@ -19,7 +19,7 @@ apiVersion: v2
 name: portal-web
 description: Portal web frontend for Seqera Platform
 type: application
-version: 0.2.6
+version: 0.2.7
 appVersion: "0.1.0"
 maintainers:
   - name: Seqera Labs

--- a/charts/platform/charts/portal-web/README.md
+++ b/charts/platform/charts/portal-web/README.md
@@ -2,7 +2,7 @@
 
 Portal web frontend for Seqera Platform
 
-![Version: 0.2.8](https://img.shields.io/badge/Version-0.2.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -32,7 +32,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/portal-web \
-  --version 0.2.8 \
+  --version 0.3.0 \
   --namespace my-namespace \
   --create-namespace
 ```
@@ -59,6 +59,13 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | global.platformServicePort | string | `""` | Seqera Platform Service port. Required when deploying this subchart standalone. When deploying as part of the parent `platform` umbrella chart, this value is inherited from the parent chart's `global` section |
 | global.agentBackendDomain | string | `"{{ printf \"ai-api.%s\" .Values.global.platformExternalDomain }}"` | Domain where the Agent Backend service listens. Evaluated as a template |
 | global.portalWebDomain | string | `"{{ printf \"ai.%s\" .Values.global.platformExternalDomain }}"` | Domain where the Portal Web frontend listens. Evaluated as a template |
+| global.ingress.enabled | bool | `false` | Enable Ingress for this chart. OR'd with the chart's local `ingress.enabled` so setting this once at the parent enables all subchart Ingresses. |
+| global.ingress.path | string | `"/"` | Default path applied to ingress rules when `ingress.path` is not set. AWS ALB users should override to `/*`. |
+| global.ingress.defaultPathType | string | `"Prefix"` | Default path type applied to ingress rules when `ingress.defaultPathType` is not set. `Prefix` works for nginx, traefik, AWS ALB, and most modern controllers. |
+| global.ingress.ingressClassName | string | `""` | Default ingress class name applied when `ingress.ingressClassName` is not set |
+| global.ingress.annotations | object | `{}` | Annotations merged into the Ingress. Local `ingress.annotations` wins on key collision. Evaluated as a template |
+| global.ingress.extraLabels | object | `{}` | Extra labels merged into the Ingress. Local `ingress.extraLabels` wins on key collision. Evaluated as a template |
+| global.ingress.tls | list | `[]` | TLS entries concatenated with the local `ingress.tls`. Evaluated as a template |
 | global.imageCredentials | list | `[]` | Optional credentials to log in and fetch images from a private registry. These credentials are shared with all the subcharts automatically |
 | global.imageCredentialsSecrets | list | `[]` | Optional list of existing Secrets containing image pull credentials to use for pulling images from private registries. These Secrets are shared with all the subcharts automatically |
 | image.registry | string | `""` | Container image registry |
@@ -126,13 +133,13 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | serviceAccount.imagePullSecretNames | list | `[]` | Names of Secrets containing credentials to pull images from registries |
 | serviceAccount.automountServiceAccountToken | bool | `false` | Automatically mount service account token |
 | ingress.enabled | bool | `false` | Enable ingress for Portal Web |
-| ingress.path | string | `"/"` | Path for the main ingress rule Note: this needs to be set to '/*' to be used with AWS ALB ingress controller |
-| ingress.defaultPathType | string | `"ImplementationSpecific"` | Default path type for the Ingress |
+| ingress.path | string | `""` | Path for the main ingress rule. When empty, falls back to `global.ingress.path` |
+| ingress.defaultPathType | string | `""` | Default path type for the Ingress. When empty, falls back to `global.ingress.defaultPathType` |
 | ingress.defaultBackend | object | `{}` | Configure the default service for the ingress (evaluated as template) Important: make sure only one defaultBackend is defined across the k8s cluster: if the ingress doesn't reconcile successfully, 'describe ingress <name>' will report problems |
 | ingress.extraHosts | list | `[]` | Additional hosts you want to include. Evaluated as a template |
 | ingress.annotations | object | `{}` | Ingress annotations specific to your load balancer. Evaluated as a template |
 | ingress.extraLabels | object | `{}` | Additional labels for the ingress object. Evaluated as a template |
-| ingress.ingressClassName | string | `""` | Name of the ingress class (replaces the deprecated annotation `kubernetes.io/ingress.class`) |
+| ingress.ingressClassName | string | `""` | Name of the ingress class (replaces the deprecated annotation `kubernetes.io/ingress.class`). When empty, falls back to `global.ingress.ingressClassName` |
 | ingress.tls | list | `[]` | TLS configuration. Evaluated as a template |
 | extraDeploy | list | `[]` | Array of extra objects to deploy with the release |
 | commonAnnotations | object | `{}` | Annotations to add to all deployed objects |

--- a/charts/platform/charts/portal-web/README.md
+++ b/charts/platform/charts/portal-web/README.md
@@ -2,7 +2,7 @@
 
 Portal web frontend for Seqera Platform
 
-![Version: 0.2.7](https://img.shields.io/badge/Version-0.2.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.2.8](https://img.shields.io/badge/Version-0.2.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -32,7 +32,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/portal-web \
-  --version 0.2.7 \
+  --version 0.2.8 \
   --namespace my-namespace \
   --create-namespace
 ```

--- a/charts/platform/charts/portal-web/README.md
+++ b/charts/platform/charts/portal-web/README.md
@@ -2,7 +2,7 @@
 
 Portal web frontend for Seqera Platform
 
-![Version: 0.2.6](https://img.shields.io/badge/Version-0.2.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.2.7](https://img.shields.io/badge/Version-0.2.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -14,6 +14,7 @@ The chart does not automatically define `cr.seqera.io` as the registry where to 
 
 The required values to set in order to have a working installation are:
 - The `.global.platformExternalDomain` value to point to the domain where Seqera Platform will be exposed.
+- The Seqera Platform Service connection details under `.global.platformServiceAddress` and `.global.platformServicePort`. These point to the Platform backend service that Portal Web communicates with. When deploying this subchart as part of the parent `platform` umbrella chart, these values are inherited automatically from the parent chart's `global` section.
 - The `.image` section to point to your container registry.
 - Container registry credentials under the `.global.imageCredentials` section (can be the credentials for cr.seqera.io or your private registry where you vendored the images to).
   * These credentials will be used by all the subcharts unless overridden in the specific subchart.
@@ -31,7 +32,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/portal-web \
-  --version 0.2.6 \
+  --version 0.2.7 \
   --namespace my-namespace \
   --create-namespace
 ```
@@ -54,8 +55,8 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | global.platformExternalDomain | string | `"example.com"` | Domain where Seqera Platform listens |
-| global.platformServiceAddress | string | `"{{ printf \"%s-platform-backend\" .Release.Name | lower }}"` | Seqera Platform Service name: can be the internal Kubernetes hostname or an external ingress hostname. Evaluated as a template |
-| global.platformServicePort | int | `8080` | Seqera Platform Service port |
+| global.platformServiceAddress | string | `""` | Seqera Platform Service name: can be the internal Kubernetes hostname or an external ingress hostname. Evaluated as a template. Required when deploying this subchart standalone. When deploying as part of the parent `platform` umbrella chart, this value is inherited from the parent chart's `global` section |
+| global.platformServicePort | string | `""` | Seqera Platform Service port. Required when deploying this subchart standalone. When deploying as part of the parent `platform` umbrella chart, this value is inherited from the parent chart's `global` section |
 | global.agentBackendDomain | string | `"{{ printf \"ai-api.%s\" .Values.global.platformExternalDomain }}"` | Domain where the Agent Backend service listens. Evaluated as a template |
 | global.portalWebDomain | string | `"{{ printf \"ai.%s\" .Values.global.platformExternalDomain }}"` | Domain where the Portal Web frontend listens. Evaluated as a template |
 | global.imageCredentials | list | `[]` | Optional credentials to log in and fetch images from a private registry. These credentials are shared with all the subcharts automatically |

--- a/charts/platform/charts/portal-web/README.md.gotmpl
+++ b/charts/platform/charts/portal-web/README.md.gotmpl
@@ -13,6 +13,7 @@ The chart does not automatically define `cr.seqera.io` as the registry where to 
 
 The required values to set in order to have a working installation are:
 - The `.global.platformExternalDomain` value to point to the domain where Seqera Platform will be exposed.
+- The Seqera Platform Service connection details under `.global.platformServiceAddress` and `.global.platformServicePort`. These point to the Platform backend service that Portal Web communicates with. When deploying this subchart as part of the parent `platform` umbrella chart, these values are inherited automatically from the parent chart's `global` section.
 - The `.image` section to point to your container registry.
 - Container registry credentials under the `.global.imageCredentials` section (can be the credentials for cr.seqera.io or your private registry where you vendored the images to).
   * These credentials will be used by all the subcharts unless overridden in the specific subchart.

--- a/charts/platform/charts/portal-web/templates/NOTES.txt
+++ b/charts/platform/charts/portal-web/templates/NOTES.txt
@@ -17,6 +17,18 @@
  limitations under the License.
 */}}
 
+{{/* We can't put checks in _helpers.tpl, it doesn't make installation fail. */}}
+
+{{- if not .Values.global.platformServiceAddress -}}
+{{- $message := "Define the Seqera Platform Service address at 'global.platformServiceAddress'. This must point to the Platform backend service (Kubernetes hostname or external ingress)." -}}
+{{- printf "\nVALUES VALIDATION:\n%s" $message | fail -}}
+{{- end -}}
+
+{{- if not .Values.global.platformServicePort -}}
+{{- $message := "Define the Seqera Platform Service port at 'global.platformServicePort'." -}}
+{{- printf "\nVALUES VALIDATION:\n%s" $message | fail -}}
+{{- end -}}
+
 Thank you for installing {{ .Chart.Name | title }}!
 
 Your release is named '{{ .Release.Name }}' and was installed in the '{{ include "common.names.namespace" . }}' namespace.

--- a/charts/platform/charts/portal-web/templates/_helpers.tpl
+++ b/charts/platform/charts/portal-web/templates/_helpers.tpl
@@ -23,3 +23,12 @@ Create the name of the service account to use
 {{- define "portal-web.serviceAccountName" -}}
 {{- default (printf "%s-sa" (include "common.names.fullname" .)) .Values.serviceAccount.name -}}
 {{- end }}
+
+{{/*
+Return this chart's primary ingress hostname. See parent platform chart's `_helpers.tpl` for
+usage notes — `'{{ include "seqera.ingress.host" . }}'` in `global.ingress.annotations` resolves
+to each chart's own domain at render time.
+*/}}
+{{- define "seqera.ingress.host" -}}
+{{- tpl .Values.global.portalWebDomain . -}}
+{{- end -}}

--- a/charts/platform/charts/portal-web/templates/ingress.yaml
+++ b/charts/platform/charts/portal-web/templates/ingress.yaml
@@ -17,12 +17,16 @@
  limitations under the License.
 */}}
 
-{{ if .Values.ingress.enabled }}
+{{ if or .Values.ingress.enabled .Values.global.ingress.enabled }}
   {{- $commonLabels := include "common.labels.standard" (dict "customLabels" .Values.commonLabels "context" $) | fromYaml -}}
-  {{- $mergedlabels := include "common.tplvalues.merge" (dict "values" (list .Values.ingress.extraLabels $commonLabels) "context" .) -}}
+  {{- $mergedlabels := include "common.tplvalues.merge" (dict "values" (list .Values.ingress.extraLabels .Values.global.ingress.extraLabels $commonLabels) "context" .) -}}
   {{- $labels := include "common.tplvalues.render" (dict "value" $mergedlabels "context" $) -}}
-  {{- $mergedAnnotations := include "common.tplvalues.merge" (dict "values" (list .Values.ingress.annotations .Values.commonAnnotations) "context" .) -}}
+  {{- $mergedAnnotations := include "common.tplvalues.merge" (dict "values" (list .Values.ingress.annotations .Values.global.ingress.annotations .Values.commonAnnotations) "context" .) -}}
   {{- $annotations := include "common.tplvalues.render" (dict "value" $mergedAnnotations "context" $) -}}
+  {{- $defaultPathType := default .Values.global.ingress.defaultPathType .Values.ingress.defaultPathType -}}
+  {{- $path := default .Values.global.ingress.path .Values.ingress.path -}}
+  {{- $ingressClassName := default .Values.global.ingress.ingressClassName .Values.ingress.ingressClassName -}}
+  {{- $tls := concat (default (list) .Values.ingress.tls) (default (list) .Values.global.ingress.tls) -}}
 
 apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress
@@ -36,11 +40,11 @@ spec:
   defaultBackend: {{- include "seqera.tplvalues.render" (dict "value" . "context" $) | nindent 4 }}
   {{- end }}
 
-  {{- if .Values.ingress.ingressClassName }}
-  ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
+  {{- if $ingressClassName }}
+  ingressClassName: {{ $ingressClassName | quote }}
   {{- end }}
 
-  {{- with .Values.ingress.tls }}
+  {{- with $tls }}
   tls: {{- include "common.tplvalues.render" (dict "value" . "context" $) | nindent 4 }}
   {{- end }}
 
@@ -48,8 +52,8 @@ spec:
     - host: {{ tpl .Values.global.portalWebDomain . | quote }}
       http:
         paths:
-          - path: {{ .Values.ingress.path | quote }}
-            pathType: {{ .Values.ingress.defaultPathType }}
+          - path: {{ $path | quote }}
+            pathType: {{ $defaultPathType }}
             backend:
               service:
                 name: {{ (include "common.names.fullname" .) | quote }}
@@ -61,7 +65,7 @@ spec:
         paths:
     {{- range .paths }}
           - path: {{ .path }}
-            pathType: {{ .pathType | default $.Values.ingress.defaultPathType }}
+            pathType: {{ .pathType | default $defaultPathType }}
             backend:
               service:
                 name: {{ tpl .serviceName $ | quote }}

--- a/charts/platform/charts/portal-web/tests/NOTES_test.yaml
+++ b/charts/platform/charts/portal-web/tests/NOTES_test.yaml
@@ -25,6 +25,28 @@ chart:
   appVersion: "v9.8.7"
 tests:
   - it: should render NOTES.txt
+    set:
+      global:
+        platformServiceAddress: "platform-backend"
+        platformServicePort: 8080
     asserts:
       - hasDocuments:
           count: 1
+
+  - it: should fail when global.platformServiceAddress is not defined
+    set:
+      global:
+        platformServiceAddress: ""
+        platformServicePort: 8080
+    asserts:
+      - failedTemplate:
+          errorPattern: "Define the Seqera Platform Service address at 'global.platformServiceAddress'"
+
+  - it: should fail when global.platformServicePort is not defined
+    set:
+      global:
+        platformServiceAddress: "platform-backend"
+        platformServicePort: ""
+    asserts:
+      - failedTemplate:
+          errorPattern: "Define the Seqera Platform Service port at 'global.platformServicePort'"

--- a/charts/platform/charts/portal-web/tests/__snapshot__/ingress_test.yaml.snap
+++ b/charts/platform/charts/portal-web/tests/__snapshot__/ingress_test.yaml.snap
@@ -23,4 +23,4 @@ should render when ingress.enabled is true:
                     port:
                       number: 80
                 path: /
-                pathType: ImplementationSpecific
+                pathType: Prefix

--- a/charts/platform/charts/portal-web/tests/configmap_test.yaml
+++ b/charts/platform/charts/portal-web/tests/configmap_test.yaml
@@ -25,6 +25,9 @@ chart:
   appVersion: "v9.9.9"
 tests:
   - it: should render a ConfigMap with default values
+    set:
+      global.platformServiceAddress: '{{ printf "%s-platform-backend" .Release.Name | lower }}'
+      global.platformServicePort: 8080
     asserts:
       - isKind:
           of: ConfigMap

--- a/charts/platform/charts/portal-web/tests/deployment_test.yaml
+++ b/charts/platform/charts/portal-web/tests/deployment_test.yaml
@@ -28,6 +28,9 @@ chart:
 tests:
   - it: should render a Deployment with default values
     template: deployment.yaml
+    set:
+      global.platformServiceAddress: '{{ printf "%s-platform-backend" .Release.Name | lower }}'
+      global.platformServicePort: 8080
     asserts:
       - matchSnapshot: {}
 

--- a/charts/platform/charts/portal-web/values.yaml
+++ b/charts/platform/charts/portal-web/values.yaml
@@ -22,10 +22,14 @@ global:
   platformExternalDomain: example.com
 
   # -- Seqera Platform Service name: can be the internal Kubernetes hostname or an external ingress
-  # hostname. Evaluated as a template
-  platformServiceAddress: '{{ printf "%s-platform-backend" .Release.Name | lower }}'
-  # -- Seqera Platform Service port
-  platformServicePort: 8080
+  # hostname. Evaluated as a template.
+  # Required when deploying this subchart standalone. When deploying as part of the parent
+  # `platform` umbrella chart, this value is inherited from the parent chart's `global` section
+  platformServiceAddress: ""
+  # -- Seqera Platform Service port.
+  # Required when deploying this subchart standalone. When deploying as part of the parent
+  # `platform` umbrella chart, this value is inherited from the parent chart's `global` section
+  platformServicePort: ""
 
   # -- Domain where the Agent Backend service listens. Evaluated as a template
   agentBackendDomain: '{{ printf "ai-api.%s" .Values.global.platformExternalDomain }}'

--- a/charts/platform/charts/portal-web/values.yaml
+++ b/charts/platform/charts/portal-web/values.yaml
@@ -37,6 +37,29 @@ global:
   # -- Domain where the Portal Web frontend listens. Evaluated as a template
   portalWebDomain: '{{ printf "ai.%s" .Values.global.platformExternalDomain }}'
 
+  # Ingress defaults shared across the parent chart and all subcharts. Each subchart's local
+  # `ingress.*` value takes precedence when set; otherwise the global is used.
+  ingress:
+    # -- Enable Ingress for this chart. OR'd with the chart's local `ingress.enabled` so
+    # setting this once at the parent enables all subchart Ingresses.
+    enabled: false
+    # -- Default path applied to ingress rules when `ingress.path` is not set.
+    # AWS ALB users should override to `/*`.
+    path: "/"
+    # -- Default path type applied to ingress rules when `ingress.defaultPathType` is not set.
+    # `Prefix` works for nginx, traefik, AWS ALB, and most modern controllers.
+    defaultPathType: "Prefix"
+    # -- Default ingress class name applied when `ingress.ingressClassName` is not set
+    ingressClassName: ""
+    # -- Annotations merged into the Ingress. Local `ingress.annotations` wins on key collision.
+    # Evaluated as a template
+    annotations: {}
+    # -- Extra labels merged into the Ingress. Local `ingress.extraLabels` wins on key collision.
+    # Evaluated as a template
+    extraLabels: {}
+    # -- TLS entries concatenated with the local `ingress.tls`. Evaluated as a template
+    tls: []
+
   # -- Optional credentials to log in and fetch images from a private registry. These credentials
   # are shared with all the subcharts automatically
   imageCredentials: []
@@ -273,12 +296,11 @@ ingress:
   # -- Enable ingress for Portal Web
   enabled: false
 
-  # -- Path for the main ingress rule
-  # Note: this needs to be set to '/*' to be used with AWS ALB ingress controller
-  path: "/"
+  # -- Path for the main ingress rule. When empty, falls back to `global.ingress.path`
+  path: ""
 
-  # -- Default path type for the Ingress
-  defaultPathType: "ImplementationSpecific"
+  # -- Default path type for the Ingress. When empty, falls back to `global.ingress.defaultPathType`
+  defaultPathType: ""
 
   # -- Configure the default service for the ingress (evaluated as template)
   # Important: make sure only one defaultBackend is defined across the k8s cluster: if the
@@ -299,7 +321,8 @@ ingress:
   annotations: {}
   # -- Additional labels for the ingress object. Evaluated as a template
   extraLabels: {}
-  # -- Name of the ingress class (replaces the deprecated annotation `kubernetes.io/ingress.class`)
+  # -- Name of the ingress class (replaces the deprecated annotation `kubernetes.io/ingress.class`).
+  # When empty, falls back to `global.ingress.ingressClassName`
   ingressClassName: ""
   # -- TLS configuration. Evaluated as a template
   tls: []

--- a/charts/platform/charts/studios/CHANGELOG.md
+++ b/charts/platform/charts/studios/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2026-05-05
+
+- **Enhancement**: allow global configuration of Ingress options. A new `global.ingress` block (`enabled`, `path`, `defaultPathType`, `ingressClassName`, `annotations`, `extraLabels`, `tls`) lets cluster-wide Ingress defaults be set once at the parent and propagate to every subchart, removing the need to repeat controller-wide config per subchart. `enabled` is OR-merged; scalar fields fall back to global when local is unset; `annotations` and `extraLabels` are merged with local winning on key collision; `tls` is concatenated (useful for a single wildcard certificate across all services).
+- Add `seqera.ingress.host` template helper in each chart's `_helpers.tpl` returning that chart's primary domain. Lets users write `external-dns.alpha.kubernetes.io/hostname: '{{ include "seqera.ingress.host" . }}'` once in `global.ingress.annotations` and have it resolve to the correct host per chart at render time, without hard-coding hostnames.
+- Add `docs/conventions/ingress.md` documenting the Ingress conventions used across charts.
+
+### Changed
+
+- Update bitnami/common to 2.39.0
+- **BREAKING**: Default `ingress.defaultPathType` is now `Prefix` (was `ImplementationSpecific`). With the previous default and the chart's default `path: "/"`, routing behavior depended on the ingress controller — NGINX treated it as a prefix match, AWS ALB required `/*` for the same effect, GKE applied its own interpretation. The result was the same chart and values producing different routing across clusters. `Prefix` is part of the Kubernetes Ingress spec and produces consistent prefix-match semantics across NGINX, Traefik, AWS ALB, and most modern controllers, giving users a predictable out-of-the-box experience. Users whose controller still requires `ImplementationSpecific` (e.g. older GKE) can set `global.ingress.defaultPathType: ImplementationSpecific` once at the parent.
+
 ## [1.2.15] - 2026-04-30
 
 ### Changed

--- a/charts/platform/charts/studios/CHANGELOG.md
+++ b/charts/platform/charts/studios/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.15] - 2026-04-30
+
+### Changed
+
+- Bump `seqera-common` dependency to 2.1.2 (Redis init container log message now reports `auth set` or `auth not set`)
+
 ## [1.2.14] - 2026-04-30
 
 ### Changed

--- a/charts/platform/charts/studios/CHANGELOG.md
+++ b/charts/platform/charts/studios/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.14] - 2026-04-30
+
+### Changed
+
+- Clear the default values for `global.platformServiceAddress` and `global.platformServicePort` so they must be explicitly set when deploying this subchart standalone. They point to the Seqera Platform backend service. When deploying as part of the parent `platform` umbrella chart, these values are inherited automatically from the parent chart's `global` section
+- Improve `NOTES.txt` validation messages for `global.platformServiceAddress` and `global.platformServicePort` to clarify that these values are inherited from the parent `platform` umbrella chart
+- Document the Platform Service connection details as a required configuration in the README
+
 ## [1.2.13] - 2026-04-30
 
 ### Changed

--- a/charts/platform/charts/studios/Chart.lock
+++ b/charts/platform/charts/studios/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 2.38.0
 - name: seqera-common
   repository: file://../../../seqera-common
-  version: 2.1.1
-digest: sha256:da56f594fa5462d454cf272386947bb8a4797df50c287d0130790b1a8b846f86
-generated: "2026-04-30T15:39:03.333125496+02:00"
+  version: 2.1.2
+digest: sha256:4d1319075460f2901b92a5aa964db5992673e65275005b33671b597179c47c83
+generated: "2026-04-30T17:18:31.198120058+02:00"

--- a/charts/platform/charts/studios/Chart.lock
+++ b/charts/platform/charts/studios/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.38.0
+  version: 2.39.0
 - name: seqera-common
   repository: file://../../../seqera-common
   version: 2.1.2
-digest: sha256:4d1319075460f2901b92a5aa964db5992673e65275005b33671b597179c47c83
-generated: "2026-04-30T17:18:31.198120058+02:00"
+digest: sha256:3eac4511073f329f614981ce9b91e6cdda035aa007a3aeecd7069958c9ede539
+generated: "2026-05-05T14:19:18.00542025+02:00"

--- a/charts/platform/charts/studios/Chart.yaml
+++ b/charts/platform/charts/studios/Chart.yaml
@@ -21,7 +21,7 @@ name: studios
 description: Studios is a unified platform for interactive analysis
 sources:
   - https://github.com/seqeralabs/helm-charts/tree/main/seqera/charts/studios
-version: 1.2.13
+version: 1.2.14
 appVersion: "0.11.0"
 maintainers:
   - name: Seqera Labs

--- a/charts/platform/charts/studios/Chart.yaml
+++ b/charts/platform/charts/studios/Chart.yaml
@@ -21,7 +21,7 @@ name: studios
 description: Studios is a unified platform for interactive analysis
 sources:
   - https://github.com/seqeralabs/helm-charts/tree/main/seqera/charts/studios
-version: 1.2.14
+version: 1.2.15
 appVersion: "0.11.0"
 maintainers:
   - name: Seqera Labs

--- a/charts/platform/charts/studios/Chart.yaml
+++ b/charts/platform/charts/studios/Chart.yaml
@@ -21,7 +21,7 @@ name: studios
 description: Studios is a unified platform for interactive analysis
 sources:
   - https://github.com/seqeralabs/helm-charts/tree/main/seqera/charts/studios
-version: 1.2.15
+version: 1.3.0
 appVersion: "0.11.0"
 maintainers:
   - name: Seqera Labs

--- a/charts/platform/charts/studios/README.md
+++ b/charts/platform/charts/studios/README.md
@@ -2,7 +2,7 @@
 
 Studios is a unified platform for interactive analysis
 
-![Version: 1.2.13](https://img.shields.io/badge/Version-1.2.13-informational?style=flat-square) ![AppVersion: 0.11.0](https://img.shields.io/badge/AppVersion-0.11.0-informational?style=flat-square)
+![Version: 1.2.14](https://img.shields.io/badge/Version-1.2.14-informational?style=flat-square) ![AppVersion: 0.11.0](https://img.shields.io/badge/AppVersion-0.11.0-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -17,6 +17,7 @@ https://docs.seqera.io/platform-enterprise/enterprise/configuration/pipeline_opt
 The chart does not automatically define `cr.seqera.io` as the registry where to take the images from: instructions are available to [vendor the Seqera container images to your private registry](https://docs.seqera.io/platform-enterprise/enterprise/prerequisites/common#vendoring-seqera-container-images-to-your-own-registry).
 
 The required values to set in order to have a working installation are:
+- The Seqera Platform Service connection details under `.global.platformServiceAddress` and `.global.platformServicePort`. These point to the Platform backend service that Studios communicates with. When deploying this subchart as part of the parent `platform` umbrella chart, these values are inherited automatically from the parent chart's `global` section.
 - The OIDC client registration token under `.proxy.oidcClientRegistrationToken` (or reference an existing Secret with `.proxy.oidcClientRegistrationTokenSecretName`). When deploying as part of the platform parent chart this is set automatically; when deploying standalone it must match the value configured in the platform backend.
 - The `.image` and the `.dbMigrationInitContainer.image` sections to point to your container registry.
 - Container registry credentials under the `.global.imageCredentials` section (can be the credentials for cr.seqera.io or your private registry where you vendored the images to).
@@ -40,7 +41,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/studios \
-  --version 1.2.13 \
+  --version 1.2.14 \
   --namespace my-namespace \
   --create-namespace
 ```
@@ -69,8 +70,8 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | global.platformExternalDomain | string | `"example.com"` | Domain where Seqera Platform listens |
-| global.platformServiceAddress | string | `"{{ printf \"%s-platform-backend\" .Release.Name | lower }}"` | Seqera Platform Service name: can be the internal Kubernetes hostname or an external ingress hostname. Evaluated as a template |
-| global.platformServicePort | int | `8080` | Seqera Platform Service port |
+| global.platformServiceAddress | string | `""` | Seqera Platform Service name: can be the internal Kubernetes hostname or an external ingress hostname. Evaluated as a template. Required when deploying this subchart standalone. When deploying as part of the parent `platform` umbrella chart, this value is inherited from the parent chart's `global` section |
+| global.platformServicePort | string | `""` | Seqera Platform Service port. Required when deploying this subchart standalone. When deploying as part of the parent `platform` umbrella chart, this value is inherited from the parent chart's `global` section |
 | global.studiosDomain | string | `"{{ printf \"studios.%s\" .Values.global.platformExternalDomain }}"` | Domain where the Studios service listens. Make sure the TLS certificate covers this and its wildcard subdomains. Evaluated as a template |
 | global.studiosConnectionUrl | string | `"{{ printf \"https://connect.%s\" (tpl .Values.global.studiosDomain $) }}"` | Base URL for Studios connections: can be any value, since each session will use a unique subdomain under `.global.studiosDomain` anyway to connect. Evaluated as a template |
 | global.imageCredentials | list | `[]` | Optional credentials to log in and fetch images from a private registry. These credentials are shared with all the subcharts automatically |

--- a/charts/platform/charts/studios/README.md
+++ b/charts/platform/charts/studios/README.md
@@ -2,7 +2,7 @@
 
 Studios is a unified platform for interactive analysis
 
-![Version: 1.2.14](https://img.shields.io/badge/Version-1.2.14-informational?style=flat-square) ![AppVersion: 0.11.0](https://img.shields.io/badge/AppVersion-0.11.0-informational?style=flat-square)
+![Version: 1.2.15](https://img.shields.io/badge/Version-1.2.15-informational?style=flat-square) ![AppVersion: 0.11.0](https://img.shields.io/badge/AppVersion-0.11.0-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -41,7 +41,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/studios \
-  --version 1.2.14 \
+  --version 1.2.15 \
   --namespace my-namespace \
   --create-namespace
 ```

--- a/charts/platform/charts/studios/README.md
+++ b/charts/platform/charts/studios/README.md
@@ -2,7 +2,7 @@
 
 Studios is a unified platform for interactive analysis
 
-![Version: 1.2.15](https://img.shields.io/badge/Version-1.2.15-informational?style=flat-square) ![AppVersion: 0.11.0](https://img.shields.io/badge/AppVersion-0.11.0-informational?style=flat-square)
+![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![AppVersion: 0.11.0](https://img.shields.io/badge/AppVersion-0.11.0-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -41,7 +41,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/studios \
-  --version 1.2.15 \
+  --version 1.3.0 \
   --namespace my-namespace \
   --create-namespace
 ```
@@ -74,6 +74,13 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | global.platformServicePort | string | `""` | Seqera Platform Service port. Required when deploying this subchart standalone. When deploying as part of the parent `platform` umbrella chart, this value is inherited from the parent chart's `global` section |
 | global.studiosDomain | string | `"{{ printf \"studios.%s\" .Values.global.platformExternalDomain }}"` | Domain where the Studios service listens. Make sure the TLS certificate covers this and its wildcard subdomains. Evaluated as a template |
 | global.studiosConnectionUrl | string | `"{{ printf \"https://connect.%s\" (tpl .Values.global.studiosDomain $) }}"` | Base URL for Studios connections: can be any value, since each session will use a unique subdomain under `.global.studiosDomain` anyway to connect. Evaluated as a template |
+| global.ingress.enabled | bool | `false` | Enable Ingress for this chart. OR'd with the chart's local `ingress.enabled` so setting this once at the parent enables all subchart Ingresses. |
+| global.ingress.path | string | `"/"` | Default path applied to ingress rules when `ingress.path` is not set. AWS ALB users should override to `/*`. |
+| global.ingress.defaultPathType | string | `"Prefix"` | Default path type applied to ingress rules when `ingress.defaultPathType` is not set. `Prefix` works for nginx, traefik, AWS ALB, and most modern controllers. |
+| global.ingress.ingressClassName | string | `""` | Default ingress class name applied when `ingress.ingressClassName` is not set |
+| global.ingress.annotations | object | `{}` | Annotations merged into the Ingress. Local `ingress.annotations` wins on key collision. Evaluated as a template |
+| global.ingress.extraLabels | object | `{}` | Extra labels merged into the Ingress. Local `ingress.extraLabels` wins on key collision. Evaluated as a template |
+| global.ingress.tls | list | `[]` | TLS entries concatenated with the local `ingress.tls`. Evaluated as a template |
 | global.imageCredentials | list | `[]` | Optional credentials to log in and fetch images from a private registry. These credentials are shared with all the subcharts automatically |
 | global.imageCredentialsSecrets | list | `[]` | Optional list of existing Secrets containing image pull credentials to use for pulling images from private registries. These Secrets are shared with all the subcharts automatically |
 | redis.host | string | `""` | Redis hostname |
@@ -178,13 +185,13 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | serviceAccount.imagePullSecretNames | list | `[]` | Names of Secrets containing credentials to pull images from registries |
 | serviceAccount.automountServiceAccountToken | bool | `true` | Automount service account token when the ServiceAccount is generated |
 | ingress.enabled | bool | `false` | Enable ingress for Studios Proxy |
-| ingress.path | string | `"/"` | Path for the main ingress rule Note: this needs to be set to '/*' to be used with AWS ALB ingress controller |
-| ingress.defaultPathType | string | `"ImplementationSpecific"` | Default path type for the Ingress |
+| ingress.path | string | `""` | Path for the main ingress rule. When empty, falls back to `global.ingress.path` |
+| ingress.defaultPathType | string | `""` | Default path type for the Ingress. When empty, falls back to `global.ingress.defaultPathType` |
 | ingress.defaultBackend | object | `{}` | Configure the default service for the ingress (evaluated as template) Important: make sure only one defaultBackend is defined across the k8s cluster: if the ingress doesn't reconcile successfully, 'describe ingress <name>' will report problems |
 | ingress.extraHosts | list | `[]` | Additional hosts you want to include. Evaluated as a template |
 | ingress.annotations | object | `{}` | Ingress annotations specific to your load balancer. Evaluated as a template |
 | ingress.extraLabels | object | `{}` | Additional labels for the ingress object. Evaluated as a template |
-| ingress.ingressClassName | string | `""` | Name of the ingress class (replaces the deprecated annotation `kubernetes.io/ingress.class`) |
+| ingress.ingressClassName | string | `""` | Name of the ingress class (replaces the deprecated annotation `kubernetes.io/ingress.class`). When empty, falls back to `global.ingress.ingressClassName` |
 | ingress.tls | list | `[]` | TLS configuration. Evaluated as a template |
 | extraDeploy | list | `[]` | Array of extra objects to deploy with the release |
 | commonAnnotations | object | `{}` | Annotations to add to all deployed objects |

--- a/charts/platform/charts/studios/README.md.gotmpl
+++ b/charts/platform/charts/studios/README.md.gotmpl
@@ -16,6 +16,7 @@ https://docs.seqera.io/platform-enterprise/enterprise/configuration/pipeline_opt
 The chart does not automatically define `cr.seqera.io` as the registry where to take the images from: instructions are available to [vendor the Seqera container images to your private registry](https://docs.seqera.io/platform-enterprise/enterprise/prerequisites/common#vendoring-seqera-container-images-to-your-own-registry).
 
 The required values to set in order to have a working installation are:
+- The Seqera Platform Service connection details under `.global.platformServiceAddress` and `.global.platformServicePort`. These point to the Platform backend service that Studios communicates with. When deploying this subchart as part of the parent `platform` umbrella chart, these values are inherited automatically from the parent chart's `global` section.
 - The OIDC client registration token under `.proxy.oidcClientRegistrationToken` (or reference an existing Secret with `.proxy.oidcClientRegistrationTokenSecretName`). When deploying as part of the platform parent chart this is set automatically; when deploying standalone it must match the value configured in the platform backend.
 - The `.image` and the `.dbMigrationInitContainer.image` sections to point to your container registry.
 - Container registry credentials under the `.global.imageCredentials` section (can be the credentials for cr.seqera.io or your private registry where you vendored the images to).

--- a/charts/platform/charts/studios/templates/NOTES.txt
+++ b/charts/platform/charts/studios/templates/NOTES.txt
@@ -47,11 +47,13 @@ It contains validations that are run at install/upgrade time.
 {{- end -}}
 
 {{- if not .Values.global.platformServiceAddress -}}
-{{- fail "global.platformServiceAddress must be defined." -}}
+{{- $message := "Define the Seqera Platform Service address at 'global.platformServiceAddress'. This must point to the Platform backend service (Kubernetes hostname or external ingress)." -}}
+{{- printf "\nVALUES VALIDATION:\n%s" $message | fail -}}
 {{- end -}}
 
 {{- if eq (toString .Values.global.platformServicePort) "" -}}
-{{- fail "global.platformServicePort must be defined." -}}
+{{- $message := "Define the Seqera Platform Service port at 'global.platformServicePort'." -}}
+{{- printf "\nVALUES VALIDATION:\n%s" $message | fail -}}
 {{- end -}}
 
 {{- if not (and .Values.global.studiosDomain .Values.global.studiosConnectionUrl) -}}

--- a/charts/platform/charts/studios/templates/_helpers.tpl
+++ b/charts/platform/charts/studios/templates/_helpers.tpl
@@ -104,3 +104,13 @@ key: {{ include "studios.oidcToken.secretKey" $studiosContext }}
     {{- printf "CONNECT_OIDC_CLIENT_REGISTRATION_TOKEN" -}}
   {{- end -}}
 {{- end -}}
+
+{{/*
+Return this chart's primary ingress hostname. See parent platform chart's `_helpers.tpl` for
+usage notes — `'{{ include "seqera.ingress.host" . }}'` in `global.ingress.annotations` resolves
+to each chart's own domain at render time. Returns the bare studios domain — users wanting the
+wildcard form can write `'*.{{ include "seqera.ingress.host" . }}'`.
+*/}}
+{{- define "seqera.ingress.host" -}}
+{{- tpl .Values.global.studiosDomain . -}}
+{{- end -}}

--- a/charts/platform/charts/studios/templates/ingress.yaml
+++ b/charts/platform/charts/studios/templates/ingress.yaml
@@ -17,12 +17,16 @@
  limitations under the License.
 */}}
 
-{{ if .Values.ingress.enabled }}
+{{ if or .Values.ingress.enabled .Values.global.ingress.enabled }}
   {{- $commonLabels := include "common.labels.standard" (dict "customLabels" .Values.commonLabels "context" $) | fromYaml -}}
-  {{- $mergedlabels := include "common.tplvalues.merge" (dict "values" (list .Values.ingress.extraLabels $commonLabels) "context" .) -}}
+  {{- $mergedlabels := include "common.tplvalues.merge" (dict "values" (list .Values.ingress.extraLabels .Values.global.ingress.extraLabels $commonLabels) "context" .) -}}
   {{- $labels := include "common.tplvalues.render" (dict "value" $mergedlabels "context" $) -}}
-  {{- $mergedAnnotations := include "common.tplvalues.merge" (dict "values" (list .Values.ingress.annotations .Values.commonAnnotations) "context" .) -}}
+  {{- $mergedAnnotations := include "common.tplvalues.merge" (dict "values" (list .Values.ingress.annotations .Values.global.ingress.annotations .Values.commonAnnotations) "context" .) -}}
   {{- $annotations := include "common.tplvalues.render" (dict "value" $mergedAnnotations "context" $) -}}
+  {{- $defaultPathType := default .Values.global.ingress.defaultPathType .Values.ingress.defaultPathType -}}
+  {{- $path := default .Values.global.ingress.path .Values.ingress.path -}}
+  {{- $ingressClassName := default .Values.global.ingress.ingressClassName .Values.ingress.ingressClassName -}}
+  {{- $tls := concat (default (list) .Values.ingress.tls) (default (list) .Values.global.ingress.tls) -}}
 
 apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress
@@ -36,11 +40,11 @@ spec:
   defaultBackend: {{- include "seqera.tplvalues.render" (dict "value" . "context" $) | nindent 4 }}
   {{- end }}
 
-  {{- if .Values.ingress.ingressClassName }}
-  ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
+  {{- if $ingressClassName }}
+  ingressClassName: {{ $ingressClassName | quote }}
   {{- end }}
 
-  {{- with .Values.ingress.tls }}
+  {{- with $tls }}
   tls: {{- include "common.tplvalues.render" (dict "value" . "context" $) | nindent 4 }}
   {{- end }}
 
@@ -49,8 +53,8 @@ spec:
     - host: '{{ printf "*.%s" (tpl .Values.global.studiosDomain $) }}'
       http:
         paths:
-          - path: {{ .Values.ingress.path | quote }}
-            pathType: {{ .Values.ingress.defaultPathType }}
+          - path: {{ $path | quote }}
+            pathType: {{ $defaultPathType }}
             backend:
               service:
                 name: {{ printf "%s-proxy" (include "common.names.fullname" .) | quote }}
@@ -63,7 +67,7 @@ spec:
         paths:
     {{- range .paths }}
           - path: {{ .path }}
-            pathType: {{ .pathType | default $.Values.ingress.defaultPathType }}
+            pathType: {{ .pathType | default $defaultPathType }}
             backend:
               service:
                 name: {{ tpl .serviceName $ | quote }}

--- a/charts/platform/charts/studios/tests/NOTES_test.yaml
+++ b/charts/platform/charts/studios/tests/NOTES_test.yaml
@@ -136,7 +136,7 @@ tests:
         studiosConnectionUrl: '{{ printf "https://connect.%s" (tpl .Values.global.studiosDomain $) }}'
     asserts:
       - failedTemplate:
-          errorPattern: ".*global.platformServiceAddress must be defined.*"
+          errorPattern: "Define the Seqera Platform Service address at 'global.platformServiceAddress'"
 
   - it: should fail when global.platformServicePort is not defined
     set:
@@ -150,7 +150,7 @@ tests:
         platformServicePort: ""
     asserts:
       - failedTemplate:
-          errorPattern: ".*global.platformServicePort must be defined.*"
+          errorPattern: "Define the Seqera Platform Service port at 'global.platformServicePort'"
 
   - it: should pass when both global.studiosDomain and global.studiosConnectionUrl are defined
     set:

--- a/charts/platform/charts/studios/tests/__snapshot__/ingress_test.yaml.snap
+++ b/charts/platform/charts/studios/tests/__snapshot__/ingress_test.yaml.snap
@@ -9,7 +9,7 @@ should configure extra hosts with multiple paths:
                 port:
                   number: 80
             path: /
-            pathType: ImplementationSpecific
+            pathType: Prefix
     - host: api.example.com
       http:
         paths:
@@ -57,7 +57,7 @@ should render complete ingress with all features:
                     port:
                       number: 80
                 path: /
-                pathType: ImplementationSpecific
+                pathType: Prefix
         - host: admin.example.com
           http:
             paths:
@@ -97,4 +97,4 @@ should render ingress when enabled with defaults:
                     port:
                       number: 80
                 path: /
-                pathType: ImplementationSpecific
+                pathType: Prefix

--- a/charts/platform/charts/studios/tests/ingress_test.yaml
+++ b/charts/platform/charts/studios/tests/ingress_test.yaml
@@ -112,7 +112,7 @@ tests:
           value: "*.studios.example.com"
       - equal:
           path: spec.rules[0].http.paths[0].pathType
-          value: "ImplementationSpecific"
+          value: "Prefix"
       - equal:
           path: spec.rules[0].http.paths[0].path
           value: "/"
@@ -467,7 +467,7 @@ tests:
     asserts:
       - equal:
           path: spec.rules[1].http.paths[0].pathType
-          value: "ImplementationSpecific"
+          value: "Prefix"
 
   - it: should handle proxy.service.http.port as integer
     set:

--- a/charts/platform/charts/studios/values.yaml
+++ b/charts/platform/charts/studios/values.yaml
@@ -38,6 +38,29 @@ global:
   # subdomain under `.global.studiosDomain` anyway to connect. Evaluated as a template
   studiosConnectionUrl: '{{ printf "https://connect.%s" (tpl .Values.global.studiosDomain $) }}'
 
+  # Ingress defaults shared across the parent chart and all subcharts. Each subchart's local
+  # `ingress.*` value takes precedence when set; otherwise the global is used.
+  ingress:
+    # -- Enable Ingress for this chart. OR'd with the chart's local `ingress.enabled` so
+    # setting this once at the parent enables all subchart Ingresses.
+    enabled: false
+    # -- Default path applied to ingress rules when `ingress.path` is not set.
+    # AWS ALB users should override to `/*`.
+    path: "/"
+    # -- Default path type applied to ingress rules when `ingress.defaultPathType` is not set.
+    # `Prefix` works for nginx, traefik, AWS ALB, and most modern controllers.
+    defaultPathType: "Prefix"
+    # -- Default ingress class name applied when `ingress.ingressClassName` is not set
+    ingressClassName: ""
+    # -- Annotations merged into the Ingress. Local `ingress.annotations` wins on key collision.
+    # Evaluated as a template
+    annotations: {}
+    # -- Extra labels merged into the Ingress. Local `ingress.extraLabels` wins on key collision.
+    # Evaluated as a template
+    extraLabels: {}
+    # -- TLS entries concatenated with the local `ingress.tls`. Evaluated as a template
+    tls: []
+
   # -- Optional credentials to log in and fetch images from a private registry. These credentials
   # are shared with all the subcharts automatically
   imageCredentials: []
@@ -462,12 +485,11 @@ ingress:
   # -- Enable ingress for Studios Proxy
   enabled: false
 
-  # -- Path for the main ingress rule
-  # Note: this needs to be set to '/*' to be used with AWS ALB ingress controller
-  path: "/"
+  # -- Path for the main ingress rule. When empty, falls back to `global.ingress.path`
+  path: ""
 
-  # -- Default path type for the Ingress
-  defaultPathType: "ImplementationSpecific"
+  # -- Default path type for the Ingress. When empty, falls back to `global.ingress.defaultPathType`
+  defaultPathType: ""
 
   # -- Configure the default service for the ingress (evaluated as template)
   # Important: make sure only one defaultBackend is defined across the k8s cluster: if the
@@ -499,7 +521,8 @@ ingress:
   annotations: {}
   # -- Additional labels for the ingress object. Evaluated as a template
   extraLabels: {}
-  # -- Name of the ingress class (replaces the deprecated annotation `kubernetes.io/ingress.class`)
+  # -- Name of the ingress class (replaces the deprecated annotation `kubernetes.io/ingress.class`).
+  # When empty, falls back to `global.ingress.ingressClassName`
   ingressClassName: ""
   # -- TLS configuration. Evaluated as a template
   tls: []

--- a/charts/platform/charts/studios/values.yaml
+++ b/charts/platform/charts/studios/values.yaml
@@ -22,10 +22,14 @@ global:
   platformExternalDomain: example.com
 
   # -- Seqera Platform Service name: can be the internal Kubernetes hostname or an external ingress
-  # hostname. Evaluated as a template
-  platformServiceAddress: '{{ printf "%s-platform-backend" .Release.Name | lower }}'
-  # -- Seqera Platform Service port
-  platformServicePort: 8080
+  # hostname. Evaluated as a template.
+  # Required when deploying this subchart standalone. When deploying as part of the parent
+  # `platform` umbrella chart, this value is inherited from the parent chart's `global` section
+  platformServiceAddress: ""
+  # -- Seqera Platform Service port.
+  # Required when deploying this subchart standalone. When deploying as part of the parent
+  # `platform` umbrella chart, this value is inherited from the parent chart's `global` section
+  platformServicePort: ""
 
   # -- Domain where the Studios service listens. Make sure the TLS certificate covers this and its
   # wildcard subdomains. Evaluated as a template

--- a/charts/platform/charts/wave/CHANGELOG.md
+++ b/charts/platform/charts/wave/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2026-05-05
+
+- **Enhancement**: allow global configuration of Ingress options. A new `global.ingress` block (`enabled`, `path`, `defaultPathType`, `ingressClassName`, `annotations`, `extraLabels`, `tls`) lets cluster-wide Ingress defaults be set once at the parent and propagate to every subchart, removing the need to repeat controller-wide config per subchart. `enabled` is OR-merged; scalar fields fall back to global when local is unset; `annotations` and `extraLabels` are merged with local winning on key collision; `tls` is concatenated (useful for a single wildcard certificate across all services).
+- Add `seqera.ingress.host` template helper in each chart's `_helpers.tpl` returning that chart's primary domain. Lets users write `external-dns.alpha.kubernetes.io/hostname: '{{ include "seqera.ingress.host" . }}'` once in `global.ingress.annotations` and have it resolve to the correct host per chart at render time, without hard-coding hostnames.
+- Add `docs/conventions/ingress.md` documenting the Ingress conventions used across charts.
+
+### Changed
+
+- Update bitnami/common to 2.39.0
+- **BREAKING**: Default `ingress.defaultPathType` is now `Prefix` (was `ImplementationSpecific`). With the previous default and the chart's default `path: "/"`, routing behavior depended on the ingress controller — NGINX treated it as a prefix match, AWS ALB required `/*` for the same effect, GKE applied its own interpretation. The result was the same chart and values producing different routing across clusters. `Prefix` is part of the Kubernetes Ingress spec and produces consistent prefix-match semantics across NGINX, Traefik, AWS ALB, and most modern controllers, giving users a predictable out-of-the-box experience. Users whose controller still requires `ImplementationSpecific` (e.g. older GKE) can set `global.ingress.defaultPathType: ImplementationSpecific` once at the parent.
+
 ## [0.1.2] - 2026-04-30
 
 ### Changed

--- a/charts/platform/charts/wave/CHANGELOG.md
+++ b/charts/platform/charts/wave/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.2] - 2026-04-30
+
+### Changed
+
+- Bump `seqera-common` dependency to 2.1.2 (Redis init container log message now reports `auth set` or `auth not set`)
+
 ## [0.1.1] - 2026-04-30
 
 ### Changed

--- a/charts/platform/charts/wave/Chart.lock
+++ b/charts/platform/charts/wave/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 2.38.0
 - name: seqera-common
   repository: file://../../../seqera-common
-  version: 2.1.1
-digest: sha256:da56f594fa5462d454cf272386947bb8a4797df50c287d0130790b1a8b846f86
-generated: "2026-04-30T15:37:57.354532523+02:00"
+  version: 2.1.2
+digest: sha256:4d1319075460f2901b92a5aa964db5992673e65275005b33671b597179c47c83
+generated: "2026-04-30T17:18:37.887535625+02:00"

--- a/charts/platform/charts/wave/Chart.lock
+++ b/charts/platform/charts/wave/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.38.0
+  version: 2.39.0
 - name: seqera-common
   repository: file://../../../seqera-common
   version: 2.1.2
-digest: sha256:4d1319075460f2901b92a5aa964db5992673e65275005b33671b597179c47c83
-generated: "2026-04-30T17:18:37.887535625+02:00"
+digest: sha256:3eac4511073f329f614981ce9b91e6cdda035aa007a3aeecd7069958c9ede539
+generated: "2026-05-05T14:19:45.779728648+02:00"

--- a/charts/platform/charts/wave/Chart.yaml
+++ b/charts/platform/charts/wave/Chart.yaml
@@ -19,7 +19,7 @@ apiVersion: v2
 name: wave
 description: Wave
 type: application
-version: 0.1.2
+version: 0.2.0
 appVersion: "v1.32.4"
 maintainers:
   - name: Seqera Labs

--- a/charts/platform/charts/wave/Chart.yaml
+++ b/charts/platform/charts/wave/Chart.yaml
@@ -19,7 +19,7 @@ apiVersion: v2
 name: wave
 description: Wave
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: "v1.32.4"
 maintainers:
   - name: Seqera Labs

--- a/charts/platform/charts/wave/README.md
+++ b/charts/platform/charts/wave/README.md
@@ -2,7 +2,7 @@
 
 Wave
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.32.4](https://img.shields.io/badge/AppVersion-v1.32.4-informational?style=flat-square)
+![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.32.4](https://img.shields.io/badge/AppVersion-v1.32.4-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -35,7 +35,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/wave \
-  --version 0.1.1 \
+  --version 0.1.2 \
   --namespace my-namespace \
   --create-namespace
 ```

--- a/charts/platform/charts/wave/README.md
+++ b/charts/platform/charts/wave/README.md
@@ -2,7 +2,7 @@
 
 Wave
 
-![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.32.4](https://img.shields.io/badge/AppVersion-v1.32.4-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.32.4](https://img.shields.io/badge/AppVersion-v1.32.4-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -35,7 +35,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/wave \
-  --version 0.1.2 \
+  --version 0.2.0 \
   --namespace my-namespace \
   --create-namespace
 ```
@@ -59,6 +59,13 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 |-----|------|---------|-------------|
 | global.platformExternalDomain | string | `"example.com"` | Domain where Seqera Platform listens |
 | global.waveDomain | string | `"{{ printf \"wave.%s\" .Values.global.platformExternalDomain }}"` | Domain where Wave listens. Evaluated as a template |
+| global.ingress.enabled | bool | `false` | Enable Ingress for this chart. OR'd with the chart's local `ingress.enabled` so setting this once at the parent enables all subchart Ingresses. |
+| global.ingress.path | string | `"/"` | Default path applied to ingress rules when `ingress.path` is not set. AWS ALB users should override to `/*`. |
+| global.ingress.defaultPathType | string | `"Prefix"` | Default path type applied to ingress rules when `ingress.defaultPathType` is not set. `Prefix` works for nginx, traefik, AWS ALB, and most modern controllers. |
+| global.ingress.ingressClassName | string | `""` | Default ingress class name applied when `ingress.ingressClassName` is not set |
+| global.ingress.annotations | object | `{}` | Annotations merged into the Ingress. Local `ingress.annotations` wins on key collision. Evaluated as a template |
+| global.ingress.extraLabels | object | `{}` | Extra labels merged into the Ingress. Local `ingress.extraLabels` wins on key collision. Evaluated as a template |
+| global.ingress.tls | list | `[]` | TLS entries concatenated with the local `ingress.tls`. Evaluated as a template |
 | global.imageCredentials | list | `[]` | Optional credentials to log in and fetch images from a private registry. These credentials are shared with all the subcharts automatically |
 | global.imageCredentialsSecrets | list | `[]` | Optional list of existing Secrets containing image pull credentials to use for pulling images from private registries. These Secrets are shared with all the subcharts automatically |
 | micronautEnvironments | list | `["postgres","redis","lite"]` | List of Micronaut environments to enable |
@@ -169,13 +176,13 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | serviceAccount.imagePullSecretNames | list | `[]` | Names of Secrets containing credentials to pull images from registries |
 | serviceAccount.automountServiceAccountToken | bool | `true` | Automatically mount service account token |
 | ingress.enabled | bool | `false` | Enable ingress for Wave |
-| ingress.path | string | `"/"` | Path for the main ingress rule Note: this needs to be set to '/*' to be used with AWS ALB ingress controller |
-| ingress.defaultPathType | string | `"ImplementationSpecific"` | Default path type for the Ingress |
+| ingress.path | string | `""` | Path for the main ingress rule. When empty, falls back to `global.ingress.path` |
+| ingress.defaultPathType | string | `""` | Default path type for the Ingress. When empty, falls back to `global.ingress.defaultPathType` |
 | ingress.defaultBackend | object | `{}` | Configure the default service for the ingress (evaluated as template) Important: make sure only one defaultBackend is defined across the k8s cluster: if the ingress doesn't reconcile successfully, 'describe ingress <name>' will report problems |
 | ingress.extraHosts | list | `[]` | Additional hosts you want to include. Evaluated as a template |
 | ingress.annotations | object | `{}` | Ingress annotations specific to your load balancer. Evaluated as a template |
 | ingress.extraLabels | object | `{}` | Additional labels for the ingress object. Evaluated as a template |
-| ingress.ingressClassName | string | `""` | Name of the ingress class (replaces the deprecated annotation `kubernetes.io/ingress.class`) |
+| ingress.ingressClassName | string | `""` | Name of the ingress class (replaces the deprecated annotation `kubernetes.io/ingress.class`). When empty, falls back to `global.ingress.ingressClassName` |
 | ingress.tls | list | `[]` | TLS configuration. Evaluated as a template |
 | extraDeploy | list | `[]` | Array of extra objects to deploy with the release |
 | commonAnnotations | object | `{}` | Annotations to add to all deployed objects |

--- a/charts/platform/charts/wave/templates/_helpers.tpl
+++ b/charts/platform/charts/wave/templates/_helpers.tpl
@@ -92,3 +92,12 @@ Build the Wave micronaut envs list: always ensure required environments are pres
     {{- printf "WAVE_REDIS_PASSWORD" -}}
   {{- end -}}
 {{- end -}}
+
+{{/*
+Return this chart's primary ingress hostname. See parent platform chart's `_helpers.tpl` for
+usage notes — `'{{ include "seqera.ingress.host" . }}'` in `global.ingress.annotations` resolves
+to each chart's own domain at render time.
+*/}}
+{{- define "seqera.ingress.host" -}}
+{{- tpl .Values.global.waveDomain . -}}
+{{- end -}}

--- a/charts/platform/charts/wave/templates/ingress.yaml
+++ b/charts/platform/charts/wave/templates/ingress.yaml
@@ -17,12 +17,16 @@
  limitations under the License.
 */}}
 
-{{ if .Values.ingress.enabled }}
+{{ if or .Values.ingress.enabled .Values.global.ingress.enabled }}
   {{- $commonLabels := include "common.labels.standard" (dict "customLabels" .Values.commonLabels "context" $) | fromYaml -}}
-  {{- $mergedlabels := include "common.tplvalues.merge" (dict "values" (list .Values.ingress.extraLabels $commonLabels) "context" .) -}}
+  {{- $mergedlabels := include "common.tplvalues.merge" (dict "values" (list .Values.ingress.extraLabels .Values.global.ingress.extraLabels $commonLabels) "context" .) -}}
   {{- $labels := include "common.tplvalues.render" (dict "value" $mergedlabels "context" $) -}}
-  {{- $mergedAnnotations := include "common.tplvalues.merge" (dict "values" (list .Values.ingress.annotations .Values.commonAnnotations) "context" .) -}}
+  {{- $mergedAnnotations := include "common.tplvalues.merge" (dict "values" (list .Values.ingress.annotations .Values.global.ingress.annotations .Values.commonAnnotations) "context" .) -}}
   {{- $annotations := include "common.tplvalues.render" (dict "value" $mergedAnnotations "context" $) -}}
+  {{- $defaultPathType := default .Values.global.ingress.defaultPathType .Values.ingress.defaultPathType -}}
+  {{- $path := default .Values.global.ingress.path .Values.ingress.path -}}
+  {{- $ingressClassName := default .Values.global.ingress.ingressClassName .Values.ingress.ingressClassName -}}
+  {{- $tls := concat (default (list) .Values.ingress.tls) (default (list) .Values.global.ingress.tls) -}}
 
 apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress
@@ -36,11 +40,11 @@ spec:
   defaultBackend: {{- include "seqera.tplvalues.render" (dict "value" . "context" $) | nindent 4 }}
   {{- end }}
 
-  {{- if .Values.ingress.ingressClassName }}
-  ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
+  {{- if $ingressClassName }}
+  ingressClassName: {{ $ingressClassName | quote }}
   {{- end }}
 
-  {{- with .Values.ingress.tls }}
+  {{- with $tls }}
   tls: {{- include "common.tplvalues.render" (dict "value" . "context" $) | nindent 4 }}
   {{- end }}
 
@@ -49,8 +53,8 @@ spec:
     - host: {{ tpl .Values.global.waveDomain . | quote }}
       http:
         paths:
-          - path: {{ .Values.ingress.path | quote }}
-            pathType: {{ .Values.ingress.defaultPathType }}
+          - path: {{ $path | quote }}
+            pathType: {{ $defaultPathType }}
             backend:
               service:
                 name: {{ (include "common.names.fullname" .) | quote }}
@@ -62,7 +66,7 @@ spec:
         paths:
     {{- range .paths }}
           - path: {{ .path }}
-            pathType: {{ .pathType | default $.Values.ingress.defaultPathType }}
+            pathType: {{ .pathType | default $defaultPathType }}
             backend:
               service:
                 name: {{ tpl .serviceName $ | quote }}

--- a/charts/platform/charts/wave/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/platform/charts/wave/tests/__snapshot__/deployment_test.yaml.snap
@@ -130,7 +130,7 @@ should render a Deployment with default values:
                 - sh
                 - -c
                 - |
-                  echo "$(date): starting check redis '$REDIS_URI' (auth ${REDISCLI_AUTH:+set})"
+                  if [ -n "$REDISCLI_AUTH" ]; then echo "$(date): starting check redis '$REDIS_URI' (auth set)"; else echo "$(date): starting check redis '$REDIS_URI' (auth not set)"; fi
                   until redis-cli -u "$REDIS_URI" get hello; do
                     echo "$(date): see you in $SLEEP_PERIOD_SECONDS seconds"
                     sleep $SLEEP_PERIOD_SECONDS

--- a/charts/platform/charts/wave/tests/__snapshot__/ingress_test.yaml.snap
+++ b/charts/platform/charts/wave/tests/__snapshot__/ingress_test.yaml.snap
@@ -23,4 +23,4 @@ should render when ingress.enabled is true:
                     port:
                       number: 9090
                 path: /
-                pathType: ImplementationSpecific
+                pathType: Prefix

--- a/charts/platform/charts/wave/values.yaml
+++ b/charts/platform/charts/wave/values.yaml
@@ -24,6 +24,29 @@ global:
   # -- Domain where Wave listens. Evaluated as a template
   waveDomain: '{{ printf "wave.%s" .Values.global.platformExternalDomain }}'
 
+  # Ingress defaults shared across the parent chart and all subcharts. Each subchart's local
+  # `ingress.*` value takes precedence when set; otherwise the global is used.
+  ingress:
+    # -- Enable Ingress for this chart. OR'd with the chart's local `ingress.enabled` so
+    # setting this once at the parent enables all subchart Ingresses.
+    enabled: false
+    # -- Default path applied to ingress rules when `ingress.path` is not set.
+    # AWS ALB users should override to `/*`.
+    path: "/"
+    # -- Default path type applied to ingress rules when `ingress.defaultPathType` is not set.
+    # `Prefix` works for nginx, traefik, AWS ALB, and most modern controllers.
+    defaultPathType: "Prefix"
+    # -- Default ingress class name applied when `ingress.ingressClassName` is not set
+    ingressClassName: ""
+    # -- Annotations merged into the Ingress. Local `ingress.annotations` wins on key collision.
+    # Evaluated as a template
+    annotations: {}
+    # -- Extra labels merged into the Ingress. Local `ingress.extraLabels` wins on key collision.
+    # Evaluated as a template
+    extraLabels: {}
+    # -- TLS entries concatenated with the local `ingress.tls`. Evaluated as a template
+    tls: []
+
   # -- Optional credentials to log in and fetch images from a private registry. These credentials
   # are shared with all the subcharts automatically
   imageCredentials: []
@@ -398,12 +421,11 @@ ingress:
   # -- Enable ingress for Wave
   enabled: false
 
-  # -- Path for the main ingress rule
-  # Note: this needs to be set to '/*' to be used with AWS ALB ingress controller
-  path: "/"
+  # -- Path for the main ingress rule. When empty, falls back to `global.ingress.path`
+  path: ""
 
-  # -- Default path type for the Ingress
-  defaultPathType: "ImplementationSpecific"
+  # -- Default path type for the Ingress. When empty, falls back to `global.ingress.defaultPathType`
+  defaultPathType: ""
 
   # -- Configure the default service for the ingress (evaluated as template)
   # Important: make sure only one defaultBackend is defined across the k8s cluster: if the
@@ -435,7 +457,8 @@ ingress:
   annotations: {}
   # -- Additional labels for the ingress object. Evaluated as a template
   extraLabels: {}
-  # -- Name of the ingress class (replaces the deprecated annotation `kubernetes.io/ingress.class`)
+  # -- Name of the ingress class (replaces the deprecated annotation `kubernetes.io/ingress.class`).
+  # When empty, falls back to `global.ingress.ingressClassName`
   ingressClassName: ""
   # -- TLS configuration. Evaluated as a template
   tls: []

--- a/charts/platform/examples/ingress-configurations/README.md
+++ b/charts/platform/examples/ingress-configurations/README.md
@@ -188,13 +188,41 @@ ingress:
       secretName: wildcard-tls
 ```
 
+### Resolving a chart's hostname in annotations: `seqera.ingress.host`
+
+Each chart ships a `seqera.ingress.host` template helper that returns its own
+primary domain (`global.platformExternalDomain` for platform,
+`global.studiosDomain` for studios, etc.). Drop it into
+`global.ingress.annotations` once and every chart's Ingress renders with the
+right hostname — useful for things like external-dns where the annotation
+value needs to match the actual host:
+
+```yaml
+global:
+  ingress:
+    annotations:
+      external-dns.alpha.kubernetes.io/hostname: '{{ include "seqera.ingress.host" . }}'
+```
+
+For wildcard forms (e.g. studios uses `*.studios.example.com`), compose the
+helper:
+
+```yaml
+external-dns.alpha.kubernetes.io/hostname: '*.{{ include "seqera.ingress.host" . }}'
+```
+
 ### Path Types
 
-- `ImplementationSpecific` (default): Ingress controller decides interpretation
-- `Prefix`: Matches URL path prefix
+- `Prefix` (default): Matches URL path prefix — works for nginx, traefik, AWS ALB, and most modern controllers
+- `ImplementationSpecific`: Ingress controller decides interpretation
 - `Exact`: Exact path match only
 
-For AWS ALB, always use path `/*` and `Prefix` type.
+For AWS ALB, set `path: "/*"` (path syntax required by ALB). The default `Prefix`
+path type works fine.
+
+The default can be set once cluster-wide via `global.ingress.defaultPathType`,
+which propagates to every chart's Ingress. A chart's local
+`ingress.defaultPathType` still wins when set.
 
 ### Common Annotations
 

--- a/charts/platform/examples/ingress-configurations/aws-alb.yaml
+++ b/charts/platform/examples/ingress-configurations/aws-alb.yaml
@@ -98,6 +98,3 @@ ingress:
   # TLS handled by ACM certificate specified in annotations
   # Don't specify tls section when using ACM certificates
   tls: []
-
-  # Use Prefix path type (required for ALB with /*)
-  defaultPathType: Prefix

--- a/charts/platform/examples/ingress-configurations/extra-hosts.yaml
+++ b/charts/platform/examples/ingress-configurations/extra-hosts.yaml
@@ -88,5 +88,3 @@ ingress:
     - hosts:
         - user-data.example.com
       secretName: platform-content-tls
-
-  defaultPathType: Prefix

--- a/charts/platform/examples/ingress-configurations/nginx-cert-manager.yaml
+++ b/charts/platform/examples/ingress-configurations/nginx-cert-manager.yaml
@@ -15,6 +15,17 @@ global:
   # Separate domain for user-generated content (XSS protection)
   contentDomain: user-data.example.com
 
+  # Cluster-wide ingress defaults. Set once here and every chart's Ingress (platform plus any
+  # enabled subcharts like studios, wave, mcp) picks them up. Per-chart overrides under
+  # `<chart>.ingress.*` still win when set.
+  ingress:
+    ingressClassName: nginx
+    annotations:
+      # `seqera.ingress.host` resolves to each chart's own primary domain, so this single
+      # annotation registers the correct host per service (platform.example.com,
+      # studios.example.com, wave.example.com, …) without hard-coding hostnames.
+      external-dns.alpha.kubernetes.io/hostname: '{{ include "seqera.ingress.host" . }}'
+
   platformDatabase:
     host: mysql.example.com
     database: platform
@@ -37,8 +48,7 @@ backend:
 ingress:
   enabled: true
 
-  # NGINX ingress class
-  ingressClassName: nginx
+  # ingressClassName is set via global.ingress.ingressClassName above so subcharts inherit it.
 
   annotations:
     # cert-manager annotations for automatic TLS certificate provisioning
@@ -66,6 +76,3 @@ ingress:
     - hosts:
         - user-data.example.com
       secretName: platform-content-tls
-
-  # Default path type
-  defaultPathType: Prefix

--- a/charts/platform/examples/ingress-configurations/traefik.yaml
+++ b/charts/platform/examples/ingress-configurations/traefik.yaml
@@ -65,8 +65,6 @@ ingress:
         - user-data.example.com
       secretName: platform-content-tls
 
-  defaultPathType: Prefix
-
 # Note: For advanced Traefik configurations, consider using IngressRoute CRD
 # and add it via extraDeploy. Example:
 #

--- a/charts/platform/examples/ingress-configurations/wildcard-tls.yaml
+++ b/charts/platform/examples/ingress-configurations/wildcard-tls.yaml
@@ -76,5 +76,3 @@ ingress:
         - platform.example.com
         - user-data.example.com
       secretName: wildcard-tls  # Single wildcard certificate
-
-  defaultPathType: Prefix

--- a/charts/platform/templates/_helpers.tpl
+++ b/charts/platform/templates/_helpers.tpl
@@ -490,3 +490,12 @@ true
 false
   {{- end -}}
 {{- end -}}
+
+{{/*
+Return this chart's primary ingress hostname. Use `'{{ include "seqera.ingress.host" . }}'` in
+`global.ingress.annotations` (e.g. `external-dns.alpha.kubernetes.io/hostname`) and the correct
+host resolves per chart at render time without hard-coding it.
+*/}}
+{{- define "seqera.ingress.host" -}}
+{{- tpl .Values.global.platformExternalDomain . -}}
+{{- end -}}

--- a/charts/platform/templates/ingress.yaml
+++ b/charts/platform/templates/ingress.yaml
@@ -17,12 +17,16 @@
  limitations under the License.
 */}}
 
-{{ if .Values.ingress.enabled }}
+{{ if or .Values.ingress.enabled .Values.global.ingress.enabled }}
   {{- $commonLabels := include "common.labels.standard" (dict "customLabels" .Values.commonLabels "context" $) | fromYaml -}}
-  {{- $mergedlabels := include "common.tplvalues.merge" (dict "values" (list .Values.ingress.extraLabels $commonLabels) "context" .) -}}
+  {{- $mergedlabels := include "common.tplvalues.merge" (dict "values" (list .Values.ingress.extraLabels .Values.global.ingress.extraLabels $commonLabels) "context" .) -}}
   {{- $labels := include "common.tplvalues.render" (dict "value" $mergedlabels "context" $) -}}
-  {{- $mergedAnnotations := include "common.tplvalues.merge" (dict "values" (list .Values.ingress.annotations .Values.commonAnnotations) "context" .) -}}
+  {{- $mergedAnnotations := include "common.tplvalues.merge" (dict "values" (list .Values.ingress.annotations .Values.global.ingress.annotations .Values.commonAnnotations) "context" .) -}}
   {{- $annotations := include "common.tplvalues.render" (dict "value" $mergedAnnotations "context" $) -}}
+  {{- $defaultPathType := default .Values.global.ingress.defaultPathType .Values.ingress.defaultPathType -}}
+  {{- $path := default .Values.global.ingress.path .Values.ingress.path -}}
+  {{- $ingressClassName := default .Values.global.ingress.ingressClassName .Values.ingress.ingressClassName -}}
+  {{- $tls := concat (default (list) .Values.ingress.tls) (default (list) .Values.global.ingress.tls) -}}
 
 apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress
@@ -36,11 +40,11 @@ spec:
   defaultBackend: {{- include "seqera.tplvalues.render" (dict "value" . "context" $) | nindent 4 }}
   {{- end }}
 
-  {{- if .Values.ingress.ingressClassName }}
-  ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
+  {{- if $ingressClassName }}
+  ingressClassName: {{ $ingressClassName | quote }}
   {{- end }}
 
-  {{- with .Values.ingress.tls }}
+  {{- with $tls }}
   tls: {{- include "common.tplvalues.render" (dict "value" . "context" $) | nindent 4 }}
   {{- end }}
 
@@ -49,8 +53,8 @@ spec:
     - host: {{ tpl .Values.global.platformExternalDomain $ | quote }}
       http:
         paths:
-          - path: {{ .Values.ingress.path | quote }}
-            pathType: {{ .Values.ingress.defaultPathType }}
+          - path: {{ $path | quote }}
+            pathType: {{ $defaultPathType }}
             backend:
               service:
                 name: {{ printf "%s-frontend" (include "common.names.fullname" .) | quote }}
@@ -63,7 +67,7 @@ spec:
       http:
         paths:
           - path: {{ .Values.ingress.contentPath | quote }}
-            pathType: {{ .Values.ingress.defaultPathType }}
+            pathType: {{ $defaultPathType }}
             backend:
               service:
                 name: {{ printf "%s-frontend" (include "common.names.fullname" .) | quote }}
@@ -77,7 +81,7 @@ spec:
         paths:
     {{- range .paths }}
           - path: {{ .path }}
-            pathType: {{ .pathType | default $.Values.ingress.defaultPathType }}
+            pathType: {{ .pathType | default $defaultPathType }}
             backend:
               service:
                 name: {{ tpl .serviceName $ | quote }}

--- a/charts/platform/tests/__snapshot__/deployment-backend_test.yaml.snap
+++ b/charts/platform/tests/__snapshot__/deployment-backend_test.yaml.snap
@@ -123,7 +123,7 @@ should produce a Deployment resource with minimal values:
           - sh
           - -c
           - |
-            echo "$(date): starting check redis '$REDIS_URI' (auth ${REDISCLI_AUTH:+set})"
+            if [ -n "$REDISCLI_AUTH" ]; then echo "$(date): starting check redis '$REDIS_URI' (auth set)"; else echo "$(date): starting check redis '$REDIS_URI' (auth not set)"; fi
             until redis-cli -u "$REDIS_URI" get hello; do
               echo "$(date): see you in $SLEEP_PERIOD_SECONDS seconds"
               sleep $SLEEP_PERIOD_SECONDS
@@ -364,7 +364,7 @@ should render the backend deployment with the correct checksums, labels and anno
                 - sh
                 - -c
                 - |
-                  echo "$(date): starting check redis '$REDIS_URI' (auth ${REDISCLI_AUTH:+set})"
+                  if [ -n "$REDISCLI_AUTH" ]; then echo "$(date): starting check redis '$REDIS_URI' (auth set)"; else echo "$(date): starting check redis '$REDIS_URI' (auth not set)"; fi
                   until redis-cli -u "$REDIS_URI" get hello; do
                     echo "$(date): see you in $SLEEP_PERIOD_SECONDS seconds"
                     sleep $SLEEP_PERIOD_SECONDS

--- a/charts/platform/tests/__snapshot__/deployment-cron_test.yaml.snap
+++ b/charts/platform/tests/__snapshot__/deployment-cron_test.yaml.snap
@@ -118,7 +118,7 @@ should produce a Deployment resource with minimal values:
           - sh
           - -c
           - |
-            echo "$(date): starting check redis '$REDIS_URI' (auth ${REDISCLI_AUTH:+set})"
+            if [ -n "$REDISCLI_AUTH" ]; then echo "$(date): starting check redis '$REDIS_URI' (auth set)"; else echo "$(date): starting check redis '$REDIS_URI' (auth not set)"; fi
             until redis-cli -u "$REDIS_URI" get hello; do
               echo "$(date): see you in $SLEEP_PERIOD_SECONDS seconds"
               sleep $SLEEP_PERIOD_SECONDS
@@ -355,7 +355,7 @@ should render the cron deployment with the correct checksums, labels and annotat
                 - sh
                 - -c
                 - |
-                  echo "$(date): starting check redis '$REDIS_URI' (auth ${REDISCLI_AUTH:+set})"
+                  if [ -n "$REDISCLI_AUTH" ]; then echo "$(date): starting check redis '$REDIS_URI' (auth set)"; else echo "$(date): starting check redis '$REDIS_URI' (auth not set)"; fi
                   until redis-cli -u "$REDIS_URI" get hello; do
                     echo "$(date): see you in $SLEEP_PERIOD_SECONDS seconds"
                     sleep $SLEEP_PERIOD_SECONDS

--- a/charts/platform/tests/__snapshot__/ingress_test.yaml.snap
+++ b/charts/platform/tests/__snapshot__/ingress_test.yaml.snap
@@ -9,7 +9,7 @@ should configure extra hosts with multiple paths:
                 port:
                   number: 80
             path: /
-            pathType: ImplementationSpecific
+            pathType: Prefix
     - host: user-data.example.com
       http:
         paths:
@@ -19,7 +19,7 @@ should configure extra hosts with multiple paths:
                 port:
                   number: 80
             path: /
-            pathType: ImplementationSpecific
+            pathType: Prefix
     - host: api.example.com
       http:
         paths:

--- a/charts/platform/tests/ingress_test.yaml
+++ b/charts/platform/tests/ingress_test.yaml
@@ -31,6 +31,18 @@ tests:
   asserts:
   - hasDocuments:
       count: 0
+- it: should render ingress when global.ingress.enabled is true even if local is false
+  set:
+    ingress:
+      enabled: false
+    global:
+      ingress:
+        enabled: true
+  asserts:
+  - hasDocuments:
+      count: 1
+  - isKind:
+      of: Ingress
 - it: should set correct hostname
   set:
     ingress:
@@ -97,7 +109,7 @@ tests:
                 port:
                   number: 80
             path: /
-            pathType: ImplementationSpecific
+            pathType: Prefix
 - it: should not expose user-data. (content) subdomain when not set
   set:
     global:
@@ -118,7 +130,7 @@ tests:
                 port:
                   number: 80
             path: /
-            pathType: ImplementationSpecific
+            pathType: Prefix
 - it: should configure TLS when enabled
   set:
     ingress:
@@ -231,6 +243,111 @@ tests:
   - equal:
       path: spec.rules[1].http.paths[0].pathType
       value: Prefix
+- it: should fall back to global.ingress.defaultPathType when local is empty
+  set:
+    ingress:
+      enabled: true
+      defaultPathType: ""
+    global:
+      ingress:
+        defaultPathType: Prefix
+  asserts:
+  - equal:
+      path: spec.rules[0].http.paths[0].pathType
+      value: Prefix
+  - equal:
+      path: spec.rules[1].http.paths[0].pathType
+      value: Prefix
+- it: should resolve {{ include "seqera.ingress.host" . }} to the chart's primary domain in annotations
+  set:
+    global:
+      platformExternalDomain: platform.example.com
+      ingress:
+        annotations:
+          external-dns.alpha.kubernetes.io/hostname: '{{ include "seqera.ingress.host" . }}'
+    ingress:
+      enabled: true
+  asserts:
+  - equal:
+      path: metadata.annotations["external-dns.alpha.kubernetes.io/hostname"]
+      value: platform.example.com
+- it: should merge global.ingress.annotations with local annotations, local wins on collision
+  set:
+    ingress:
+      enabled: true
+      annotations:
+        nginx.ingress.kubernetes.io/proxy-body-size: "1g"
+        chart-only: "yes"
+    global:
+      ingress:
+        annotations:
+          cert-manager.io/cluster-issuer: letsencrypt-prod
+          nginx.ingress.kubernetes.io/proxy-body-size: "100m"
+  asserts:
+  - equal:
+      path: metadata.annotations
+      value:
+        cert-manager.io/cluster-issuer: letsencrypt-prod
+        chart-only: "yes"
+        nginx.ingress.kubernetes.io/proxy-body-size: "1g"
+- it: should merge global.ingress.extraLabels with local extraLabels, local wins on collision
+  set:
+    ingress:
+      enabled: true
+      extraLabels:
+        env: dev
+        chart: platform
+    global:
+      ingress:
+        extraLabels:
+          env: prod
+          team: devops
+  asserts:
+  - equal:
+      path: metadata.labels.env
+      value: dev
+  - equal:
+      path: metadata.labels.team
+      value: devops
+  - equal:
+      path: metadata.labels.chart
+      value: platform
+- it: should concatenate global.ingress.tls with local tls
+  set:
+    ingress:
+      enabled: true
+      tls:
+      - hosts:
+        - platform.example.com
+        secretName: platform-tls
+    global:
+      ingress:
+        tls:
+        - hosts:
+          - "*.example.com"
+          secretName: wildcard-tls
+  asserts:
+  - equal:
+      path: spec.tls
+      value:
+      - hosts:
+        - platform.example.com
+        secretName: platform-tls
+      - hosts:
+        - "*.example.com"
+        secretName: wildcard-tls
+- it: should prefer local ingress.defaultPathType over global
+  set:
+    ingress:
+      enabled: true
+      defaultPathType: Exact
+    global:
+      ingress:
+        defaultPathType: Prefix
+  asserts:
+  - equal:
+      path: spec.rules[0].http.paths[0].pathType
+      value: Exact
 - it: should use correct API version
   set:
     ingress:

--- a/charts/platform/values.yaml
+++ b/charts/platform/values.yaml
@@ -65,6 +65,35 @@ global:
   # -- Domain where the Portal Web frontend listens. Evaluated as a template
   portalWebDomain: '{{ printf "ai.%s" .Values.global.platformExternalDomain }}'
 
+  # Ingress defaults shared across the parent chart and all subcharts. Each subchart's local
+  # `ingress.*` value takes precedence when set; otherwise the global is used.
+  ingress:
+    # -- Enable Ingress for the parent chart and every subchart that exposes one. Each chart's
+    # local `ingress.enabled` is OR'd with this — set this to `true` to turn on all Ingresses
+    # in one switch
+    enabled: false
+    # -- Default path applied to ingress rules when a chart's local `ingress.path` is not set.
+    # AWS ALB users should override to `/*`.
+    path: "/"
+    # -- Default path type applied to ingress rules when a chart's local `ingress.defaultPathType`
+    # is not set. `Prefix` works for nginx, traefik, AWS ALB, and most modern controllers.
+    # Override to `ImplementationSpecific` only if your controller requires it (e.g. older GKE).
+    defaultPathType: "Prefix"
+    # -- Default ingress class name applied to ingress rules when a chart's local
+    # `ingress.ingressClassName` is not set. Replaces the deprecated `kubernetes.io/ingress.class`
+    # annotation
+    ingressClassName: ""
+    # -- Annotations merged into every chart's Ingress (e.g. cert-manager issuer, NGINX
+    # `proxy-body-size`, ALB SSL config). Local `ingress.annotations` wins on key collision.
+    # Evaluated as a template
+    annotations: {}
+    # -- Extra labels merged into every chart's Ingress. Local `ingress.extraLabels` wins on key
+    # collision. Evaluated as a template
+    extraLabels: {}
+    # -- TLS entries concatenated with each chart's local `ingress.tls`. Useful for a single
+    # wildcard cert that covers all services. Evaluated as a template
+    tls: []
+
   # -- Optional credentials to log in and fetch images from a private registry. These credentials
   # are shared with all the subcharts automatically
   imageCredentials: []
@@ -1302,16 +1331,14 @@ ingress:
   # -- Enable ingress for Platform
   enabled: false
 
-  # -- Path for the main ingress rule
-  # Note: this needs to be set to '/*' to be used with AWS ALB ingress controller
-  path: "/"
+  # -- Path for the main ingress rule. When empty, falls back to `global.ingress.path`
+  path: ""
 
   # -- Path for the content domain ingress rule
-  # Note: this needs to be set to '/*' to be used with AWS ALB ingress controller
   contentPath: "/"
 
-  # -- Default path type for the Ingress
-  defaultPathType: "ImplementationSpecific"
+  # -- Default path type for the Ingress. When empty, falls back to `global.ingress.defaultPathType`
+  defaultPathType: ""
 
   # -- Configure the default service for the ingress (evaluated as template)
   # Important: make sure only one defaultBackend is defined across the k8s cluster: if the
@@ -1343,7 +1370,8 @@ ingress:
   annotations: {}
   # -- Additional labels for the ingress object. Evaluated as a template
   extraLabels: {}
-  # -- Name of the ingress class (replaces the deprecated annotation `kubernetes.io/ingress.class`)
+  # -- Name of the ingress class (replaces the deprecated annotation `kubernetes.io/ingress.class`).
+  # When empty, falls back to `global.ingress.ingressClassName`
   ingressClassName: ""
   # -- TLS configuration. Evaluated as a template
   tls: []

--- a/charts/seqera-common/CHANGELOG.md
+++ b/charts/seqera-common/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.2] - 2026-04-30
+
+### Security
+
+- `seqera.initContainers.waitForRedis` wait-loop log message now reports `auth set` or `auth not set` instead of `auth set` or empty
+
 ## [2.1.1] - 2026-04-30
 
 ### Security

--- a/charts/seqera-common/Chart.yaml
+++ b/charts/seqera-common/Chart.yaml
@@ -19,7 +19,7 @@ apiVersion: v2
 type: library
 name: seqera-common
 appVersion: 1.0.0
-version: 2.1.1
+version: 2.1.2
 description: A Library Helm Chart for grouping common logic between Seqera charts.
   This chart is not deployable by itself.
 home: https://github.com/seqeralabs/helm-charts

--- a/charts/seqera-common/README.md
+++ b/charts/seqera-common/README.md
@@ -1,6 +1,6 @@
 # seqera-common
 
-![Version: 2.1.1](https://img.shields.io/badge/Version-2.1.1-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 2.1.2](https://img.shields.io/badge/Version-2.1.2-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 A Library Helm Chart for grouping common logic between Seqera charts. This chart is not deployable by itself.
 

--- a/charts/seqera-common/templates/_initcontainers.tpl
+++ b/charts/seqera-common/templates/_initcontainers.tpl
@@ -124,7 +124,7 @@ include "seqera.initContainers.waitForRedis" (dict "name" "redis" "waitValues" .
     - 'sh'
     - '-c'
     - |
-      echo "$(date): starting check redis '$REDIS_URI' (auth ${REDISCLI_AUTH:+set})"
+      if [ -n "$REDISCLI_AUTH" ]; then echo "$(date): starting check redis '$REDIS_URI' (auth set)"; else echo "$(date): starting check redis '$REDIS_URI' (auth not set)"; fi
       until redis-cli -u "$REDIS_URI" get hello; do
         echo "$(date): see you in $SLEEP_PERIOD_SECONDS seconds"
         sleep $SLEEP_PERIOD_SECONDS

--- a/docs/conventions/ingress.md
+++ b/docs/conventions/ingress.md
@@ -1,0 +1,281 @@
+# Ingress Conventions
+
+How Ingress resources are structured across the `platform` chart and its
+subcharts (`studios`, `portal-web`, `mcp`, `wave`, `agent-backend`).
+
+The goal is consistency: every chart that exposes HTTP traffic ships the same
+Ingress shape so users only have to learn one set of values.
+
+## One Ingress per chart
+
+Each chart that exposes HTTP traffic owns exactly one `templates/ingress.yaml`.
+Subcharts do not share an Ingress with the parent — each component is
+independently toggleable via its own `ingress.enabled`.
+
+When adding a new chart that needs HTTP exposure, copy the structure from an
+existing template (e.g. `charts/platform/charts/wave/templates/ingress.yaml`)
+rather than inventing a new shape.
+
+## Standard structure
+
+Every Ingress template follows the same skeleton:
+
+```gotemplate
+{{ if or .Values.ingress.enabled .Values.global.ingress.enabled }}
+  {{- $commonLabels := include "common.labels.standard" (dict "customLabels" .Values.commonLabels "context" $) | fromYaml -}}
+  {{- $mergedlabels := include "common.tplvalues.merge" (dict "values" (list .Values.ingress.extraLabels $commonLabels) "context" .) -}}
+  {{- $labels := include "common.tplvalues.render" (dict "value" $mergedlabels "context" $) -}}
+  {{- $mergedAnnotations := include "common.tplvalues.merge" (dict "values" (list .Values.ingress.annotations .Values.commonAnnotations) "context" .) -}}
+  {{- $annotations := include "common.tplvalues.render" (dict "value" $mergedAnnotations "context" $) -}}
+  {{- $defaultPathType := default .Values.global.ingress.defaultPathType .Values.ingress.defaultPathType -}}
+  {{- $path := default .Values.global.ingress.path .Values.ingress.path -}}
+  {{- $ingressClassName := default .Values.global.ingress.ingressClassName .Values.ingress.ingressClassName -}}
+
+apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
+kind: Ingress
+metadata:
+  name: {{ include "common.names.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- $labels | nindent 4 }}
+  annotations: {{- $annotations | nindent 4 }}
+spec:
+  {{- with .Values.ingress.defaultBackend }}
+  defaultBackend: {{- include "seqera.tplvalues.render" (dict "value" . "context" $) | nindent 4 }}
+  {{- end }}
+
+  {{- if $ingressClassName }}
+  ingressClassName: {{ $ingressClassName | quote }}
+  {{- end }}
+
+  {{- with .Values.ingress.tls }}
+  tls: {{- include "common.tplvalues.render" (dict "value" . "context" $) | nindent 4 }}
+  {{- end }}
+
+  rules:
+    - host: {{ tpl .Values.global.<chartDomain> . | quote }}
+      http:
+        paths:
+          - path: {{ $path | quote }}
+            pathType: {{ $defaultPathType }}
+            backend:
+              service:
+                name: {{ (include "common.names.fullname" .) | quote }}
+                port:
+                  number: {{ tpl (toString .Values.service.http.port) . | int }}
+
+  {{- range .Values.ingress.extraHosts }}
+    - host: {{ tpl .host $ | quote }}
+      http:
+        paths:
+    {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType | default $defaultPathType }}
+            backend:
+              service:
+                name: {{ tpl .serviceName $ | quote }}
+                port:
+                  number: {{ tpl (toString .portNumber) $ | int }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+```
+
+The pieces that should not change between charts:
+
+- **Gate**: `{{ if or .Values.ingress.enabled .Values.global.ingress.enabled }}` —
+  disabled by default; flipping `global.ingress.enabled: true` enables every
+  chart's Ingress at once.
+- **API version**: resolved via `common.capabilities.ingress.apiVersion`, never
+  hard-coded.
+- **Name / namespace**: `common.names.fullname` and `common.names.namespace`.
+- **Labels**: standard labels merged with `commonLabels` and
+  `ingress.extraLabels`, then `tpl`-rendered.
+- **Annotations**: `commonAnnotations` merged with `ingress.annotations`, then
+  `tpl`-rendered.
+- **`defaultBackend`, `ingressClassName`, `tls`**: optional, all rendered
+  through the same `tpl` helper so values can reference `.Release` etc.
+- **`extraHosts`**: every chart accepts the same `extraHosts` shape so users
+  can add hostnames without forking the chart.
+
+## Hostnames live in `global`
+
+Primary hostnames are pulled from `.Values.global.*Domain` so the parent chart
+and its subcharts can be wired up without duplicating values. Examples in use:
+
+| Chart           | Host source                                                                    |
+| --------------- | ------------------------------------------------------------------------------ |
+| `platform`      | `global.platformExternalDomain`, `global.contentDomain` (optional second host) |
+| `studios`       | `global.studiosDomain` (wildcard `*.<domain>`)                                 |
+| `portal-web`    | `global.portalWebDomain`                                                       |
+| `wave`          | `global.waveDomain`                                                            |
+| `mcp`           | `global.mcpDomain`                                                             |
+| `agent-backend` | `global.agentBackendDomain`                                                    |
+
+Hosts are always passed through `tpl` so they can reference other values
+(e.g. `'{{ printf "*.%s" .Values.global.studiosDomain }}'`).
+
+When adding a new chart, define a new `global.<name>Domain` value rather than
+introducing a chart-local `ingress.host`.
+
+## Backend service wiring
+
+The default rule's backend points at the chart's own Service, named via
+`common.names.fullname`. Two patterns appear:
+
+- **Single-service charts** (`portal-web`, `wave`, `mcp`, `agent-backend`):
+  backend is `{{ include "common.names.fullname" . }}`.
+- **Multi-service charts** (`platform`, `studios`): backend is suffixed —
+  `{{ printf "%s-frontend" (include "common.names.fullname" .) }}` for
+  `platform`, `-proxy` for `studios`.
+
+Ports are read from the relevant Service values block (e.g.
+`.Values.frontend.service.http.port`) and always rendered with
+`{{ tpl (toString ...) . | int }}` so templated ports survive the cast.
+
+## Cluster-wide ingress defaults via `global.ingress`
+
+In practice, users who expose one Seqera service via Ingress almost always expose
+them all the same way: same controller, same class name, same annotations
+(cert-manager, ALB scheme, NGINX body-size limits, etc.). Forcing those values
+to be repeated under `platform.ingress.*`, `studios.ingress.*`, `wave.ingress.*`,
+and so on is verbose and drift-prone. `global.ingress` lifts the controller-wide
+concerns to one place; per-chart overrides remain available for the rare case
+where one service genuinely needs different routing.
+
+Seven fields are controller-wide concerns rather than per-chart settings:
+
+| Field              | Local default | Global default | Resolution                                                       |
+| ------------------ | ------------- | -------------- | ---------------------------------------------------------------- |
+| `enabled`          | `false`       | `false`        | OR — either being `true` enables the Ingress                     |
+| `path`             | `""`          | `"/"`          | Local wins when set; otherwise global. ALB → `"/*"`              |
+| `defaultPathType`  | `""`          | `"Prefix"`     | Local wins when set; otherwise global                            |
+| `ingressClassName` | `""`          | `""`           | Local wins when set; otherwise global                            |
+| `annotations`      | `{}`          | `{}`           | Merged; local wins on key collision (e.g. cert-manager, ALB SSL) |
+| `extraLabels`      | `{}`          | `{}`           | Merged; local wins on key collision                              |
+| `tls`              | `[]`          | `[]`           | Concatenated — supports a single wildcard cert across charts     |
+
+Set these once at the parent's `global.ingress.*` and every subchart's Ingress
+picks them up. Three resolution patterns:
+
+- **OR** for `enabled` so flipping `global.ingress.enabled: true` turns on
+  every chart's Ingress in one switch.
+- **Local-wins-when-set** for the scalar fields (`path`, `defaultPathType`,
+  `ingressClassName`) so a chart can opt out of the cluster-wide default
+  without disabling it for everyone.
+- **Merge / concat** for the collection fields (`annotations`, `extraLabels`,
+  `tls`) so cluster-wide entries (cert-manager issuer, NGINX `proxy-body-size`,
+  wildcard cert) coexist with chart-specific additions.
+
+In templates the resolution is done once at the top:
+
+```gotemplate
+{{- $defaultPathType := default .Values.global.ingress.defaultPathType .Values.ingress.defaultPathType -}}
+{{- $path := default .Values.global.ingress.path .Values.ingress.path -}}
+{{- $ingressClassName := default .Values.global.ingress.ingressClassName .Values.ingress.ingressClassName -}}
+{{- $tls := concat (default (list) .Values.ingress.tls) (default (list) .Values.global.ingress.tls) -}}
+```
+
+`annotations` and `extraLabels` are merged inline as part of the existing
+`common.tplvalues.merge` chain — the global is added to the list of sources,
+positioned so local entries win on key collision.
+
+## The `seqera.ingress.host` helper
+
+Each chart's `_helpers.tpl` defines a template called `seqera.ingress.host`
+that returns that chart's primary domain (`global.platformExternalDomain` for
+platform, `global.studiosDomain` for studios, etc.). The point of having the
+same template name everywhere is that users can write a single annotation in
+`global.ingress.annotations` that resolves to the right hostname per chart:
+
+```yaml
+global:
+  ingress:
+    annotations:
+      external-dns.alpha.kubernetes.io/hostname: '{{ include "seqera.ingress.host" . }}'
+```
+
+When the platform chart renders its Ingress, the include resolves to
+`platform.example.com`. When studios renders, the same string resolves to
+`studios.example.com`. No hard-coding required, and it composes — for a
+wildcard form, write `'\*.{{ include "seqera.ingress.host" . }}'`.
+
+When adding a new chart, define `seqera.ingress.host` in its `_helpers.tpl`
+returning the chart's primary domain via `tpl`:
+
+```gotemplate
+{{- define "seqera.ingress.host" -}}
+{{- tpl .Values.global.<chartDomain> . -}}
+{{- end -}}
+```
+
+## TLS
+
+`ingress.tls` is an empty list by default. When set, it is rendered through
+`common.tplvalues.render` so users can template hostnames:
+
+```yaml
+ingress:
+  tls:
+    - hosts:
+        - "{{ .Values.global.platformExternalDomain }}"
+      secretName: my-tls
+```
+
+TLS secrets are **not** generated by the chart — bring your own (typically
+managed by cert-manager or external-secrets).
+
+## Annotations and ingress class
+
+- `ingressClassName` is the supported way to pick a controller. Do **not** use
+  the deprecated `kubernetes.io/ingress.class` annotation. Set it once at
+  `global.ingress.ingressClassName`; per-chart overrides are rare.
+- `ingress.annotations` is merged with `commonAnnotations`. Controller-specific
+  config (ALB, nginx, etc.) goes here.
+
+## Required values shape
+
+Every chart's `values.yaml` must expose this block under `ingress:`:
+
+```yaml
+ingress:
+  enabled: false
+  path: ""             # falls back to global.ingress.path
+  defaultPathType: ""  # falls back to global.ingress.defaultPathType
+  ingressClassName: "" # falls back to global.ingress.ingressClassName
+  defaultBackend: {}
+  extraHosts: []
+  annotations: {}
+  extraLabels: {}
+  tls: []
+```
+
+And in `global:`:
+
+```yaml
+global:
+  ingress:
+    enabled: false
+    path: "/"
+    defaultPathType: "Prefix"
+    ingressClassName: ""
+    annotations: {}
+    extraLabels: {}
+    tls: []
+```
+
+Keep the `# --` helm-docs comments on each field — the README is generated
+from them.
+
+## Testing
+
+Every Ingress template has a matching `tests/ingress_test.yaml`. Tests should
+cover at minimum:
+
+- Resource is **not** rendered when `ingress.enabled: false`.
+- A `matchSnapshot` for the default-enabled rendering.
+- Targeted `equal` assertions for `ingressClassName`, `tls`, `extraHosts`, and
+  any chart-specific host logic (e.g. the optional `contentDomain` rule in
+  `platform`, the wildcard host in `studios`).
+
+Follow the test rules in [CLAUDE.md](../../CLAUDE.md) — assert on whole
+maps/lists, not individual fields.


### PR DESCRIPTION
`global.platformServiceAddress` was copied as-is from the platform chart to its subcharts, which works fine when deploying the subcharts along with the main platform umbrella chart.
When deploying subcharts independently from the main chart, the platformServiceAddress is actually required, and it basically never matches the default value `<releasename>-platform-backend:8080`, breaking installations without an immediate error.

By emptying the values in the subcharts' values.yaml and adding input requirements we can prevent such errors in the future.