### PR TITLE
chore: improve wait-for-redis initcont no-auth-set message

### DIFF
--- a/charts/platform/CHANGELOG.md
+++ b/charts/platform/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.32.7] - 2026-04-30
+
+### Changed
+
+- Bump `seqera-common` to 2.1.2, `wave` to 0.1.2, `agent-backend` to 0.4.11, `mcp` to 0.3.6, `pipeline-optimization` to 2.0.5, `portal-web` to 0.2.8, `studios` to 1.2.15 (Redis init container log message now reports `auth set` or `auth not set`)
+
 ## [0.32.6] - 2026-04-30
 
 ### Changed

--- a/charts/platform/Chart.lock
+++ b/charts/platform/Chart.lock
@@ -4,24 +4,24 @@ dependencies:
   version: 2.38.0
 - name: seqera-common
   repository: file://../seqera-common
-  version: 2.1.1
+  version: 2.1.2
 - name: pipeline-optimization
   repository: file://charts/pipeline-optimization
-  version: 2.0.4
+  version: 2.0.5
 - name: studios
   repository: file://charts/studios
-  version: 1.2.14
+  version: 1.2.15
 - name: wave
   repository: file://charts/wave
-  version: 0.1.1
+  version: 0.1.2
 - name: mcp
   repository: file://charts/mcp
-  version: 0.3.5
+  version: 0.3.6
 - name: agent-backend
   repository: file://charts/agent-backend
-  version: 0.4.10
+  version: 0.4.11
 - name: portal-web
   repository: file://charts/portal-web
-  version: 0.2.7
-digest: sha256:4a6dd5e974677c8fccf8a1c408a8feb1c0e78bb60303a39b0080cc76fe5fa773
-generated: "2026-04-30T16:28:18.95822714+02:00"
+  version: 0.2.8
+digest: sha256:27521223337ca1b5d2afbb18b9cd356f53e6693e30ce7e0cc70cf35c5ae3c569
+generated: "2026-04-30T17:17:57.223873+02:00"

--- a/charts/platform/Chart.yaml
+++ b/charts/platform/Chart.yaml
@@ -37,7 +37,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.32.6
+version: 0.32.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/platform/README.md
+++ b/charts/platform/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart to deploy Seqera Platform (also referred to as Tower) on Kubernetes.
 
-![Version: 0.32.6](https://img.shields.io/badge/Version-0.32.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v25.3.4](https://img.shields.io/badge/AppVersion-v25.3.4-informational?style=flat-square)
+![Version: 0.32.7](https://img.shields.io/badge/Version-0.32.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v25.3.4](https://img.shields.io/badge/AppVersion-v25.3.4-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -41,7 +41,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/platform \
-  --version 0.32.6 \
+  --version 0.32.7 \
   --namespace my-namespace \
   --create-namespace
 ```

--- a/charts/platform/charts/agent-backend/CHANGELOG.md
+++ b/charts/platform/charts/agent-backend/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.11] - 2026-04-30
+
+### Changed
+
+- Bump `seqera-common` dependency to 2.1.2 (Redis init container log message now reports `auth set` or `auth not set`)
+
 ## [0.4.10] - 2026-04-30
 
 ### Changed

--- a/charts/platform/charts/agent-backend/Chart.lock
+++ b/charts/platform/charts/agent-backend/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 2.38.0
 - name: seqera-common
   repository: file://../../../seqera-common
-  version: 2.1.1
-digest: sha256:da56f594fa5462d454cf272386947bb8a4797df50c287d0130790b1a8b846f86
-generated: "2026-04-30T15:38:32.35183224+02:00"
+  version: 2.1.2
+digest: sha256:4d1319075460f2901b92a5aa964db5992673e65275005b33671b597179c47c83
+generated: "2026-04-30T17:18:03.74270588+02:00"

--- a/charts/platform/charts/agent-backend/Chart.yaml
+++ b/charts/platform/charts/agent-backend/Chart.yaml
@@ -19,7 +19,7 @@ apiVersion: v2
 name: agent-backend
 description: Backend service for Seqera CLI AI capabilities
 type: application
-version: 0.4.10
+version: 0.4.11
 appVersion: "2.0.0"
 maintainers:
   - name: Seqera Labs

--- a/charts/platform/charts/agent-backend/README.md
+++ b/charts/platform/charts/agent-backend/README.md
@@ -2,7 +2,7 @@
 
 Backend service for Seqera CLI AI capabilities
 
-![Version: 0.4.10](https://img.shields.io/badge/Version-0.4.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 0.4.11](https://img.shields.io/badge/Version-0.4.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -39,7 +39,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/agent-backend \
-  --version 0.4.10 \
+  --version 0.4.11 \
   --namespace my-namespace \
   --create-namespace
 ```

--- a/charts/platform/charts/agent-backend/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/platform/charts/agent-backend/tests/__snapshot__/deployment_test.yaml.snap
@@ -129,7 +129,7 @@ should render a Deployment with default values:
                 - sh
                 - -c
                 - |
-                  echo "$(date): starting check redis '$REDIS_URI' (auth ${REDISCLI_AUTH:+set}${REDISCLI_AUTH:-not set})"
+                  if [ -n "$REDISCLI_AUTH" ]; then echo "$(date): starting check redis '$REDIS_URI' (auth set)"; else echo "$(date): starting check redis '$REDIS_URI' (auth not set)"; fi
                   until redis-cli -u "$REDIS_URI" get hello; do
                     echo "$(date): see you in $SLEEP_PERIOD_SECONDS seconds"
                     sleep $SLEEP_PERIOD_SECONDS

--- a/charts/platform/charts/agent-backend/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/platform/charts/agent-backend/tests/__snapshot__/deployment_test.yaml.snap
@@ -129,7 +129,7 @@ should render a Deployment with default values:
                 - sh
                 - -c
                 - |
-                  echo "$(date): starting check redis '$REDIS_URI' (auth ${REDISCLI_AUTH:+set})"
+                  echo "$(date): starting check redis '$REDIS_URI' (auth ${REDISCLI_AUTH:+set}${REDISCLI_AUTH:-not set})"
                   until redis-cli -u "$REDIS_URI" get hello; do
                     echo "$(date): see you in $SLEEP_PERIOD_SECONDS seconds"
                     sleep $SLEEP_PERIOD_SECONDS

--- a/charts/platform/charts/mcp/CHANGELOG.md
+++ b/charts/platform/charts/mcp/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.6] - 2026-04-30
+
+### Changed
+
+- Bump `seqera-common` dependency to 2.1.2 (Redis init container log message now reports `auth set` or `auth not set`)
+
 ## [0.3.5] - 2026-04-30
 
 ### Changed

--- a/charts/platform/charts/mcp/Chart.lock
+++ b/charts/platform/charts/mcp/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 2.38.0
 - name: seqera-common
   repository: file://../../../seqera-common
-  version: 2.1.1
-digest: sha256:ce02e7a0f1f7ded086daa13cd2fd8d6850f75f7984f14d06dfe35d729924ff2d
-generated: "2026-04-30T15:38:40.11341971+02:00"
+  version: 2.1.2
+digest: sha256:66f5f1fb1ad2a6fd814da84d51f11c2a3f10633e1ba8d23f72eab6294ab68d49
+generated: "2026-04-30T17:18:10.359219514+02:00"

--- a/charts/platform/charts/mcp/Chart.yaml
+++ b/charts/platform/charts/mcp/Chart.yaml
@@ -22,7 +22,7 @@ description: |
   Wave container provisioning, bioinformatics data, and nf-core modules through intelligent
   RAG-based natural language interactions.
 type: application
-version: 0.3.5
+version: 0.3.6
 appVersion: "1.1.0"
 maintainers:
   - name: Seqera Labs

--- a/charts/platform/charts/mcp/README.md
+++ b/charts/platform/charts/mcp/README.md
@@ -4,7 +4,7 @@ A Model Context Protocol (MCP) server that provides comprehensive access to the 
 Wave container provisioning, bioinformatics data, and nf-core modules through intelligent
 RAG-based natural language interactions.
 
-![Version: 0.3.5](https://img.shields.io/badge/Version-0.3.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
+![Version: 0.3.6](https://img.shields.io/badge/Version-0.3.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -38,7 +38,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/mcp \
-  --version 0.3.5 \
+  --version 0.3.6 \
   --namespace my-namespace \
   --create-namespace
 ```

--- a/charts/platform/charts/pipeline-optimization/CHANGELOG.md
+++ b/charts/platform/charts/pipeline-optimization/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.5] - 2026-04-30
+
+### Changed
+
+- Bump `seqera-common` dependency to 2.1.2 (Redis init container log message now reports `auth set` or `auth not set`)
+
 ## [2.0.4] - 2026-04-30
 
 ### Changed

--- a/charts/platform/charts/pipeline-optimization/Chart.lock
+++ b/charts/platform/charts/pipeline-optimization/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 2.38.0
 - name: seqera-common
   repository: file://../../../seqera-common
-  version: 2.1.1
-digest: sha256:da56f594fa5462d454cf272386947bb8a4797df50c287d0130790b1a8b846f86
-generated: "2026-04-30T15:38:47.655519629+02:00"
+  version: 2.1.2
+digest: sha256:4d1319075460f2901b92a5aa964db5992673e65275005b33671b597179c47c83
+generated: "2026-04-30T17:18:17.504134609+02:00"

--- a/charts/platform/charts/pipeline-optimization/Chart.yaml
+++ b/charts/platform/charts/pipeline-optimization/Chart.yaml
@@ -23,7 +23,7 @@ maintainers:
     email: devops@seqera.io
     url: https://seqera.io
 type: application
-version: 2.0.4
+version: 2.0.5
 appVersion: "0.4.13"
 dependencies:
   - name: common

--- a/charts/platform/charts/pipeline-optimization/README.md
+++ b/charts/platform/charts/pipeline-optimization/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart to deploy the Seqera Pipeline Optimization service (referred to as Groundswell in Platform configuration files).
 
-![Version: 2.0.4](https://img.shields.io/badge/Version-2.0.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.13](https://img.shields.io/badge/AppVersion-0.4.13-informational?style=flat-square)
+![Version: 2.0.5](https://img.shields.io/badge/Version-2.0.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.13](https://img.shields.io/badge/AppVersion-0.4.13-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -37,7 +37,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/pipeline-optimization \
-  --version 2.0.4 \
+  --version 2.0.5 \
   --namespace my-namespace \
   --create-namespace
 ```

--- a/charts/platform/charts/portal-web/CHANGELOG.md
+++ b/charts/platform/charts/portal-web/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this chart will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.2.8] - 2026-04-30
+
+### Changed
+
+- Bump `seqera-common` dependency to 2.1.2 (Redis init container log message now reports `auth set` or `auth not set`)
+
 ## [0.2.7] - 2026-04-30
 
 ### Changed

--- a/charts/platform/charts/portal-web/Chart.lock
+++ b/charts/platform/charts/portal-web/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 2.38.0
 - name: seqera-common
   repository: file://../../../seqera-common
-  version: 2.1.1
-digest: sha256:ce02e7a0f1f7ded086daa13cd2fd8d6850f75f7984f14d06dfe35d729924ff2d
-generated: "2026-04-30T15:38:55.348142126+02:00"
+  version: 2.1.2
+digest: sha256:66f5f1fb1ad2a6fd814da84d51f11c2a3f10633e1ba8d23f72eab6294ab68d49
+generated: "2026-04-30T17:18:24.090883307+02:00"

--- a/charts/platform/charts/portal-web/Chart.yaml
+++ b/charts/platform/charts/portal-web/Chart.yaml
@@ -19,7 +19,7 @@ apiVersion: v2
 name: portal-web
 description: Portal web frontend for Seqera Platform
 type: application
-version: 0.2.7
+version: 0.2.8
 appVersion: "0.1.0"
 maintainers:
   - name: Seqera Labs

--- a/charts/platform/charts/portal-web/README.md
+++ b/charts/platform/charts/portal-web/README.md
@@ -2,7 +2,7 @@
 
 Portal web frontend for Seqera Platform
 
-![Version: 0.2.7](https://img.shields.io/badge/Version-0.2.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.2.8](https://img.shields.io/badge/Version-0.2.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -32,7 +32,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/portal-web \
-  --version 0.2.7 \
+  --version 0.2.8 \
   --namespace my-namespace \
   --create-namespace
 ```

--- a/charts/platform/charts/studios/CHANGELOG.md
+++ b/charts/platform/charts/studios/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.15] - 2026-04-30
+
+### Changed
+
+- Bump `seqera-common` dependency to 2.1.2 (Redis init container log message now reports `auth set` or `auth not set`)
+
 ## [1.2.14] - 2026-04-30
 
 ### Changed

--- a/charts/platform/charts/studios/Chart.lock
+++ b/charts/platform/charts/studios/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 2.38.0
 - name: seqera-common
   repository: file://../../../seqera-common
-  version: 2.1.1
-digest: sha256:da56f594fa5462d454cf272386947bb8a4797df50c287d0130790b1a8b846f86
-generated: "2026-04-30T15:39:03.333125496+02:00"
+  version: 2.1.2
+digest: sha256:4d1319075460f2901b92a5aa964db5992673e65275005b33671b597179c47c83
+generated: "2026-04-30T17:18:31.198120058+02:00"

--- a/charts/platform/charts/studios/Chart.yaml
+++ b/charts/platform/charts/studios/Chart.yaml
@@ -21,7 +21,7 @@ name: studios
 description: Studios is a unified platform for interactive analysis
 sources:
   - https://github.com/seqeralabs/helm-charts/tree/main/seqera/charts/studios
-version: 1.2.14
+version: 1.2.15
 appVersion: "0.11.0"
 maintainers:
   - name: Seqera Labs

--- a/charts/platform/charts/studios/README.md
+++ b/charts/platform/charts/studios/README.md
@@ -2,7 +2,7 @@
 
 Studios is a unified platform for interactive analysis
 
-![Version: 1.2.14](https://img.shields.io/badge/Version-1.2.14-informational?style=flat-square) ![AppVersion: 0.11.0](https://img.shields.io/badge/AppVersion-0.11.0-informational?style=flat-square)
+![Version: 1.2.15](https://img.shields.io/badge/Version-1.2.15-informational?style=flat-square) ![AppVersion: 0.11.0](https://img.shields.io/badge/AppVersion-0.11.0-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -41,7 +41,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/studios \
-  --version 1.2.14 \
+  --version 1.2.15 \
   --namespace my-namespace \
   --create-namespace
 ```

--- a/charts/platform/charts/wave/CHANGELOG.md
+++ b/charts/platform/charts/wave/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.2] - 2026-04-30
+
+### Changed
+
+- Bump `seqera-common` dependency to 2.1.2 (Redis init container log message now reports `auth set` or `auth not set`)
+
 ## [0.1.1] - 2026-04-30
 
 ### Changed

--- a/charts/platform/charts/wave/Chart.lock
+++ b/charts/platform/charts/wave/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 2.38.0
 - name: seqera-common
   repository: file://../../../seqera-common
-  version: 2.1.1
-digest: sha256:da56f594fa5462d454cf272386947bb8a4797df50c287d0130790b1a8b846f86
-generated: "2026-04-30T15:37:57.354532523+02:00"
+  version: 2.1.2
+digest: sha256:4d1319075460f2901b92a5aa964db5992673e65275005b33671b597179c47c83
+generated: "2026-04-30T17:18:37.887535625+02:00"

--- a/charts/platform/charts/wave/Chart.yaml
+++ b/charts/platform/charts/wave/Chart.yaml
@@ -19,7 +19,7 @@ apiVersion: v2
 name: wave
 description: Wave
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: "v1.32.4"
 maintainers:
   - name: Seqera Labs

--- a/charts/platform/charts/wave/README.md
+++ b/charts/platform/charts/wave/README.md
@@ -2,7 +2,7 @@
 
 Wave
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.32.4](https://img.shields.io/badge/AppVersion-v1.32.4-informational?style=flat-square)
+![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.32.4](https://img.shields.io/badge/AppVersion-v1.32.4-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -35,7 +35,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/wave \
-  --version 0.1.1 \
+  --version 0.1.2 \
   --namespace my-namespace \
   --create-namespace
 ```

--- a/charts/platform/charts/wave/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/platform/charts/wave/tests/__snapshot__/deployment_test.yaml.snap
@@ -130,7 +130,7 @@ should render a Deployment with default values:
                 - sh
                 - -c
                 - |
-                  echo "$(date): starting check redis '$REDIS_URI' (auth ${REDISCLI_AUTH:+set})"
+                  echo "$(date): starting check redis '$REDIS_URI' (auth ${REDISCLI_AUTH:+set}${REDISCLI_AUTH:-not set})"
                   until redis-cli -u "$REDIS_URI" get hello; do
                     echo "$(date): see you in $SLEEP_PERIOD_SECONDS seconds"
                     sleep $SLEEP_PERIOD_SECONDS

--- a/charts/platform/charts/wave/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/platform/charts/wave/tests/__snapshot__/deployment_test.yaml.snap
@@ -130,7 +130,7 @@ should render a Deployment with default values:
                 - sh
                 - -c
                 - |
-                  echo "$(date): starting check redis '$REDIS_URI' (auth ${REDISCLI_AUTH:+set}${REDISCLI_AUTH:-not set})"
+                  if [ -n "$REDISCLI_AUTH" ]; then echo "$(date): starting check redis '$REDIS_URI' (auth set)"; else echo "$(date): starting check redis '$REDIS_URI' (auth not set)"; fi
                   until redis-cli -u "$REDIS_URI" get hello; do
                     echo "$(date): see you in $SLEEP_PERIOD_SECONDS seconds"
                     sleep $SLEEP_PERIOD_SECONDS

--- a/charts/platform/tests/__snapshot__/deployment-backend_test.yaml.snap
+++ b/charts/platform/tests/__snapshot__/deployment-backend_test.yaml.snap
@@ -123,7 +123,7 @@ should produce a Deployment resource with minimal values:
           - sh
           - -c
           - |
-            echo "$(date): starting check redis '$REDIS_URI' (auth ${REDISCLI_AUTH:+set}${REDISCLI_AUTH:-not set})"
+            if [ -n "$REDISCLI_AUTH" ]; then echo "$(date): starting check redis '$REDIS_URI' (auth set)"; else echo "$(date): starting check redis '$REDIS_URI' (auth not set)"; fi
             until redis-cli -u "$REDIS_URI" get hello; do
               echo "$(date): see you in $SLEEP_PERIOD_SECONDS seconds"
               sleep $SLEEP_PERIOD_SECONDS
@@ -364,7 +364,7 @@ should render the backend deployment with the correct checksums, labels and anno
                 - sh
                 - -c
                 - |
-                  echo "$(date): starting check redis '$REDIS_URI' (auth ${REDISCLI_AUTH:+set}${REDISCLI_AUTH:-not set})"
+                  if [ -n "$REDISCLI_AUTH" ]; then echo "$(date): starting check redis '$REDIS_URI' (auth set)"; else echo "$(date): starting check redis '$REDIS_URI' (auth not set)"; fi
                   until redis-cli -u "$REDIS_URI" get hello; do
                     echo "$(date): see you in $SLEEP_PERIOD_SECONDS seconds"
                     sleep $SLEEP_PERIOD_SECONDS

--- a/charts/platform/tests/__snapshot__/deployment-backend_test.yaml.snap
+++ b/charts/platform/tests/__snapshot__/deployment-backend_test.yaml.snap
@@ -123,7 +123,7 @@ should produce a Deployment resource with minimal values:
           - sh
           - -c
           - |
-            echo "$(date): starting check redis '$REDIS_URI' (auth ${REDISCLI_AUTH:+set})"
+            echo "$(date): starting check redis '$REDIS_URI' (auth ${REDISCLI_AUTH:+set}${REDISCLI_AUTH:-not set})"
             until redis-cli -u "$REDIS_URI" get hello; do
               echo "$(date): see you in $SLEEP_PERIOD_SECONDS seconds"
               sleep $SLEEP_PERIOD_SECONDS
@@ -364,7 +364,7 @@ should render the backend deployment with the correct checksums, labels and anno
                 - sh
                 - -c
                 - |
-                  echo "$(date): starting check redis '$REDIS_URI' (auth ${REDISCLI_AUTH:+set})"
+                  echo "$(date): starting check redis '$REDIS_URI' (auth ${REDISCLI_AUTH:+set}${REDISCLI_AUTH:-not set})"
                   until redis-cli -u "$REDIS_URI" get hello; do
                     echo "$(date): see you in $SLEEP_PERIOD_SECONDS seconds"
                     sleep $SLEEP_PERIOD_SECONDS

--- a/charts/platform/tests/__snapshot__/deployment-cron_test.yaml.snap
+++ b/charts/platform/tests/__snapshot__/deployment-cron_test.yaml.snap
@@ -118,7 +118,7 @@ should produce a Deployment resource with minimal values:
           - sh
           - -c
           - |
-            echo "$(date): starting check redis '$REDIS_URI' (auth ${REDISCLI_AUTH:+set}${REDISCLI_AUTH:-not set})"
+            if [ -n "$REDISCLI_AUTH" ]; then echo "$(date): starting check redis '$REDIS_URI' (auth set)"; else echo "$(date): starting check redis '$REDIS_URI' (auth not set)"; fi
             until redis-cli -u "$REDIS_URI" get hello; do
               echo "$(date): see you in $SLEEP_PERIOD_SECONDS seconds"
               sleep $SLEEP_PERIOD_SECONDS
@@ -355,7 +355,7 @@ should render the cron deployment with the correct checksums, labels and annotat
                 - sh
                 - -c
                 - |
-                  echo "$(date): starting check redis '$REDIS_URI' (auth ${REDISCLI_AUTH:+set}${REDISCLI_AUTH:-not set})"
+                  if [ -n "$REDISCLI_AUTH" ]; then echo "$(date): starting check redis '$REDIS_URI' (auth set)"; else echo "$(date): starting check redis '$REDIS_URI' (auth not set)"; fi
                   until redis-cli -u "$REDIS_URI" get hello; do
                     echo "$(date): see you in $SLEEP_PERIOD_SECONDS seconds"
                     sleep $SLEEP_PERIOD_SECONDS

--- a/charts/platform/tests/__snapshot__/deployment-cron_test.yaml.snap
+++ b/charts/platform/tests/__snapshot__/deployment-cron_test.yaml.snap
@@ -118,7 +118,7 @@ should produce a Deployment resource with minimal values:
           - sh
           - -c
           - |
-            echo "$(date): starting check redis '$REDIS_URI' (auth ${REDISCLI_AUTH:+set})"
+            echo "$(date): starting check redis '$REDIS_URI' (auth ${REDISCLI_AUTH:+set}${REDISCLI_AUTH:-not set})"
             until redis-cli -u "$REDIS_URI" get hello; do
               echo "$(date): see you in $SLEEP_PERIOD_SECONDS seconds"
               sleep $SLEEP_PERIOD_SECONDS
@@ -355,7 +355,7 @@ should render the cron deployment with the correct checksums, labels and annotat
                 - sh
                 - -c
                 - |
-                  echo "$(date): starting check redis '$REDIS_URI' (auth ${REDISCLI_AUTH:+set})"
+                  echo "$(date): starting check redis '$REDIS_URI' (auth ${REDISCLI_AUTH:+set}${REDISCLI_AUTH:-not set})"
                   until redis-cli -u "$REDIS_URI" get hello; do
                     echo "$(date): see you in $SLEEP_PERIOD_SECONDS seconds"
                     sleep $SLEEP_PERIOD_SECONDS

--- a/charts/seqera-common/CHANGELOG.md
+++ b/charts/seqera-common/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.2] - 2026-04-30
+
+### Security
+
+- `seqera.initContainers.waitForRedis` wait-loop log message now reports `auth set` or `auth not set` instead of `auth set` or empty
+
 ## [2.1.1] - 2026-04-30
 
 ### Security

--- a/charts/seqera-common/Chart.yaml
+++ b/charts/seqera-common/Chart.yaml
@@ -19,7 +19,7 @@ apiVersion: v2
 type: library
 name: seqera-common
 appVersion: 1.0.0
-version: 2.1.1
+version: 2.1.2
 description: A Library Helm Chart for grouping common logic between Seqera charts.
   This chart is not deployable by itself.
 home: https://github.com/seqeralabs/helm-charts

--- a/charts/seqera-common/README.md
+++ b/charts/seqera-common/README.md
@@ -1,6 +1,6 @@
 # seqera-common
 
-![Version: 2.1.1](https://img.shields.io/badge/Version-2.1.1-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 2.1.2](https://img.shields.io/badge/Version-2.1.2-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 A Library Helm Chart for grouping common logic between Seqera charts. This chart is not deployable by itself.
 

--- a/charts/seqera-common/templates/_initcontainers.tpl
+++ b/charts/seqera-common/templates/_initcontainers.tpl
@@ -124,7 +124,7 @@ include "seqera.initContainers.waitForRedis" (dict "name" "redis" "waitValues" .
     - 'sh'
     - '-c'
     - |
-      echo "$(date): starting check redis '$REDIS_URI' (auth ${REDISCLI_AUTH:+set}${REDISCLI_AUTH:-not set})"
+      if [ -n "$REDISCLI_AUTH" ]; then echo "$(date): starting check redis '$REDIS_URI' (auth set)"; else echo "$(date): starting check redis '$REDIS_URI' (auth not set)"; fi
       until redis-cli -u "$REDIS_URI" get hello; do
         echo "$(date): see you in $SLEEP_PERIOD_SECONDS seconds"
         sleep $SLEEP_PERIOD_SECONDS

--- a/charts/seqera-common/templates/_initcontainers.tpl
+++ b/charts/seqera-common/templates/_initcontainers.tpl
@@ -124,7 +124,7 @@ include "seqera.initContainers.waitForRedis" (dict "name" "redis" "waitValues" .
     - 'sh'
     - '-c'
     - |
-      echo "$(date): starting check redis '$REDIS_URI' (auth ${REDISCLI_AUTH:+set})"
+      echo "$(date): starting check redis '$REDIS_URI' (auth ${REDISCLI_AUTH:+set}${REDISCLI_AUTH:-not set})"
       until redis-cli -u "$REDIS_URI" get hello; do
         echo "$(date): see you in $SLEEP_PERIOD_SECONDS seconds"
         sleep $SLEEP_PERIOD_SECONDS


### PR DESCRIPTION
Fix on top of #130 to improve logs when no authentication password is provided (now `(auth not set)` is printed, compared to `(auth )`).

Also update the seqera-common dependency in wave and agent-backend reported in https://github.com/seqeralabs/helm-charts/pull/132