### PR TITLE
feat: reorganize agent-backend providers, bump chart to 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ Currently, it includes charts for:
   Nextflow pipelines running on Platform - internally referred to as Groundswell.
 - [Seqera MCP](./charts/platform/charts/mcp/README.md): Model Context Protocol (MCP) server to allow LLMs to
   interact with Seqera products.
-- [Seqera AI Backend](./charts/platform/charts/agent-backend/README.md): Backend service for Seqera CLI AI
+- [Agent Backend](./charts/platform/charts/agent-backend/README.md): Backend service for Seqera Co-Scientist CLI
   capabilities.
-- [Seqera Portal web interface](./charts/platform/charts/portal-web/README.md): Web service for Seqera AI
+- [Portal](./charts/platform/charts/portal-web/README.md): Web service for Seqera Co-Scientist
 - [Seqera Common](./charts/common/README.md): Library chart with shared resources and configurations
 
 The Platform chart is the main chart, and other charts can be deployed as sub-charts of Platform.

--- a/VENDORING.md
+++ b/VENDORING.md
@@ -6,7 +6,7 @@ internal OCI registry.
 
 Seqera images are hosted on `cr.seqera.io`. Similarly, we recommend vendoring (replicating) images
 into your own internal container registry. Refer to the [Seqera
-documentation](https://docs.seqera.io/platform-enterprise/enterprise/prerequisites/common#vendoring-seqera-container-images-to-your-own-registry)
+documentation](https://docs.seqera.io/platform-enterprise/enterprise/configuration/mirroring)
 for more information.
 
 ## Automatic replication via Container Registry feature - recommended approach

--- a/charts/platform/CHANGELOG.md
+++ b/charts/platform/CHANGELOG.md
@@ -189,8 +189,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **BREAKING** Bump MCP subchart to 0.2.0: removed support for custom OAuth provider. MCP now exclusively uses Seqera Platform as the OAuth provider. Removed values: `oauth.clientId`, `oauth.clientSecretString`, `oauth.clientSecretExistingSecretName`, `oauth.clientSecretExistingSecretKey`
-- Add Seqera AI installation example
-- Refine Seqera AI and MCP wording in documentation
+- Add Seqera Co-Scientist installation example
+- Refine Seqera Co-Scientist and MCP wording in documentation
 
 ## [0.28.3] - 2026-03-26
 

--- a/charts/platform/CHANGELOG.md
+++ b/charts/platform/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.33.1] - 2026-05-11
+
+### Changed
+
+- Bump `agent-backend` to 1.0.0: provider configuration redesigned to support multiple LLM providers. See [agent-backend CHANGELOG](charts/agent-backend/CHANGELOG.md) for the full migration guide.
+
 ## [0.33.0] - 2026-04-30
 
 ### Added

--- a/charts/platform/CHANGELOG.md
+++ b/charts/platform/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `mcp`: Bump app version to 1.3.0.
+- `mcp`: `TOWER_API_ENDPOINT` now uses the internal platform service address and port (`global.platformServiceAddress`/`global.platformServicePort`) instead of the external domain.
 - Bump `agent-backend` to 1.0.0: provider configuration redesigned to support multiple LLM providers. See [agent-backend CHANGELOG](charts/agent-backend/CHANGELOG.md) for the full migration guide.
 - `agent-backend`: remove redundant Anthropic validation from NOTES.txt, add `bedrock.sandbox.runtimeArn` required validator, replace `NEXTFLOW_DOCS_USE_REDIS_INDEX` with `NEXTFLOW_DOCS_TOOL`.
 - Update image paths in the README and values.yaml - the chart does not hardcode `cr.seqera.io` as the registry, customers are invited to vendor the images to their private registry as well as the charts.

--- a/charts/platform/CHANGELOG.md
+++ b/charts/platform/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bump `agent-backend` to 1.0.0: provider configuration redesigned to support multiple LLM providers. See [agent-backend CHANGELOG](charts/agent-backend/CHANGELOG.md) for the full migration guide.
+- `agent-backend`: remove redundant Anthropic validation from NOTES.txt, add `bedrock.sandbox.runtimeArn` required validator, replace `NEXTFLOW_DOCS_USE_REDIS_INDEX` with `NEXTFLOW_DOCS_TOOL`.
 
 ## [0.33.0] - 2026-04-30
 

--- a/charts/platform/CHANGELOG.md
+++ b/charts/platform/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `agent-backend` to 1.0.0: provider configuration redesigned to support multiple LLM providers. See [agent-backend CHANGELOG](charts/agent-backend/CHANGELOG.md) for the full migration guide.
 - `agent-backend`: remove redundant Anthropic validation from NOTES.txt, add `bedrock.sandbox.runtimeArn` required validator, replace `NEXTFLOW_DOCS_USE_REDIS_INDEX` with `NEXTFLOW_DOCS_TOOL`.
+- Update image paths in the README and values.yaml - the chart does not hardcode `cr.seqera.io` as the registry, customers are invited to vendor the images to their private registry as well as the charts.
 
 ## [0.33.0] - 2026-04-30
 

--- a/charts/platform/Chart.lock
+++ b/charts/platform/Chart.lock
@@ -19,9 +19,9 @@ dependencies:
   version: 0.4.0
 - name: agent-backend
   repository: file://charts/agent-backend
-  version: 0.5.0
+  version: 1.0.0
 - name: portal-web
   repository: file://charts/portal-web
   version: 0.3.0
-digest: sha256:91713efc8b064ff4d302d405bf0f27ead8297706ebfada779ef5d15fd7419a6b
-generated: "2026-05-05T14:25:51.292458674+02:00"
+digest: sha256:d4ba08956b47827aea9dcea7d448a74e8cd6dc14a151146044c0ac9408853cc7
+generated: "2026-05-11T14:55:23.188503804+02:00"

--- a/charts/platform/Chart.lock
+++ b/charts/platform/Chart.lock
@@ -7,21 +7,21 @@ dependencies:
   version: 2.1.2
 - name: pipeline-optimization
   repository: file://charts/pipeline-optimization
-  version: 2.0.6
+  version: 2.0.7
 - name: studios
   repository: file://charts/studios
-  version: 1.3.0
+  version: 1.3.1
 - name: wave
   repository: file://charts/wave
-  version: 0.2.0
+  version: 0.2.1
 - name: mcp
   repository: file://charts/mcp
-  version: 0.4.0
+  version: 0.4.1
 - name: agent-backend
   repository: file://charts/agent-backend
   version: 1.0.0
 - name: portal-web
   repository: file://charts/portal-web
-  version: 0.3.0
-digest: sha256:d4ba08956b47827aea9dcea7d448a74e8cd6dc14a151146044c0ac9408853cc7
-generated: "2026-05-11T14:55:23.188503804+02:00"
+  version: 0.3.1
+digest: sha256:13bf2abdc12ad0782eab052065837ee5b5edee59ae03fc8d2b3bc576548475b1
+generated: "2026-05-12T12:30:11.733560019+02:00"

--- a/charts/platform/Chart.yaml
+++ b/charts/platform/Chart.yaml
@@ -37,7 +37,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.33.0
+version: 0.33.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -81,7 +81,7 @@ dependencies:
       - mcp
     condition: mcp.enabled
   - name: agent-backend
-    version: "0.5.x"
+    version: "1.x.x"
     repository: "file://charts/agent-backend"
     tags:
       - agent-backend

--- a/charts/platform/README.md
+++ b/charts/platform/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart to deploy Seqera Platform (also referred to as Tower) on Kubernetes.
 
-![Version: 0.33.0](https://img.shields.io/badge/Version-0.33.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v25.3.4](https://img.shields.io/badge/AppVersion-v25.3.4-informational?style=flat-square)
+![Version: 0.33.1](https://img.shields.io/badge/Version-0.33.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v25.3.4](https://img.shields.io/badge/AppVersion-v25.3.4-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -41,7 +41,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/platform \
-  --version 0.33.0 \
+  --version 0.33.1 \
   --namespace my-namespace \
   --create-namespace
 ```
@@ -63,7 +63,7 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | Repository | Name | Version |
 |------------|------|---------|
 | file://../seqera-common | seqera-common | 2.x.x |
-| file://charts/agent-backend | agent-backend | 0.5.x |
+| file://charts/agent-backend | agent-backend | 1.x.x |
 | file://charts/mcp | mcp | 0.4.x |
 | file://charts/pipeline-optimization | pipeline-optimization | 2.x.x |
 | file://charts/portal-web | portal-web | 0.3.x |

--- a/charts/platform/README.md
+++ b/charts/platform/README.md
@@ -198,7 +198,7 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | redis.existingSecretKey | string | `"TOWER_REDIS_PASSWORD"` | Key in the existing Secret containing the password for Redis |
 | redis.enableTls | bool | `false` | Enable TLS when connecting to Redis |
 | backend.image.registry | string | `""` | Backend container image registry |
-| backend.image.repository | string | `"private/nf-tower-enterprise/backend"` | Backend container image repository |
+| backend.image.repository | string | `"enterprise/platform/backend"` | Backend container image repository |
 | backend.image.tag | string | `"{{ .chart.AppVersion }}"` | Backend container image tag |
 | backend.image.digest | string | `""` | Backend container image digest in the format `sha256:1234abcdef` |
 | backend.image.pullPolicy | string | `"IfNotPresent"` | imagePullPolicy for the backend container Ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images |
@@ -255,7 +255,7 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | backend.livenessProbe.failureThreshold | int | `10` | Consecutive failures before restarting the container |
 | backend.livenessProbe.successThreshold | int | `1` | Typically 1 (usually ignored) |
 | frontend.image.registry | string | `""` | Frontend container image registry |
-| frontend.image.repository | string | `"private/nf-tower-enterprise/frontend"` | Frontend container image repository |
+| frontend.image.repository | string | `"enterprise/platform/frontend"` | Frontend container image repository |
 | frontend.image.tag | string | `"{{ .chart.AppVersion }}-unprivileged"` | Specify a tag to override the version defined in .Chart.appVersion |
 | frontend.image.digest | string | `""` | Frontend container image digest in the format `sha256:1234abcdef` |
 | frontend.image.pullPolicy | string | `"IfNotPresent"` | imagePullPolicy for the frontend container Ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images |
@@ -312,7 +312,7 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | frontend.livenessProbe.failureThreshold | int | `10` | Consecutive failures before restarting the container |
 | frontend.livenessProbe.successThreshold | int | `1` | Typically 1 (usually ignored) |
 | cron.image.registry | string | `""` | Cron container image registry |
-| cron.image.repository | string | `"private/nf-tower-enterprise/backend"` | Cron container image repository |
+| cron.image.repository | string | `"enterprise/platform/backend"` | Cron container image repository |
 | cron.image.tag | string | `"{{ .chart.AppVersion }}"` | Cron container image tag |
 | cron.image.digest | string | `""` | Cron container image digest in the format `sha256:1234abcdef` |
 | cron.image.pullPolicy | string | `"IfNotPresent"` | imagePullPolicy for the cron container Ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images |
@@ -370,7 +370,7 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | cron.livenessProbe.failureThreshold | int | `10` | Consecutive failures before restarting the container |
 | cron.livenessProbe.successThreshold | int | `1` | Typically 1 (usually ignored) |
 | cron.dbMigrationInitContainer.image.registry | string | `""` | Database migration container image registry |
-| cron.dbMigrationInitContainer.image.repository | string | `"private/nf-tower-enterprise/migrate-db"` | Database migration container image repository |
+| cron.dbMigrationInitContainer.image.repository | string | `"enterprise/platform/migrate-db"` | Database migration container image repository |
 | cron.dbMigrationInitContainer.image.tag | string | `"{{ .chart.AppVersion }}"` | Specify a tag to override the version defined in .Chart.appVersion |
 | cron.dbMigrationInitContainer.image.digest | string | `""` | Database migration container image digest in the format `sha256:1234abcdef` |
 | cron.dbMigrationInitContainer.image.pullPolicy | string | `"IfNotPresent"` | imagePullPolicy for the database migration init container Ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images |

--- a/charts/platform/charts/agent-backend/CHANGELOG.md
+++ b/charts/platform/charts/agent-backend/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove redundant Anthropic API key validation from `NOTES.txt`; fully covered by `validateProviders` in `_helpers.tpl`.
 - Add validator: `sandbox.provider: bedrock` now requires `bedrock.sandbox.runtimeArn` to be set.
 - Replace deprecated `NEXTFLOW_DOCS_USE_REDIS_INDEX` env var with `NEXTFLOW_DOCS_TOOL` (`memory` when `embeddings.provider` is set, `disabled` otherwise). Remove `nextflowDocs.useRedisIndex` value.
+- Update image paths in the README and values.yaml - the chart does not hardcode `cr.seqera.io` as the registry, customers are invited to vendor the images to their private registry as well as the charts.
 
 ## [0.5.0] - 2026-05-05
 

--- a/charts/platform/charts/agent-backend/CHANGELOG.md
+++ b/charts/platform/charts/agent-backend/CHANGELOG.md
@@ -21,13 +21,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   | `bedrockAnthropicModel`              | `bedrock.inference.anthropicModel`       |
   | `embeddings.bedrock.region`          | `bedrock.embeddings.region`              |
   | `embeddings.bedrock.modelId`         | `bedrock.embeddings.model`               |
-  | `embeddings.bedrock.dimensions`      | `bedrock.embeddings.dimensions`          |
+  | `embeddings.bedrock.dimensions`      | _(removed — see below)_                  |
   | `anthropicApiKey`                    | `anthropic.apiKey`                       |
   | `anthropicApiKeyExistingSecretName`  | `anthropic.existingSecretName`           |
   | `anthropicApiKeyExistingSecretKey`   | `anthropic.existingSecretKey`            |
   | _(was hardcoded `true`)_             | `inference.provider: bedrock`            |
   | _(was hardcoded `"bedrock"`)_        | `embeddings.provider: bedrock`           |
   | _(was implicit)_                     | `sandbox.provider: bedrock`              |
+
+- **BREAKING**: Remove `bedrock.embeddings.dimensions` value and `NEXTFLOW_DOCS_BEDROCK_DIMENSIONS` env var: the application provides a good default.
 
 ## [0.5.0] - 2026-05-05
 

--- a/charts/platform/charts/agent-backend/CHANGELOG.md
+++ b/charts/platform/charts/agent-backend/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0] - 2026-05-11
 
+### Added
+
+- Add link to [Seqera AI prerequisites](https://docs.seqera.io/platform-enterprise/seqera-ai/prerequisites) documentation in the README.
+
 ### Changed
 
 - **BREAKING**: Redesign provider configuration to support multiple LLM providers. The flat Bedrock-only

--- a/charts/platform/charts/agent-backend/CHANGELOG.md
+++ b/charts/platform/charts/agent-backend/CHANGELOG.md
@@ -34,6 +34,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   | _(was implicit)_                     | `sandbox.provider: bedrock`              |
 
 - **BREAKING**: Remove `bedrock.embeddings.dimensions` value and `NEXTFLOW_DOCS_BEDROCK_DIMENSIONS` env var: the application provides a good default.
+- Remove redundant Anthropic API key validation from `NOTES.txt`; fully covered by `validateProviders` in `_helpers.tpl`.
+- Add validator: `sandbox.provider: bedrock` now requires `bedrock.sandbox.runtimeArn` to be set.
+- Replace deprecated `NEXTFLOW_DOCS_USE_REDIS_INDEX` env var with `NEXTFLOW_DOCS_TOOL` (`memory` when `embeddings.provider` is set, `disabled` otherwise). Remove `nextflowDocs.useRedisIndex` value.
 
 ## [0.5.0] - 2026-05-05
 

--- a/charts/platform/charts/agent-backend/CHANGELOG.md
+++ b/charts/platform/charts/agent-backend/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0] - 2026-05-11
+
+### Changed
+
+- **BREAKING**: Redesign provider configuration to support multiple LLM providers. The flat Bedrock-only
+  values have been replaced with a structured `inference` / `embeddings` / `sandbox` routing layer and
+  per-provider configuration blocks (`bedrock`, `anthropic`). Operators must now declare which provider
+  serves each capability. See migration table below.
+
+  | Old key                              | New key                                  |
+  |--------------------------------------|------------------------------------------|
+  | `bedrockAgentCoreArn`                | `bedrock.sandbox.runtimeArn`             |
+  | `bedrockAssumeRoleArn`               | `bedrock.default.assumeRoleArn`          |
+  | `bedrockAnthropicModel`              | `bedrock.inference.anthropicModel`       |
+  | `embeddings.bedrock.region`          | `bedrock.embeddings.region`              |
+  | `embeddings.bedrock.modelId`         | `bedrock.embeddings.model`               |
+  | `embeddings.bedrock.dimensions`      | `bedrock.embeddings.dimensions`          |
+  | `anthropicApiKey`                    | `anthropic.apiKey`                       |
+  | `anthropicApiKeyExistingSecretName`  | `anthropic.existingSecretName`           |
+  | `anthropicApiKeyExistingSecretKey`   | `anthropic.existingSecretKey`            |
+  | _(was hardcoded `true`)_             | `inference.provider: bedrock`            |
+  | _(was hardcoded `"bedrock"`)_        | `embeddings.provider: bedrock`           |
+  | _(was implicit)_                     | `sandbox.provider: bedrock`              |
+
 ## [0.5.0] - 2026-05-05
 
 - **Enhancement**: allow global configuration of Ingress options. A new `global.ingress` block (`enabled`, `path`, `defaultPathType`, `ingressClassName`, `annotations`, `extraLabels`, `tls`) lets cluster-wide Ingress defaults be set once at the parent and propagate to every subchart, removing the need to repeat controller-wide config per subchart. `enabled` is OR-merged; scalar fields fall back to global when local is unset; `annotations` and `extraLabels` are merged with local winning on key collision; `tls` is concatenated (useful for a single wildcard certificate across all services).

--- a/charts/platform/charts/agent-backend/Chart.yaml
+++ b/charts/platform/charts/agent-backend/Chart.yaml
@@ -19,7 +19,7 @@ apiVersion: v2
 name: agent-backend
 description: Backend service for Seqera CLI AI capabilities
 type: application
-version: 0.5.0
+version: 1.0.0
 appVersion: "2.0.0"
 maintainers:
   - name: Seqera Labs

--- a/charts/platform/charts/agent-backend/README.md
+++ b/charts/platform/charts/agent-backend/README.md
@@ -10,6 +10,8 @@ Backend service for Seqera CLI AI capabilities
 
 ## Requirements and configuration
 
+For a full list of prerequisites needed to deploy Seqera AI, refer to the [Seqera AI prerequisites](https://docs.seqera.io/platform-enterprise/seqera-ai/prerequisites) documentation.
+
 The chart does not automatically define `cr.seqera.io` as the registry where to take the images from: instructions are available to [vendor the Seqera container images to your private registry](https://docs.seqera.io/platform-enterprise/enterprise/prerequisites/common#vendoring-seqera-container-images-to-your-own-registry).
 
 The required values to set in order to have a working installation are:

--- a/charts/platform/charts/agent-backend/README.md
+++ b/charts/platform/charts/agent-backend/README.md
@@ -89,11 +89,10 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | bedrock.inference.assumeRoleArn | string | `""` | IAM role ARN for Bedrock inference (overrides bedrock.default.assumeRoleArn). |
 | bedrock.inference.region | string | `""` | AWS region for Bedrock inference (overrides bedrock.default.region). |
 | bedrock.inference.anthropicModel | string | `""` | Anthropic inference profile ARN to use on Bedrock (e.g. a custom or cross-region profile). |
-| bedrock.embeddings | object | `{"assumeRoleArn":"","dimensions":"1024","model":"amazon.titan-embed-text-v2:0","region":""}` | Embeddings-specific Bedrock overrides. |
+| bedrock.embeddings | object | `{"assumeRoleArn":"","model":"amazon.titan-embed-text-v2:0","region":""}` | Embeddings-specific Bedrock overrides. |
 | bedrock.embeddings.assumeRoleArn | string | `""` | IAM role ARN for Bedrock embeddings (overrides bedrock.default.assumeRoleArn). |
 | bedrock.embeddings.region | string | `""` | AWS region for Bedrock embeddings (overrides bedrock.default.region). |
 | bedrock.embeddings.model | string | `"amazon.titan-embed-text-v2:0"` | Bedrock model ID used for embeddings. |
-| bedrock.embeddings.dimensions | string | `"1024"` | Embedding vector dimensions expected from the configured Bedrock model. |
 | bedrock.sandbox | object | `{"assumeRoleArn":"","region":"","runtimeArn":""}` | Sandbox (AgentCore) Bedrock configuration. |
 | bedrock.sandbox.assumeRoleArn | string | `""` | IAM role ARN for AgentCore (overrides bedrock.default.assumeRoleArn). |
 | bedrock.sandbox.region | string | `""` | AWS region for AgentCore. |

--- a/charts/platform/charts/agent-backend/README.md
+++ b/charts/platform/charts/agent-backend/README.md
@@ -16,15 +16,19 @@ The required values to set in order to have a working installation are:
 - The `.image` section to point to your container registry.
 - The Seqera Platform Service connection details under `.global.platformServiceAddress` and `.global.platformServicePort`. These point to the Platform backend service that the Agent Backend communicates with. When deploying this subchart as part of the parent `platform` umbrella chart, these values are inherited automatically from the parent chart's `global` section.
 - The database connection details for the MySQL database under the `.database` section.
-- The redis connection details under the `.redis` section.
-- The Bedrock AgentCore runtime ARN under the `.bedrockAgentCoreArn` section.
-- Anthropic API credentials under `.anthropicApiKey` or `.anthropicApiKeyExistingSecretName`.
-- Bedrock embedding settings under `.embeddings` (in particular the AWS region to use for the Bedrock embedding engine).
+- The Redis connection details under the `.redis` section.
+- The inference provider under `.inference.provider` (one of `bedrock`, `anthropic`) and the corresponding provider credentials:
+  * For Bedrock: optionally set `.bedrock.default.region` and `.bedrock.default.assumeRoleArn` as defaults applied to all Bedrock-backed services, with per-service overrides available under `.bedrock.inference.*`.
+  * For Anthropic: set `.anthropic.apiKey` or reference an existing Secret via `.anthropic.existingSecretName`.
 - Container registry credentials under the `.global.imageCredentials` section (can be the credentials for cr.seqera.io or your private registry where you vendored the images to).
   * These credentials will be used by all the subcharts unless overridden in the specific subchart.
   * Multiple credentials can be specified to cover different registries.
   * Specific pull secrets can be defined in each `.image` section to extend the global credentials.
   * Image pull secrets defined in the specific `.image` section will be added to the global ones, not replacing them.
+
+The following capabilities are **optional** and disabled when their provider is not set:
+- **Embeddings** (AWS Bedrock only): set `.embeddings.provider: bedrock` and configure `.bedrock.embeddings.*` (model, dimensions, region, assumeRoleArn).
+- **Sandbox** (AWS Bedrock AgentCore only): set `.sandbox.provider: bedrock` and configure `.bedrock.sandbox.*` (runtimeArn, region, assumeRoleArn).
 
 The Helm chart comes with several requirement checks that will validate the provided configuration before proceeding with the installation.
 

--- a/charts/platform/charts/agent-backend/README.md
+++ b/charts/platform/charts/agent-backend/README.md
@@ -2,7 +2,7 @@
 
 Backend service for Seqera CLI AI capabilities
 
-![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -39,7 +39,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/agent-backend \
-  --version 0.5.0 \
+  --version 1.0.0 \
   --namespace my-namespace \
   --create-namespace
 ```
@@ -75,6 +75,28 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | global.ingress.tls | list | `[]` | TLS entries concatenated with the local `ingress.tls`. Evaluated as a template |
 | global.imageCredentials | list | `[]` | Optional credentials to log in and fetch images from a private registry. These credentials are shared with all the subcharts automatically |
 | global.imageCredentialsSecrets | list | `[]` | Optional list of existing Secrets containing image pull credentials to use for pulling images from private registries. These Secrets are shared with all the subcharts automatically |
+| inference.provider | string | `""` | Inference provider. One of: "bedrock", "anthropic". Required. |
+| embeddings.provider | string | `""` | Embeddings provider. One of: "bedrock". When empty, embeddings are disabled. |
+| sandbox.provider | string | `""` | Sandbox provider. One of: "bedrock". When empty, sandbox is disabled. |
+| bedrock.default | object | `{"assumeRoleArn":"","region":""}` | Default credentials/region applied to any Bedrock-backed service that does not set its own. |
+| bedrock.default.assumeRoleArn | string | `""` | Default IAM role ARN to assume for all Bedrock services (cross-account access). |
+| bedrock.default.region | string | `""` | Default AWS region for all Bedrock services. |
+| bedrock.inference | object | `{"anthropicModel":"","assumeRoleArn":"","region":""}` | Inference-specific Bedrock overrides. Each field maps to one env var; leave empty to omit and let the backend fall back to bedrock.default.* |
+| bedrock.inference.assumeRoleArn | string | `""` | IAM role ARN for Bedrock inference (overrides bedrock.default.assumeRoleArn). |
+| bedrock.inference.region | string | `""` | AWS region for Bedrock inference (overrides bedrock.default.region). |
+| bedrock.inference.anthropicModel | string | `""` | Anthropic inference profile ARN to use on Bedrock (e.g. a custom or cross-region profile). |
+| bedrock.embeddings | object | `{"assumeRoleArn":"","dimensions":"1024","model":"amazon.titan-embed-text-v2:0","region":""}` | Embeddings-specific Bedrock overrides. |
+| bedrock.embeddings.assumeRoleArn | string | `""` | IAM role ARN for Bedrock embeddings (overrides bedrock.default.assumeRoleArn). |
+| bedrock.embeddings.region | string | `""` | AWS region for Bedrock embeddings (overrides bedrock.default.region). |
+| bedrock.embeddings.model | string | `"amazon.titan-embed-text-v2:0"` | Bedrock model ID used for embeddings. |
+| bedrock.embeddings.dimensions | string | `"1024"` | Embedding vector dimensions expected from the configured Bedrock model. |
+| bedrock.sandbox | object | `{"assumeRoleArn":"","region":"","runtimeArn":""}` | Sandbox (AgentCore) Bedrock configuration. |
+| bedrock.sandbox.assumeRoleArn | string | `""` | IAM role ARN for AgentCore (overrides bedrock.default.assumeRoleArn). |
+| bedrock.sandbox.region | string | `""` | AWS region for AgentCore. |
+| bedrock.sandbox.runtimeArn | string | `""` | AWS Bedrock AgentCore runtime ARN for sandbox sessions. |
+| anthropic.apiKey | string | `""` | Anthropic API key. Set this OR existingSecretName, not both. |
+| anthropic.existingSecretName | string | `""` | Name of an existing Secret containing the Anthropic API key. Note: the Secret must already exist in the same namespace at the time of deployment |
+| anthropic.existingSecretKey | string | `"ANTHROPIC_API_KEY"` | Key in the existing Secret containing the Anthropic API key |
 | database.host | string | `""` | MySQL database hostname |
 | database.port | int | `3306` | MySQL database port |
 | database.name | string | `""` | MySQL database name |
@@ -92,16 +114,7 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | redis.password | string | `""` | Redis password |
 | redis.existingSecretName | string | `""` | Name of an existing Secret containing the Redis password, as an alternative to the password field. Note: the Secret must already exist in the same namespace at the time of deployment |
 | redis.existingSecretKey | string | `"AGENT_BACKEND_REDIS_PASSWORD"` | Key in the existing Secret containing the Redis password |
-| bedrockAgentCoreArn | string | `""` | AWS Bedrock AgentCore runtime ARN for sandbox sessions |
-| bedrockAssumeRoleArn | string | `""` | Optional IAM role ARN that the Agent Backend assumes for cross-account Bedrock access. Leave empty to let the pod directly use the AWS credentials provided to it (single-account setup). |
-| bedrockAnthropicModel | string | `""` | Override the Anthropic model used on Bedrock by specifying an inference profile ARN. You can create a custom inference profile that uses the Anthropic model you want or use the default inference profile for the model provided by AWS. When doing cross-account access with `bedrockAssumeRoleArn`, you may want to specify an inference profile ARN on the account where the hop role is defined |
-| embeddings.bedrock.region | string | `""` | AWS region where the Bedrock model is hosted |
-| embeddings.bedrock.modelId | string | `"amazon.titan-embed-text-v2:0"` | Bedrock model ID used for embeddings |
-| embeddings.bedrock.dimensions | string | `"1024"` | Embedding vector dimensions expected from the configured Bedrock model |
 | nextflowDocs.useRedisIndex | bool | `false` | Use a Redis-backed vector index for the Nextflow documentation knowledge base. Disabled by default. |
-| anthropicApiKey | string | `""` | Anthropic API key. Define the value as a String or a Secret, not both at the same time |
-| anthropicApiKeyExistingSecretName | string | `""` | Name of an existing Secret containing the Anthropic API key. Note: the Secret must already exist in the same namespace at the time of deployment |
-| anthropicApiKeyExistingSecretKey | string | `"ANTHROPIC_API_KEY"` | Key in the existing Secret containing the Anthropic API key |
 | tokenEncryptionKey | string | `""` | Token encryption key (must be a valid Fernet key). Define the value as a String or a Secret, not both at the same time. If not defined, a random Fernet key will be auto-generated at each deployment. WARNING: Always explicitly set this value or use an existing secret when using Kustomize. Auto-generated random values are incompatible with Kustomize. When upgrading releases via Kustomize, Helm cannot query the cluster to check if a secret already exists, causing it to regenerate a new random value on each upgrade |
 | tokenEncryptionKeyExistingSecretName | string | `""` | Name of an existing Secret containing the token encryption key. Note: the Secret must already exist in the same namespace at the time of deployment |
 | tokenEncryptionKeyExistingSecretKey | string | `"AGENT_BACKEND_TOKEN_ENCRYPTION_KEY"` | Key in the existing Secret containing the token encryption key |

--- a/charts/platform/charts/agent-backend/README.md
+++ b/charts/platform/charts/agent-backend/README.md
@@ -119,12 +119,11 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | redis.password | string | `""` | Redis password |
 | redis.existingSecretName | string | `""` | Name of an existing Secret containing the Redis password, as an alternative to the password field. Note: the Secret must already exist in the same namespace at the time of deployment |
 | redis.existingSecretKey | string | `"AGENT_BACKEND_REDIS_PASSWORD"` | Key in the existing Secret containing the Redis password |
-| nextflowDocs.useRedisIndex | bool | `false` | Use a Redis-backed vector index for the Nextflow documentation knowledge base. Disabled by default. |
 | tokenEncryptionKey | string | `""` | Token encryption key (must be a valid Fernet key). Define the value as a String or a Secret, not both at the same time. If not defined, a random Fernet key will be auto-generated at each deployment. WARNING: Always explicitly set this value or use an existing secret when using Kustomize. Auto-generated random values are incompatible with Kustomize. When upgrading releases via Kustomize, Helm cannot query the cluster to check if a secret already exists, causing it to regenerate a new random value on each upgrade |
 | tokenEncryptionKeyExistingSecretName | string | `""` | Name of an existing Secret containing the token encryption key. Note: the Secret must already exist in the same namespace at the time of deployment |
 | tokenEncryptionKeyExistingSecretKey | string | `"AGENT_BACKEND_TOKEN_ENCRYPTION_KEY"` | Key in the existing Secret containing the token encryption key |
 | image.registry | string | `""` | Container image registry |
-| image.repository | string | `"private/nf-tower-enterprise/agent-backend"` | Container image repository |
+| image.repository | string | `"ai/agent-backend/backend"` | Container image repository |
 | image.tag | string | `"{{ .chart.AppVersion }}"` | Container image tag |
 | image.digest | string | `""` | Container image digest in the format `sha256:1234abcdef` |
 | image.pullPolicy | string | `"IfNotPresent"` | imagePullPolicy for the container Ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images |

--- a/charts/platform/charts/agent-backend/README.md
+++ b/charts/platform/charts/agent-backend/README.md
@@ -84,19 +84,15 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | inference.provider | string | `""` | Inference provider. One of: "bedrock", "anthropic". Required. |
 | embeddings.provider | string | `""` | Embeddings provider. One of: "bedrock". When empty, embeddings are disabled. |
 | sandbox.provider | string | `""` | Sandbox provider. One of: "bedrock". When empty, sandbox is disabled. |
-| bedrock.default | object | `{"assumeRoleArn":"","region":""}` | Default credentials/region applied to any Bedrock-backed service that does not set its own. |
-| bedrock.default.assumeRoleArn | string | `""` | Default IAM role ARN to assume for all Bedrock services (cross-account access). |
-| bedrock.default.region | string | `""` | Default AWS region for all Bedrock services. |
-| bedrock.inference | object | `{"anthropicModel":"","assumeRoleArn":"","region":""}` | Inference-specific Bedrock overrides. Each field maps to one env var; leave empty to omit and let the backend fall back to bedrock.default.* |
-| bedrock.inference.assumeRoleArn | string | `""` | IAM role ARN for Bedrock inference (overrides bedrock.default.assumeRoleArn). |
+| bedrock.default.assumeRoleArn | string | `""` | Optional default IAM role ARN to assume before invoking the Bedrock APIs. |
+| bedrock.default.region | string | `""` | Default AWS region to use for all Bedrock services. |
+| bedrock.inference.assumeRoleArn | string | `""` | Optional IAM role ARN to assume for Bedrock inference (overrides bedrock.default.assumeRoleArn). |
 | bedrock.inference.region | string | `""` | AWS region for Bedrock inference (overrides bedrock.default.region). |
-| bedrock.inference.anthropicModel | string | `""` | Anthropic inference profile ARN to use on Bedrock (e.g. a custom or cross-region profile). |
-| bedrock.embeddings | object | `{"assumeRoleArn":"","model":"amazon.titan-embed-text-v2:0","region":""}` | Embeddings-specific Bedrock overrides. |
-| bedrock.embeddings.assumeRoleArn | string | `""` | IAM role ARN for Bedrock embeddings (overrides bedrock.default.assumeRoleArn). |
+| bedrock.inference.anthropicModel | string | `""` | Anthropic inference profile ARN to use on Bedrock (e.g. a custom or cross-region/cross-account profile). |
+| bedrock.embeddings.assumeRoleArn | string | `""` | Optional IAM role ARN to assume for Bedrock embeddings (overrides bedrock.default.assumeRoleArn). |
 | bedrock.embeddings.region | string | `""` | AWS region for Bedrock embeddings (overrides bedrock.default.region). |
 | bedrock.embeddings.model | string | `"amazon.titan-embed-text-v2:0"` | Bedrock model ID used for embeddings. |
-| bedrock.sandbox | object | `{"assumeRoleArn":"","region":"","runtimeArn":""}` | Sandbox (AgentCore) Bedrock configuration. |
-| bedrock.sandbox.assumeRoleArn | string | `""` | IAM role ARN for AgentCore (overrides bedrock.default.assumeRoleArn). |
+| bedrock.sandbox.assumeRoleArn | string | `""` | Optional IAM role ARN to assume before invoking AgentCore (overrides bedrock.default.assumeRoleArn). |
 | bedrock.sandbox.region | string | `""` | AWS region for AgentCore. |
 | bedrock.sandbox.runtimeArn | string | `""` | AWS Bedrock AgentCore runtime ARN for sandbox sessions. |
 | anthropic.apiKey | string | `""` | Anthropic API key. Set this OR existingSecretName, not both. |

--- a/charts/platform/charts/agent-backend/README.md.gotmpl
+++ b/charts/platform/charts/agent-backend/README.md.gotmpl
@@ -15,15 +15,19 @@ The required values to set in order to have a working installation are:
 - The `.image` section to point to your container registry.
 - The Seqera Platform Service connection details under `.global.platformServiceAddress` and `.global.platformServicePort`. These point to the Platform backend service that the Agent Backend communicates with. When deploying this subchart as part of the parent `platform` umbrella chart, these values are inherited automatically from the parent chart's `global` section.
 - The database connection details for the MySQL database under the `.database` section.
-- The redis connection details under the `.redis` section.
-- The Bedrock AgentCore runtime ARN under the `.bedrockAgentCoreArn` section.
-- Anthropic API credentials under `.anthropicApiKey` or `.anthropicApiKeyExistingSecretName`.
-- Bedrock embedding settings under `.embeddings` (in particular the AWS region to use for the Bedrock embedding engine).
+- The Redis connection details under the `.redis` section.
+- The inference provider under `.inference.provider` (one of `bedrock`, `anthropic`) and the corresponding provider credentials:
+  * For Bedrock: optionally set `.bedrock.default.region` and `.bedrock.default.assumeRoleArn` as defaults applied to all Bedrock-backed services, with per-service overrides available under `.bedrock.inference.*`.
+  * For Anthropic: set `.anthropic.apiKey` or reference an existing Secret via `.anthropic.existingSecretName`.
 - Container registry credentials under the `.global.imageCredentials` section (can be the credentials for cr.seqera.io or your private registry where you vendored the images to).
   * These credentials will be used by all the subcharts unless overridden in the specific subchart.
   * Multiple credentials can be specified to cover different registries.
   * Specific pull secrets can be defined in each `.image` section to extend the global credentials.
   * Image pull secrets defined in the specific `.image` section will be added to the global ones, not replacing them.
+
+The following capabilities are **optional** and disabled when their provider is not set:
+- **Embeddings** (AWS Bedrock only): set `.embeddings.provider: bedrock` and configure `.bedrock.embeddings.*` (model, dimensions, region, assumeRoleArn).
+- **Sandbox** (AWS Bedrock AgentCore only): set `.sandbox.provider: bedrock` and configure `.bedrock.sandbox.*` (runtimeArn, region, assumeRoleArn).
 
 The Helm chart comes with several requirement checks that will validate the provided configuration before proceeding with the installation.
 

--- a/charts/platform/charts/agent-backend/README.md.gotmpl
+++ b/charts/platform/charts/agent-backend/README.md.gotmpl
@@ -9,6 +9,8 @@
 
 ## Requirements and configuration
 
+For a full list of prerequisites needed to deploy Seqera AI, refer to the [Seqera AI prerequisites](https://docs.seqera.io/platform-enterprise/seqera-ai/prerequisites) documentation.
+
 The chart does not automatically define `cr.seqera.io` as the registry where to take the images from: instructions are available to [vendor the Seqera container images to your private registry](https://docs.seqera.io/platform-enterprise/enterprise/prerequisites/common#vendoring-seqera-container-images-to-your-own-registry).
 
 The required values to set in order to have a working installation are:

--- a/charts/platform/charts/agent-backend/templates/NOTES.txt
+++ b/charts/platform/charts/agent-backend/templates/NOTES.txt
@@ -54,16 +54,6 @@
 {{- printf "\nVALUES VALIDATION:\n%s" $message | fail -}}
 {{- end -}}
 
-{{- if and (not .Values.anthropic.apiKey) (not .Values.anthropic.existingSecretName) -}}
-{{- $message := "Define the Anthropic API key at 'anthropic.apiKey' or provide an existing secret name at 'anthropic.existingSecretName'." -}}
-{{- printf "\nVALUES VALIDATION:\n%s" $message | fail -}}
-{{- end -}}
-
-{{- if and .Values.anthropic.apiKey .Values.anthropic.existingSecretName -}}
-{{- $message := "Either provide 'anthropic.apiKey' or an existing secret name in 'anthropic.existingSecretName', but not both." -}}
-{{- printf "\nVALUES VALIDATION:\n%s" $message | fail -}}
-{{- end -}}
-
 {{- if not .Values.redis.host -}}
 {{- $message := "Define the Agent Backend Redis host at 'redis.host'." -}}
 {{- printf "\nVALUES VALIDATION:\n%s" $message | fail -}}

--- a/charts/platform/charts/agent-backend/templates/NOTES.txt
+++ b/charts/platform/charts/agent-backend/templates/NOTES.txt
@@ -54,13 +54,13 @@
 {{- printf "\nVALUES VALIDATION:\n%s" $message | fail -}}
 {{- end -}}
 
-{{- if and (not .Values.anthropicApiKey) (not .Values.anthropicApiKeyExistingSecretName) -}}
-{{- $message := "Define the Anthropic API key at 'anthropicApiKey' or provide an existing secret name at 'anthropicApiKeyExistingSecretName'." -}}
+{{- if and (not .Values.anthropic.apiKey) (not .Values.anthropic.existingSecretName) -}}
+{{- $message := "Define the Anthropic API key at 'anthropic.apiKey' or provide an existing secret name at 'anthropic.existingSecretName'." -}}
 {{- printf "\nVALUES VALIDATION:\n%s" $message | fail -}}
 {{- end -}}
 
-{{- if and .Values.anthropicApiKey .Values.anthropicApiKeyExistingSecretName -}}
-{{- $message := "Either provide 'anthropicApiKey' or an existing secret name in 'anthropicApiKeyExistingSecretName', but not both." -}}
+{{- if and .Values.anthropic.apiKey .Values.anthropic.existingSecretName -}}
+{{- $message := "Either provide 'anthropic.apiKey' or an existing secret name in 'anthropic.existingSecretName', but not both." -}}
 {{- printf "\nVALUES VALIDATION:\n%s" $message | fail -}}
 {{- end -}}
 
@@ -71,16 +71,6 @@
 
 {{- if and .Values.redis.password .Values.redis.existingSecretName -}}
 {{- $message := "Either provide 'redis.password' or an existing secret name in 'redis.existingSecretName', but not both." -}}
-{{- printf "\nVALUES VALIDATION:\n%s" $message | fail -}}
-{{- end -}}
-
-{{- if not .Values.bedrockAgentCoreArn -}}
-{{- $message := "Define the Bedrock AgentCore runtime ARN at 'bedrockAgentCoreArn'." -}}
-{{- printf "\nVALUES VALIDATION:\n%s" $message | fail -}}
-{{- end -}}
-
-{{- if not (and .Values.embeddings.bedrock.region .Values.embeddings.bedrock.modelId .Values.embeddings.bedrock.dimensions) -}}
-{{- $message := "Define the Bedrock embedding configuration values under '.embeddings.bedrock'." -}}
 {{- printf "\nVALUES VALIDATION:\n%s" $message | fail -}}
 {{- end -}}
 

--- a/charts/platform/charts/agent-backend/templates/_helpers.tpl
+++ b/charts/platform/charts/agent-backend/templates/_helpers.tpl
@@ -45,19 +45,49 @@ Return the name of the secret containing the database password.
 {{/*
 Return the name of the secret containing the Anthropic API key.
 */}}
-{{- define "agent-backend.anthropicApiKey.existingSecret" -}}
-  {{- printf "%s" (tpl .Values.anthropicApiKeyExistingSecretName .) -}}
+{{- define "agent-backend.anthropic.existingSecret" -}}
+  {{- printf "%s" (tpl .Values.anthropic.existingSecretName .) -}}
 {{- end -}}
-{{- define "agent-backend.anthropicApiKey.existingSecret.secretName" -}}
-  {{- include "agent-backend.anthropicApiKey.existingSecret" . | default (include "common.names.fullname" .) -}}
+{{- define "agent-backend.anthropic.existingSecret.secretName" -}}
+  {{- include "agent-backend.anthropic.existingSecret" . | default (include "common.names.fullname" .) -}}
 {{- end -}}
 
-{{- define "agent-backend.anthropicApiKey.existingSecret.secretKey" -}}
-  {{- if (include "agent-backend.anthropicApiKey.existingSecret" .) -}}
-    {{- printf "%s" (tpl .Values.anthropicApiKeyExistingSecretKey .) | default "ANTHROPIC_API_KEY" -}}
+{{- define "agent-backend.anthropic.existingSecret.secretKey" -}}
+  {{- if (include "agent-backend.anthropic.existingSecret" .) -}}
+    {{- printf "%s" (tpl .Values.anthropic.existingSecretKey .) | default "ANTHROPIC_API_KEY" -}}
   {{- else -}}
     {{- printf "ANTHROPIC_API_KEY" -}}
   {{- end -}}
+{{- end -}}
+
+{{/*
+Validate provider selections. Call this from configmap.yaml to fail fast on misconfiguration.
+*/}}
+{{- define "agent-backend.validateProviders" -}}
+  {{- $inferenceProvider := .Values.inference.provider -}}
+  {{- $embeddingsProvider := .Values.embeddings.provider -}}
+  {{- $sandboxProvider := .Values.sandbox.provider -}}
+
+  {{- if not $inferenceProvider -}}
+    {{- fail "inference.provider is required. Set it to one of: bedrock, anthropic" -}}
+  {{- else if not (has $inferenceProvider (list "bedrock" "anthropic")) -}}
+    {{- fail (printf "inference.provider %q is not supported. Must be one of: bedrock, anthropic" $inferenceProvider) -}}
+  {{- end -}}
+
+  {{- if and $embeddingsProvider (not (has $embeddingsProvider (list "bedrock"))) -}}
+    {{- fail (printf "embeddings.provider %q is not supported. Must be: bedrock" $embeddingsProvider) -}}
+  {{- end -}}
+
+  {{- if and $sandboxProvider (not (has $sandboxProvider (list "bedrock"))) -}}
+    {{- fail (printf "sandbox.provider %q is not supported. Must be: bedrock" $sandboxProvider) -}}
+  {{- end -}}
+
+  {{- if eq $inferenceProvider "anthropic" -}}
+    {{- if not (or .Values.anthropic.apiKey .Values.anthropic.existingSecretName) -}}
+      {{- fail "inference.provider is \"anthropic\" but neither anthropic.apiKey nor anthropic.existingSecretName is set" -}}
+    {{- end -}}
+  {{- end -}}
+
 {{- end -}}
 
 {{/*

--- a/charts/platform/charts/agent-backend/templates/_helpers.tpl
+++ b/charts/platform/charts/agent-backend/templates/_helpers.tpl
@@ -82,6 +82,12 @@ Validate provider selections. Call this from configmap.yaml to fail fast on misc
     {{- fail (printf "sandbox.provider %q is not supported. Must be: bedrock" $sandboxProvider) -}}
   {{- end -}}
 
+  {{- if eq $sandboxProvider "bedrock" -}}
+    {{- if not .Values.bedrock.sandbox.runtimeArn -}}
+      {{- fail "sandbox.provider is \"bedrock\" but bedrock.sandbox.runtimeArn is not set" -}}
+    {{- end -}}
+  {{- end -}}
+
   {{- if eq $inferenceProvider "anthropic" -}}
     {{- if not (or .Values.anthropic.apiKey .Values.anthropic.existingSecretName) -}}
       {{- fail "inference.provider is \"anthropic\" but neither anthropic.apiKey nor anthropic.existingSecretName is set" -}}

--- a/charts/platform/charts/agent-backend/templates/configmap.yaml
+++ b/charts/platform/charts/agent-backend/templates/configmap.yaml
@@ -85,7 +85,7 @@ data:
   {{- end }}
   NEXTFLOW_DOCS_BEDROCK_MODEL_ID: {{ tpl (toString .Values.bedrock.embeddings.model) . | quote }}
 {{- end }}
-  NEXTFLOW_DOCS_USE_REDIS_INDEX: {{ .Values.nextflowDocs.useRedisIndex | quote }}
+  NEXTFLOW_DOCS_TOOL: {{ ternary "memory" "disabled" (not (empty .Values.embeddings.provider)) | quote }}
 
 {{- if .Values.sandbox.provider }}
   {{- if .Values.bedrock.sandbox.runtimeArn }}

--- a/charts/platform/charts/agent-backend/templates/configmap.yaml
+++ b/charts/platform/charts/agent-backend/templates/configmap.yaml
@@ -84,7 +84,6 @@ data:
   BEDROCK_EMBEDDINGS_REGION: {{ tpl .Values.bedrock.embeddings.region . | quote }}
   {{- end }}
   NEXTFLOW_DOCS_BEDROCK_MODEL_ID: {{ tpl (toString .Values.bedrock.embeddings.model) . | quote }}
-  NEXTFLOW_DOCS_BEDROCK_DIMENSIONS: {{ include "seqera.tplvalues.render" (dict "value" .Values.bedrock.embeddings.dimensions "context" $) | quote }}
 {{- end }}
   NEXTFLOW_DOCS_USE_REDIS_INDEX: {{ .Values.nextflowDocs.useRedisIndex | quote }}
 

--- a/charts/platform/charts/agent-backend/templates/configmap.yaml
+++ b/charts/platform/charts/agent-backend/templates/configmap.yaml
@@ -51,19 +51,53 @@ data:
   AGENT_BACKEND_REDIS_DB: {{ .Values.redis.db | quote }}
   AGENT_BACKEND_REDIS_TLS: {{ .Values.redis.enableTls | quote }}
 
-  AGENTCORE_AGENT_ARN: {{ tpl .Values.bedrockAgentCoreArn . | quote }}
-
-  USE_BEDROCK_INFERENCE: "true"
-  KNOWLEDGE_INDEXER_EMBEDDINGS_PROVIDER: "bedrock"
-  BEDROCK_REGION: {{ tpl (toString .Values.embeddings.bedrock.region) . | quote }}
-  NEXTFLOW_DOCS_BEDROCK_MODEL_ID: {{ tpl (toString .Values.embeddings.bedrock.modelId) . | quote }}
-  NEXTFLOW_DOCS_BEDROCK_DIMENSIONS: {{ include "seqera.tplvalues.render" (dict "value" .Values.embeddings.bedrock.dimensions "context" $) | quote }}
-  NEXTFLOW_DOCS_USE_REDIS_INDEX: {{ .Values.nextflowDocs.useRedisIndex | quote }}
-{{- if .Values.bedrockAssumeRoleArn }}
-  AWS_BEDROCK_SERVICES_DEFAULT_ASSUME_ROLE_ARN: {{ tpl .Values.bedrockAssumeRoleArn . | quote }}
+{{- include "agent-backend.validateProviders" . | nindent 0 }}
+{{- if .Values.inference.provider }}
+  USE_BEDROCK_INFERENCE: {{ eq .Values.inference.provider "bedrock" | quote }}
 {{- end }}
-{{- if .Values.bedrockAnthropicModel }}
-  BEDROCK_ANTHROPIC_MODEL: {{ tpl .Values.bedrockAnthropicModel . | quote }}
+{{- if .Values.embeddings.provider }}
+  KNOWLEDGE_INDEXER_EMBEDDINGS_PROVIDER: {{ .Values.embeddings.provider | quote }}
+{{- end }}
+
+{{- if .Values.bedrock.default.assumeRoleArn }}
+  AWS_BEDROCK_SERVICES_DEFAULT_ASSUME_ROLE_ARN: {{ tpl .Values.bedrock.default.assumeRoleArn . | quote }}
+{{- end }}
+{{- if .Values.bedrock.default.region }}
+  AWS_BEDROCK_SERVICES_DEFAULT_REGION: {{ tpl .Values.bedrock.default.region . | quote }}
+{{- end }}
+
+{{- if .Values.bedrock.inference.assumeRoleArn }}
+  AWS_BEDROCK_INFERENCE_ASSUME_ROLE_ARN: {{ tpl .Values.bedrock.inference.assumeRoleArn . | quote }}
+{{- end }}
+{{- if .Values.bedrock.inference.region }}
+  BEDROCK_INFERENCE_REGION: {{ tpl .Values.bedrock.inference.region . | quote }}
+{{- end }}
+{{- if .Values.bedrock.inference.anthropicModel }}
+  BEDROCK_ANTHROPIC_MODEL: {{ tpl .Values.bedrock.inference.anthropicModel . | quote }}
+{{- end }}
+
+{{- if .Values.embeddings.provider }}
+  {{- if .Values.bedrock.embeddings.assumeRoleArn }}
+  AWS_BEDROCK_EMBEDDINGS_ASSUME_ROLE_ARN: {{ tpl .Values.bedrock.embeddings.assumeRoleArn . | quote }}
+  {{- end }}
+  {{- if .Values.bedrock.embeddings.region }}
+  BEDROCK_EMBEDDINGS_REGION: {{ tpl .Values.bedrock.embeddings.region . | quote }}
+  {{- end }}
+  NEXTFLOW_DOCS_BEDROCK_MODEL_ID: {{ tpl (toString .Values.bedrock.embeddings.model) . | quote }}
+  NEXTFLOW_DOCS_BEDROCK_DIMENSIONS: {{ include "seqera.tplvalues.render" (dict "value" .Values.bedrock.embeddings.dimensions "context" $) | quote }}
+{{- end }}
+  NEXTFLOW_DOCS_USE_REDIS_INDEX: {{ .Values.nextflowDocs.useRedisIndex | quote }}
+
+{{- if .Values.sandbox.provider }}
+  {{- if .Values.bedrock.sandbox.runtimeArn }}
+  AGENTCORE_AGENT_ARN: {{ tpl .Values.bedrock.sandbox.runtimeArn . | quote }}
+  {{- end }}
+  {{- if .Values.bedrock.sandbox.assumeRoleArn }}
+  AWS_AGENTCORE_ASSUME_ROLE_ARN: {{ tpl .Values.bedrock.sandbox.assumeRoleArn . | quote }}
+  {{- end }}
+  {{- if .Values.bedrock.sandbox.region }}
+  AGENTCORE_REGION: {{ tpl .Values.bedrock.sandbox.region . | quote }}
+  {{- end }}
 {{- end }}
 
   LOG_LEVEL: {{ .Values.logLevel | default "INFO" | quote }}

--- a/charts/platform/charts/agent-backend/templates/deployment.yaml
+++ b/charts/platform/charts/agent-backend/templates/deployment.yaml
@@ -118,8 +118,8 @@ spec:
             - name: ANTHROPIC_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "agent-backend.anthropicApiKey.existingSecret.secretName" . }}
-                  key: {{ include "agent-backend.anthropicApiKey.existingSecret.secretKey" . }}
+                  name: {{ include "agent-backend.anthropic.existingSecret.secretName" . }}
+                  key: {{ include "agent-backend.anthropic.existingSecret.secretKey" . }}
             - name: AGENT_BACKEND_TOKEN_ENCRYPTION_KEY
               valueFrom:
                 secretKeyRef:

--- a/charts/platform/charts/agent-backend/templates/secret.yaml
+++ b/charts/platform/charts/agent-backend/templates/secret.yaml
@@ -38,8 +38,8 @@ data:
 {{- if not (include "agent-backend.database.existingSecret" .) }}
   AGENT_BACKEND_DB_PASSWORD: {{ include "common.secrets.passwords.manage" (dict "secret" (include "agent-backend.database.existingSecret.secretName" .) "key" (include "agent-backend.database.existingSecret.secretKey" .) "providedValues" (list "database.password") "context" $ "honorProvidedValues" true) }}
 {{- end }}
-{{- if not (include "agent-backend.anthropicApiKey.existingSecret" .) }}
-  ANTHROPIC_API_KEY: {{ include "common.secrets.passwords.manage" (dict "secret" (include "agent-backend.anthropicApiKey.existingSecret.secretName" .) "key" (include "agent-backend.anthropicApiKey.existingSecret.secretKey" .) "providedValues" (list "anthropicApiKey") "context" $ "honorProvidedValues" true) }}
+{{- if not (include "agent-backend.anthropic.existingSecret" .) }}
+  ANTHROPIC_API_KEY: {{ include "common.secrets.passwords.manage" (dict "secret" (include "agent-backend.anthropic.existingSecret.secretName" .) "key" (include "agent-backend.anthropic.existingSecret.secretKey" .) "providedValues" (list "anthropic.apiKey") "context" $ "honorProvidedValues" true) }}
 {{- end }}
 {{- if not (include "agent-backend.tokenEncryptionKey.existingSecret" .) }}
   AGENT_BACKEND_TOKEN_ENCRYPTION_KEY: {{ include "agent-backend.tokenEncryptionKey.value" . }}

--- a/charts/platform/charts/agent-backend/tests/NOTES_test.yaml
+++ b/charts/platform/charts/agent-backend/tests/NOTES_test.yaml
@@ -23,34 +23,31 @@ templates:
 chart:
   version: 1.0.0
   appVersion: "v1.0.0"
+
+# Suite-level defaults that satisfy all required fields. Individual tests override only
+# what they are testing.
+set:
+  global.platformServiceAddress: "platform-backend"
+  global.platformServicePort: 8080
+  database.host: "database.example.com"
+  database.name: "agent_backend"
+  database.username: "agent"
+  database.password: "test-password"
+  anthropic.apiKey: "test-anthropic-key"
+  redis.host: "redis.example.com"
+
 tests:
   # Platform Service connection tests
   - it: should fail when global.platformServiceAddress is not defined
     set:
-      global:
-        platformServiceAddress: ""
-        platformServicePort: 8080
-      database:
-        host: "database.example.com"
-        name: "agent_backend"
-        username: "agent"
-        password: "test-password"
-      anthropicApiKey: "test-anthropic-key"
+      global.platformServiceAddress: ""
     asserts:
       - failedTemplate:
           errorPattern: "Define the Seqera Platform Service address at 'global.platformServiceAddress'"
 
   - it: should fail when global.platformServicePort is not defined
     set:
-      global:
-        platformServiceAddress: "platform-backend"
-        platformServicePort: ""
-      database:
-        host: "database.example.com"
-        name: "agent_backend"
-        username: "agent"
-        password: "test-password"
-      anthropicApiKey: "test-anthropic-key"
+      global.platformServicePort: ""
     asserts:
       - failedTemplate:
           errorPattern: "Define the Seqera Platform Service port at 'global.platformServicePort'"
@@ -58,227 +55,80 @@ tests:
   # Database host tests
   - it: should fail when database.host is not defined
     set:
-      global:
-        platformServiceAddress: "platform-backend"
-        platformServicePort: 8080
-      database:
-        host: ""
-        name: "agent_backend"
-        username: "agent"
-        password: "test-password"
-      anthropicApiKey: "test-anthropic-key"
+      database.host: ""
     asserts:
       - failedTemplate:
           errorPattern: "Define the Agent Backend database host at 'database.host'\\."
 
-  - it: should fail when database.host is missing
-    set:
-      global:
-        platformServiceAddress: "platform-backend"
-        platformServicePort: 8080
-      database:
-        name: "agent_backend"
-        username: "agent"
-        password: "test-password"
-      anthropicApiKey: "test-anthropic-key"
-    asserts:
-      - failedTemplate:
-          errorPattern: "Define the Agent Backend database host at 'database.host'\\."
-
-  # Database name tests
   - it: should fail when database.name is not defined
     set:
-      global:
-        platformServiceAddress: "platform-backend"
-        platformServicePort: 8080
-      database:
-        host: "database.example.com"
-        name: ""
-        username: "agent"
-        password: "test-password"
-      anthropicApiKey: "test-anthropic-key"
+      database.name: ""
     asserts:
       - failedTemplate:
           errorPattern: "Define the Agent Backend database name at 'database.name'\\."
 
-  - it: should fail when database.name is missing
-    set:
-      global:
-        platformServiceAddress: "platform-backend"
-        platformServicePort: 8080
-      database:
-        host: "database.example.com"
-        username: "agent"
-        password: "test-password"
-      anthropicApiKey: "test-anthropic-key"
-    asserts:
-      - failedTemplate:
-          errorPattern: "Define the Agent Backend database name at 'database.name'\\."
-
-  # Database username tests
   - it: should fail when database.username is not defined
     set:
-      global:
-        platformServiceAddress: "platform-backend"
-        platformServicePort: 8080
-      database:
-        host: "database.example.com"
-        name: "agent_backend"
-        username: ""
-        password: "test-password"
-      anthropicApiKey: "test-anthropic-key"
+      database.username: ""
     asserts:
       - failedTemplate:
           errorPattern: "Define the Agent Backend database username at 'database.username'\\."
 
-  - it: should fail when database.username is missing
-    set:
-      global:
-        platformServiceAddress: "platform-backend"
-        platformServicePort: 8080
-      database:
-        host: "database.example.com"
-        name: "agent_backend"
-        password: "test-password"
-      anthropicApiKey: "test-anthropic-key"
-    asserts:
-      - failedTemplate:
-          errorPattern: "Define the Agent Backend database username at 'database.username'\\."
-
-  # Database password tests
   - it: should fail when database.password is not defined and no existingSecretName
     set:
-      global:
-        platformServiceAddress: "platform-backend"
-        platformServicePort: 8080
-      database:
-        host: "database.example.com"
-        name: "agent_backend"
-        username: "agent"
-        password: ""
-        existingSecretName: ""
-      anthropicApiKey: "test-anthropic-key"
+      database.password: ""
+      database.existingSecretName: ""
     asserts:
       - failedTemplate:
           errorPattern: "Define the Agent Backend database password at 'database.password' or provide an existing secret name at 'database.existingSecretName'\\."
 
   - it: should fail when both database.password and database.existingSecretName are defined
     set:
-      global:
-        platformServiceAddress: "platform-backend"
-        platformServicePort: 8080
-      database:
-        host: "database.example.com"
-        name: "agent_backend"
-        username: "agent"
-        password: "test-password"
-        existingSecretName: "my-secret"
-      anthropicApiKey: "test-anthropic-key"
+      database.password: "test-password"
+      database.existingSecretName: "my-secret"
     asserts:
       - failedTemplate:
           errorPattern: "Either provide 'database.password' or an existing secret name in 'database.existingSecretName', but not both\\."
 
   - it: should pass when only database.password is set
-    set:
-      global:
-        platformServiceAddress: "platform-backend"
-        platformServicePort: 8080
-      database:
-        host: "database.example.com"
-        name: "agent_backend"
-        username: "agent"
-        password: "test-password"
-      anthropicApiKey: "test-anthropic-key"
-      redis.host: "redis.example.com"
-      bedrockAgentCoreArn: "arn:aws:bedrock:us-east-1::agent-runtime/test"
-      embeddings.bedrock.region: "us-east-1"
     asserts:
       - hasDocuments:
           count: 1
 
   - it: should pass when only database.existingSecretName is set
     set:
-      global:
-        platformServiceAddress: "platform-backend"
-        platformServicePort: 8080
-      database:
-        host: "database.example.com"
-        name: "agent_backend"
-        username: "agent"
-        existingSecretName: "my-secret"
-      anthropicApiKey: "test-anthropic-key"
-      redis.host: "redis.example.com"
-      bedrockAgentCoreArn: "arn:aws:bedrock:us-east-1::agent-runtime/test"
-      embeddings.bedrock.region: "us-east-1"
+      database.password: ""
+      database.existingSecretName: "my-secret"
     asserts:
       - hasDocuments:
           count: 1
 
   # Anthropic API key tests
-  - it: should fail when anthropicApiKey is not defined and no existingSecretName
+  - it: should fail when anthropic.apiKey is not defined and no existingSecretName
     set:
-      global:
-        platformServiceAddress: "platform-backend"
-        platformServicePort: 8080
-      database:
-        host: "database.example.com"
-        name: "agent_backend"
-        username: "agent"
-        password: "test-password"
-      anthropicApiKey: ""
-      anthropicApiKeyExistingSecretName: ""
+      anthropic.apiKey: ""
+      anthropic.existingSecretName: ""
     asserts:
       - failedTemplate:
-          errorPattern: "Define the Anthropic API key at 'anthropicApiKey' or provide an existing secret name at 'anthropicApiKeyExistingSecretName'\\."
+          errorPattern: "Define the Anthropic API key at 'anthropic.apiKey' or provide an existing secret name at 'anthropic.existingSecretName'\\."
 
-  - it: should fail when both anthropicApiKey and anthropicApiKeyExistingSecretName are defined
+  - it: should fail when both anthropic.apiKey and anthropic.existingSecretName are defined
     set:
-      global:
-        platformServiceAddress: "platform-backend"
-        platformServicePort: 8080
-      database:
-        host: "database.example.com"
-        name: "agent_backend"
-        username: "agent"
-        password: "test-password"
-      anthropicApiKey: "test-anthropic-key"
-      anthropicApiKeyExistingSecretName: "my-anthropic-secret"
+      anthropic.apiKey: "test-anthropic-key"
+      anthropic.existingSecretName: "my-anthropic-secret"
     asserts:
       - failedTemplate:
-          errorPattern: "Either provide 'anthropicApiKey' or an existing secret name in 'anthropicApiKeyExistingSecretName', but not both\\."
+          errorPattern: "Either provide 'anthropic.apiKey' or an existing secret name in 'anthropic.existingSecretName', but not both\\."
 
-  - it: should pass when only anthropicApiKey is set
-    set:
-      global:
-        platformServiceAddress: "platform-backend"
-        platformServicePort: 8080
-      database:
-        host: "database.example.com"
-        name: "agent_backend"
-        username: "agent"
-        password: "test-password"
-      anthropicApiKey: "test-anthropic-key"
-      redis.host: "redis.example.com"
-      bedrockAgentCoreArn: "arn:aws:bedrock:us-east-1::agent-runtime/test"
-      embeddings.bedrock.region: "us-east-1"
+  - it: should pass when only anthropic.apiKey is set
     asserts:
       - hasDocuments:
           count: 1
 
-  - it: should pass when only anthropicApiKeyExistingSecretName is set
+  - it: should pass when only anthropic.existingSecretName is set
     set:
-      global:
-        platformServiceAddress: "platform-backend"
-        platformServicePort: 8080
-      database:
-        host: "database.example.com"
-        name: "agent_backend"
-        username: "agent"
-        password: "test-password"
-      anthropicApiKeyExistingSecretName: "my-anthropic-secret"
-      redis.host: "redis.example.com"
-      bedrockAgentCoreArn: "arn:aws:bedrock:us-east-1::agent-runtime/test"
-      embeddings.bedrock.region: "us-east-1"
+      anthropic.apiKey: ""
+      anthropic.existingSecretName: "my-anthropic-secret"
     asserts:
       - hasDocuments:
           count: 1
@@ -286,186 +136,32 @@ tests:
   # Redis host tests
   - it: should fail when redis.host is not defined
     set:
-      global:
-        platformServiceAddress: "platform-backend"
-        platformServicePort: 8080
-      database:
-        host: "database.example.com"
-        name: "agent_backend"
-        username: "agent"
-        password: "test-password"
-      anthropicApiKey: "test-anthropic-key"
       redis.host: ""
-      bedrockAgentCoreArn: "arn:aws:bedrock:us-east-1::agent-runtime/test"
     asserts:
       - failedTemplate:
           errorPattern: "Define the Agent Backend Redis host at 'redis.host'\\."
 
   - it: should fail when both redis.password and redis.existingSecretName are defined
     set:
-      global:
-        platformServiceAddress: "platform-backend"
-        platformServicePort: 8080
-      database:
-        host: "database.example.com"
-        name: "agent_backend"
-        username: "agent"
-        password: "test-password"
-      anthropicApiKey: "test-anthropic-key"
-      redis.host: "redis.example.com"
       redis.password: "my-redis-password"
       redis.existingSecretName: "my-redis-secret"
-      bedrockAgentCoreArn: "arn:aws:bedrock:us-east-1::agent-runtime/test"
     asserts:
       - failedTemplate:
           errorPattern: "Either provide 'redis.password' or an existing secret name in 'redis.existingSecretName', but not both\\."
 
-  # Bedrock AgentCore ARN tests
-  - it: should fail when bedrockAgentCoreArn is not defined
-    set:
-      global:
-        platformServiceAddress: "platform-backend"
-        platformServicePort: 8080
-      database:
-        host: "database.example.com"
-        name: "agent_backend"
-        username: "agent"
-        password: "test-password"
-      anthropicApiKey: "test-anthropic-key"
-      redis.host: "redis.example.com"
-      bedrockAgentCoreArn: ""
-    asserts:
-      - failedTemplate:
-          errorPattern: "Define the Bedrock AgentCore runtime ARN at 'bedrockAgentCoreArn'\\."
-
-  - it: should fail when bedrockAgentCoreArn is missing
-    set:
-      global:
-        platformServiceAddress: "platform-backend"
-        platformServicePort: 8080
-      database:
-        host: "database.example.com"
-        name: "agent_backend"
-        username: "agent"
-        password: "test-password"
-      anthropicApiKey: "test-anthropic-key"
-      redis.host: "redis.example.com"
-    asserts:
-      - failedTemplate:
-          errorPattern: "Define the Bedrock AgentCore runtime ARN at 'bedrockAgentCoreArn'\\."
-
-  # Bedrock embeddings configuration tests
-  - it: should fail when embeddings.bedrock.region is not defined
-    set:
-      global:
-        platformServiceAddress: "platform-backend"
-        platformServicePort: 8080
-      database:
-        host: "database.example.com"
-        name: "agent_backend"
-        username: "agent"
-        password: "test-password"
-      anthropicApiKey: "test-anthropic-key"
-      redis.host: "redis.example.com"
-      bedrockAgentCoreArn: "arn:aws:bedrock:us-east-1::agent-runtime/test"
-      embeddings.bedrock.region: ""
-    asserts:
-      - failedTemplate:
-          errorPattern: "Define the Bedrock embedding configuration values under '.embeddings.bedrock'\\."
-
-  - it: should fail when embeddings.bedrock.modelId is not defined
-    set:
-      global:
-        platformServiceAddress: "platform-backend"
-        platformServicePort: 8080
-      database:
-        host: "database.example.com"
-        name: "agent_backend"
-        username: "agent"
-        password: "test-password"
-      anthropicApiKey: "test-anthropic-key"
-      redis.host: "redis.example.com"
-      bedrockAgentCoreArn: "arn:aws:bedrock:us-east-1::agent-runtime/test"
-      embeddings.bedrock.region: "us-east-1"
-      embeddings.bedrock.modelId: ""
-    asserts:
-      - failedTemplate:
-          errorPattern: "Define the Bedrock embedding configuration values under '.embeddings.bedrock'\\."
-
-  - it: should fail when embeddings.bedrock.dimensions is not defined
-    set:
-      global:
-        platformServiceAddress: "platform-backend"
-        platformServicePort: 8080
-      database:
-        host: "database.example.com"
-        name: "agent_backend"
-        username: "agent"
-        password: "test-password"
-      anthropicApiKey: "test-anthropic-key"
-      redis.host: "redis.example.com"
-      bedrockAgentCoreArn: "arn:aws:bedrock:us-east-1::agent-runtime/test"
-      embeddings.bedrock.region: "us-east-1"
-      embeddings.bedrock.dimensions: ""
-    asserts:
-      - failedTemplate:
-          errorPattern: "Define the Bedrock embedding configuration values under '.embeddings.bedrock'\\."
-
-  - it: should pass when all embeddings.bedrock values are set
-    set:
-      global:
-        platformServiceAddress: "platform-backend"
-        platformServicePort: 8080
-      database:
-        host: "database.example.com"
-        name: "agent_backend"
-        username: "agent"
-        password: "test-password"
-      anthropicApiKey: "test-anthropic-key"
-      redis.host: "redis.example.com"
-      bedrockAgentCoreArn: "arn:aws:bedrock:us-east-1::agent-runtime/test"
-      embeddings.bedrock.region: "us-east-1"
-      embeddings.bedrock.modelId: "test-model"
-      embeddings.bedrock.dimensions: 1024
-    asserts:
-      - hasDocuments:
-          count: 1
-
-  # Complete valid configuration test
+  # Complete valid configuration
   - it: should pass with all required values properly set
-    set:
-      global:
-        platformServiceAddress: "platform-backend"
-        platformServicePort: 8080
-      database:
-        host: "database.example.com"
-        name: "agent_backend"
-        username: "agent"
-        password: "test-password"
-      anthropicApiKey: "test-anthropic-key"
-      redis.host: "redis.example.com"
-      bedrockAgentCoreArn: "arn:aws:bedrock:us-east-1::agent-runtime/test"
-      embeddings.bedrock.region: "us-east-1"
     asserts:
       - hasDocuments:
           count: 1
 
-  # Valid configuration with external secrets
   - it: should pass with all required values using external secrets
     set:
-      global:
-        platformServiceAddress: "platform-backend"
-        platformServicePort: 8080
-      database:
-        host: "database.example.com"
-        name: "agent_backend"
-        username: "agent"
-        existingSecretName: "db-secret"
-      anthropicApiKeyExistingSecretName: "anthropic-secret"
-      redis.host: "redis.example.com"
+      database.password: ""
+      database.existingSecretName: "db-secret"
+      anthropic.apiKey: ""
+      anthropic.existingSecretName: "anthropic-secret"
       redis.existingSecretName: "redis-secret"
-      bedrockAgentCoreArn: "arn:aws:bedrock:us-east-1::agent-runtime/test"
-      embeddings.bedrock.region: "us-east-1"
     asserts:
       - hasDocuments:
           count: 1

--- a/charts/platform/charts/agent-backend/tests/NOTES_test.yaml
+++ b/charts/platform/charts/agent-backend/tests/NOTES_test.yaml
@@ -33,7 +33,6 @@ set:
   database.name: "agent_backend"
   database.username: "agent"
   database.password: "test-password"
-  anthropic.apiKey: "test-anthropic-key"
   redis.host: "redis.example.com"
 
 tests:
@@ -103,36 +102,6 @@ tests:
       - hasDocuments:
           count: 1
 
-  # Anthropic API key tests
-  - it: should fail when anthropic.apiKey is not defined and no existingSecretName
-    set:
-      anthropic.apiKey: ""
-      anthropic.existingSecretName: ""
-    asserts:
-      - failedTemplate:
-          errorPattern: "Define the Anthropic API key at 'anthropic.apiKey' or provide an existing secret name at 'anthropic.existingSecretName'\\."
-
-  - it: should fail when both anthropic.apiKey and anthropic.existingSecretName are defined
-    set:
-      anthropic.apiKey: "test-anthropic-key"
-      anthropic.existingSecretName: "my-anthropic-secret"
-    asserts:
-      - failedTemplate:
-          errorPattern: "Either provide 'anthropic.apiKey' or an existing secret name in 'anthropic.existingSecretName', but not both\\."
-
-  - it: should pass when only anthropic.apiKey is set
-    asserts:
-      - hasDocuments:
-          count: 1
-
-  - it: should pass when only anthropic.existingSecretName is set
-    set:
-      anthropic.apiKey: ""
-      anthropic.existingSecretName: "my-anthropic-secret"
-    asserts:
-      - hasDocuments:
-          count: 1
-
   # Redis host tests
   - it: should fail when redis.host is not defined
     set:
@@ -159,8 +128,6 @@ tests:
     set:
       database.password: ""
       database.existingSecretName: "db-secret"
-      anthropic.apiKey: ""
-      anthropic.existingSecretName: "anthropic-secret"
       redis.existingSecretName: "redis-secret"
     asserts:
       - hasDocuments:

--- a/charts/platform/charts/agent-backend/tests/__snapshot__/configmap_test.yaml.snap
+++ b/charts/platform/charts/agent-backend/tests/__snapshot__/configmap_test.yaml.snap
@@ -1,4 +1,4 @@
-should render a ConfigMap with default values:
+should render a ConfigMap with default bedrock-only values:
   1: |
     apiVersion: v1
     data:
@@ -13,15 +13,10 @@ should render a ConfigMap with default values:
       AGENT_BACKEND_REDIS_HOST: ""
       AGENT_BACKEND_REDIS_PORT: "6379"
       AGENT_BACKEND_REDIS_TLS: "false"
-      AGENTCORE_AGENT_ARN: ""
-      BEDROCK_REGION: ""
-      KNOWLEDGE_INDEXER_EMBEDDINGS_PROVIDER: bedrock
       LOG_LEVEL: INFO
-      NEXTFLOW_DOCS_BEDROCK_DIMENSIONS: "1024"
-      NEXTFLOW_DOCS_BEDROCK_MODEL_ID: amazon.titan-embed-text-v2:0
       NEXTFLOW_DOCS_USE_REDIS_INDEX: "false"
       SEQERA_MCP_URL: https://mcp.test.example.com/mcp
-      SEQERA_PLATFORM_API_URL: http://release-name-platform-backend:8080
+      SEQERA_PLATFORM_API_URL: http://my-platform-backend:8080
       SEQERA_PLATFORM_URL: https://test.example.com
       USE_BEDROCK_INFERENCE: "true"
     kind: ConfigMap

--- a/charts/platform/charts/agent-backend/tests/__snapshot__/configmap_test.yaml.snap
+++ b/charts/platform/charts/agent-backend/tests/__snapshot__/configmap_test.yaml.snap
@@ -14,7 +14,7 @@ should render a ConfigMap with default bedrock-only values:
       AGENT_BACKEND_REDIS_PORT: "6379"
       AGENT_BACKEND_REDIS_TLS: "false"
       LOG_LEVEL: INFO
-      NEXTFLOW_DOCS_USE_REDIS_INDEX: "false"
+      NEXTFLOW_DOCS_TOOL: disabled
       SEQERA_MCP_URL: https://mcp.test.example.com/mcp
       SEQERA_PLATFORM_API_URL: http://my-platform-backend:8080
       SEQERA_PLATFORM_URL: https://test.example.com

--- a/charts/platform/charts/agent-backend/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/platform/charts/agent-backend/tests/__snapshot__/deployment_test.yaml.snap
@@ -51,7 +51,7 @@ should render a Deployment with default values:
               envFrom:
                 - configMapRef:
                     name: release-name-agent-backend
-              image: private/nf-tower-enterprise/agent-backend:v9.9.9
+              image: ai/agent-backend/backend:v9.9.9
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 failureThreshold: 10
@@ -167,7 +167,7 @@ should render a Deployment with default values:
               envFrom:
                 - configMapRef:
                     name: release-name-agent-backend
-              image: private/nf-tower-enterprise/agent-backend:v9.9.9
+              image: ai/agent-backend/backend:v9.9.9
               imagePullPolicy: IfNotPresent
               name: init
               resources:

--- a/charts/platform/charts/agent-backend/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/platform/charts/agent-backend/tests/__snapshot__/deployment_test.yaml.snap
@@ -21,7 +21,7 @@ should render a Deployment with default values:
       template:
         metadata:
           annotations:
-            checksum/configmap: 657d89441dd5ef12580ca56600b2c05f5de63bc27f61911cad1a9e91dfabbda0
+            checksum/configmap: 44200b5ac359bae8677f19c8fe122dbffdf68622a912ef6dd4f773286fe759a6
             checksum/secret: ac4ca92760ab83180bef6b3504a9f7b2663f3c2972a4b7e57a8e3173c6092172
           labels:
             app.kubernetes.io/component: agent-backend

--- a/charts/platform/charts/agent-backend/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/platform/charts/agent-backend/tests/__snapshot__/deployment_test.yaml.snap
@@ -21,7 +21,7 @@ should render a Deployment with default values:
       template:
         metadata:
           annotations:
-            checksum/configmap: f133dfcb4869e3b4a713c59b09af19365251f62b2d24f49dc81a5c928bbc0fb2
+            checksum/configmap: 657d89441dd5ef12580ca56600b2c05f5de63bc27f61911cad1a9e91dfabbda0
             checksum/secret: ac4ca92760ab83180bef6b3504a9f7b2663f3c2972a4b7e57a8e3173c6092172
           labels:
             app.kubernetes.io/component: agent-backend

--- a/charts/platform/charts/agent-backend/tests/_helpers_test.yaml
+++ b/charts/platform/charts/agent-backend/tests/_helpers_test.yaml
@@ -25,6 +25,8 @@ templates:
 chart:
   version: 1.2.3
   appVersion: "v9.9.9"
+set:
+  inference.provider: bedrock
 tests:
   - it: should use custom image from global registry override
     template: deployment.yaml

--- a/charts/platform/charts/agent-backend/tests/configmap_test.yaml
+++ b/charts/platform/charts/agent-backend/tests/configmap_test.yaml
@@ -372,21 +372,21 @@ tests:
           path: data.AGENT_BACKEND_DB_TLS_CA
           value: "/certs/ca.pem"
 
-  # ---- Nextflow docs Redis index ----
+  # ---- Nextflow docs tool ----
 
-  - it: should set NEXTFLOW_DOCS_USE_REDIS_INDEX to false by default
+  - it: should set NEXTFLOW_DOCS_TOOL to disabled when embeddings.provider is not set
     asserts:
       - equal:
-          path: data.NEXTFLOW_DOCS_USE_REDIS_INDEX
-          value: "false"
+          path: data.NEXTFLOW_DOCS_TOOL
+          value: "disabled"
 
-  - it: should set NEXTFLOW_DOCS_USE_REDIS_INDEX when enabled
+  - it: should set NEXTFLOW_DOCS_TOOL to memory when embeddings.provider is set
     set:
-      nextflowDocs.useRedisIndex: true
+      embeddings.provider: bedrock
     asserts:
       - equal:
-          path: data.NEXTFLOW_DOCS_USE_REDIS_INDEX
-          value: "true"
+          path: data.NEXTFLOW_DOCS_TOOL
+          value: "memory"
 
   # ---- Validation failures ----
 
@@ -433,9 +433,9 @@ tests:
       - isKind:
           of: ConfigMap
 
-  - it: should not render AGENTCORE_AGENT_ARN when sandbox.provider is bedrock but runtimeArn is not set
+  - it: should fail when sandbox.provider is bedrock but runtimeArn is not set
     set:
       sandbox.provider: bedrock
     asserts:
-      - notExists:
-          path: data.AGENTCORE_AGENT_ARN
+      - failedTemplate:
+          errorPattern: "bedrock.sandbox.runtimeArn is not set"

--- a/charts/platform/charts/agent-backend/tests/configmap_test.yaml
+++ b/charts/platform/charts/agent-backend/tests/configmap_test.yaml
@@ -23,16 +23,20 @@ templates:
 chart:
   version: 1.2.3
   appVersion: "v9.9.9"
+
+# Suite-level defaults: only inference.provider is required.
+set:
+  global.platformExternalDomain: test.example.com
+  global.platformServiceAddress: my-platform-backend
+  global.platformServicePort: 8080
+  global.mcpDomain: mcp.test.example.com
+  inference.provider: bedrock
+  database.host: mysql.default.svc.cluster.local
+  database.name: agentdb
+  database.username: agent
+
 tests:
-  - it: should render a ConfigMap with default values
-    set:
-      global.platformExternalDomain: test.example.com
-      global.platformServiceAddress: '{{ printf "%s-platform-backend" .Release.Name | lower }}'
-      global.platformServicePort: 8080
-      global.mcpDomain: mcp.test.example.com
-      database.host: mysql.default.svc.cluster.local
-      database.name: agentdb
-      database.username: agent
+  - it: should render a ConfigMap with default bedrock-only values
     asserts:
       - isKind:
           of: ConfigMap
@@ -40,8 +44,6 @@ tests:
 
   - it: should contain database configuration
     set:
-      global.platformExternalDomain: test.example.com
-      global.mcpDomain: mcp.test.example.com
       database.host: mysql.default.svc.cluster.local
       database.port: 3306
       database.name: agentdb
@@ -66,9 +68,6 @@ tests:
       global.platformServiceAddress: my-platform-backend
       global.platformServicePort: 9090
       global.mcpDomain: mcp.prod.example.com
-      database.host: mysql
-      database.name: db
-      database.username: user
     asserts:
       - equal:
           path: data.SEQERA_PLATFORM_API_URL
@@ -80,9 +79,6 @@ tests:
       global.platformServiceAddress: '{{ printf "%s-platform-backend" .Release.Name | lower }}'
       global.platformServicePort: 8080
       global.mcpDomain: mcp.prod.example.com
-      database.host: mysql
-      database.name: db
-      database.username: user
     asserts:
       - equal:
           path: data.SEQERA_PLATFORM_API_URL
@@ -92,9 +88,6 @@ tests:
     set:
       global.platformExternalDomain: prod.example.com
       global.mcpDomain: mcp.prod.example.com
-      database.host: mysql
-      database.name: db
-      database.username: user
     asserts:
       - equal:
           path: data.SEQERA_PLATFORM_URL
@@ -105,11 +98,6 @@ tests:
 
   - it: should use custom service port in configmap
     set:
-      global.platformExternalDomain: test.example.com
-      global.mcpDomain: mcp.test.example.com
-      database.host: mysql
-      database.name: db
-      database.username: user
       service.http.targetPort: 9000
     asserts:
       - equal:
@@ -118,95 +106,198 @@ tests:
 
   - it: should template mcpDomain
     set:
-      global.platformExternalDomain: test.example.com
       global.mcpDomain: "{{ .Release.Name }}-mcp.example.com"
-      database.host: mysql
-      database.name: db
-      database.username: user
     asserts:
       - equal:
           path: data.SEQERA_MCP_URL
           value: "https://RELEASE-NAME-mcp.example.com/mcp"
 
-  - it: should set custom environment and log level
+  - it: should set custom log level
     set:
-      global.platformExternalDomain: test.example.com
-      global.mcpDomain: mcp.test.example.com
-      database.host: mysql
-      database.name: db
-      database.username: user
       logLevel: DEBUG
     asserts:
       - equal:
           path: data.LOG_LEVEL
           value: DEBUG
 
-  - it: should set KNOWLEDGE_INDEXER_EMBEDDINGS_PROVIDER to bedrock
-    set:
-      global.platformExternalDomain: test.example.com
-      global.mcpDomain: mcp.test.example.com
-      database.host: mysql
-      database.name: db
-      database.username: user
-    asserts:
-      - equal:
-          path: data.KNOWLEDGE_INDEXER_EMBEDDINGS_PROVIDER
-          value: "bedrock"
+  # ---- Provider routing: inference ----
 
-  - it: should always enable Bedrock inference
-    set:
-      global.platformExternalDomain: test.example.com
-      global.mcpDomain: mcp.test.example.com
-      database.host: mysql
-      database.name: db
-      database.username: user
+  - it: should set USE_BEDROCK_INFERENCE to true when inference.provider is bedrock
     asserts:
       - equal:
           path: data.USE_BEDROCK_INFERENCE
           value: "true"
 
-  - it: should render Bedrock embeddings settings with default values
+  - it: should set USE_BEDROCK_INFERENCE to false when inference.provider is anthropic
     set:
-      global.platformExternalDomain: test.example.com
-      global.mcpDomain: mcp.test.example.com
-      database.host: mysql
-      database.name: db
-      database.username: user
+      inference.provider: anthropic
+      anthropic.apiKey: sk-ant-test123
     asserts:
-      - isSubset:
-          path: data
-          content:
-            USE_BEDROCK_INFERENCE: "true"
-            BEDROCK_REGION: ""
-            NEXTFLOW_DOCS_BEDROCK_MODEL_ID: amazon.titan-embed-text-v2:0
-            NEXTFLOW_DOCS_BEDROCK_DIMENSIONS: "1024"
+      - equal:
+          path: data.USE_BEDROCK_INFERENCE
+          value: "false"
 
-  - it: should render Bedrock embeddings settings when configured
-    set:
-      global.platformExternalDomain: test.example.com
-      global.mcpDomain: mcp.test.example.com
-      database.host: mysql
-      database.name: db
-      database.username: user
-      embeddings.bedrock.region: eu-west-2
-      embeddings.bedrock.modelId: amazon.titan-embed-text-v2:0
-      embeddings.bedrock.dimensions: 1024
+  # ---- Provider routing: embeddings (optional) ----
+
+  - it: should not set KNOWLEDGE_INDEXER_EMBEDDINGS_PROVIDER when embeddings.provider is empty
     asserts:
-      - isSubset:
-          path: data
-          content:
-            USE_BEDROCK_INFERENCE: "true"
-            BEDROCK_REGION: eu-west-2
-            NEXTFLOW_DOCS_BEDROCK_MODEL_ID: amazon.titan-embed-text-v2:0
-            NEXTFLOW_DOCS_BEDROCK_DIMENSIONS: "1024"
+      - notExists:
+          path: data.KNOWLEDGE_INDEXER_EMBEDDINGS_PROVIDER
+
+  - it: should set KNOWLEDGE_INDEXER_EMBEDDINGS_PROVIDER when embeddings.provider is set
+    set:
+      embeddings.provider: bedrock
+    asserts:
+      - equal:
+          path: data.KNOWLEDGE_INDEXER_EMBEDDINGS_PROVIDER
+          value: "bedrock"
+
+  - it: should not render embeddings env vars when embeddings.provider is empty
+    asserts:
+      - notExists:
+          path: data.NEXTFLOW_DOCS_BEDROCK_MODEL_ID
+      - notExists:
+          path: data.NEXTFLOW_DOCS_BEDROCK_DIMENSIONS
+      - notExists:
+          path: data.AWS_BEDROCK_EMBEDDINGS_ASSUME_ROLE_ARN
+      - notExists:
+          path: data.BEDROCK_EMBEDDINGS_REGION
+
+  - it: should render embeddings env vars with defaults when embeddings.provider is bedrock
+    set:
+      embeddings.provider: bedrock
+    asserts:
+      - equal:
+          path: data.NEXTFLOW_DOCS_BEDROCK_MODEL_ID
+          value: amazon.titan-embed-text-v2:0
+      - equal:
+          path: data.NEXTFLOW_DOCS_BEDROCK_DIMENSIONS
+          value: "1024"
+      - notExists:
+          path: data.AWS_BEDROCK_EMBEDDINGS_ASSUME_ROLE_ARN
+      - notExists:
+          path: data.BEDROCK_EMBEDDINGS_REGION
+
+  - it: should render all Bedrock embeddings env vars when fully configured
+    set:
+      embeddings.provider: bedrock
+      bedrock.embeddings.assumeRoleArn: arn:aws:iam::123456789012:role/embeddings-role
+      bedrock.embeddings.region: eu-west-2
+      bedrock.embeddings.model: amazon.titan-embed-text-v2:0
+      bedrock.embeddings.dimensions: "1024"
+    asserts:
+      - equal:
+          path: data.AWS_BEDROCK_EMBEDDINGS_ASSUME_ROLE_ARN
+          value: arn:aws:iam::123456789012:role/embeddings-role
+      - equal:
+          path: data.BEDROCK_EMBEDDINGS_REGION
+          value: eu-west-2
+      - equal:
+          path: data.NEXTFLOW_DOCS_BEDROCK_MODEL_ID
+          value: amazon.titan-embed-text-v2:0
+      - equal:
+          path: data.NEXTFLOW_DOCS_BEDROCK_DIMENSIONS
+          value: "1024"
+
+  # ---- Provider routing: sandbox (optional) ----
+
+  - it: should not render sandbox env vars when sandbox.provider is empty
+    asserts:
+      - notExists:
+          path: data.AGENTCORE_AGENT_ARN
+      - notExists:
+          path: data.AGENTCORE_REGION
+      - notExists:
+          path: data.AWS_AGENTCORE_ASSUME_ROLE_ARN
+
+  - it: should render AGENTCORE_AGENT_ARN when sandbox.provider and runtimeArn are set
+    set:
+      sandbox.provider: bedrock
+      bedrock.sandbox.runtimeArn: arn:aws:bedrock-agentcore:eu-west-2:123456789012:runtime/example-runtime
+    asserts:
+      - equal:
+          path: data.AGENTCORE_AGENT_ARN
+          value: arn:aws:bedrock-agentcore:eu-west-2:123456789012:runtime/example-runtime
+      - notExists:
+          path: data.AGENTCORE_REGION
+      - notExists:
+          path: data.AWS_AGENTCORE_ASSUME_ROLE_ARN
+
+  - it: should render all sandbox env vars when fully configured
+    set:
+      sandbox.provider: bedrock
+      bedrock.sandbox.runtimeArn: arn:aws:bedrock-agentcore:eu-west-2:123456789012:runtime/default
+      bedrock.sandbox.region: eu-west-2
+      bedrock.sandbox.assumeRoleArn: arn:aws:iam::123456789012:role/agentcore-role
+    asserts:
+      - equal:
+          path: data.AGENTCORE_AGENT_ARN
+          value: arn:aws:bedrock-agentcore:eu-west-2:123456789012:runtime/default
+      - equal:
+          path: data.AGENTCORE_REGION
+          value: eu-west-2
+      - equal:
+          path: data.AWS_AGENTCORE_ASSUME_ROLE_ARN
+          value: arn:aws:iam::123456789012:role/agentcore-role
+
+  # ---- Bedrock default credentials ----
+
+  - it: should not set AWS_BEDROCK_SERVICES_DEFAULT_ASSUME_ROLE_ARN when not configured
+    asserts:
+      - notExists:
+          path: data.AWS_BEDROCK_SERVICES_DEFAULT_ASSUME_ROLE_ARN
+
+  - it: should set AWS_BEDROCK_SERVICES_DEFAULT_ASSUME_ROLE_ARN when configured
+    set:
+      bedrock.default.assumeRoleArn: arn:aws:iam::123456789012:role/bedrock-cross-account
+    asserts:
+      - equal:
+          path: data.AWS_BEDROCK_SERVICES_DEFAULT_ASSUME_ROLE_ARN
+          value: arn:aws:iam::123456789012:role/bedrock-cross-account
+
+  - it: should not set AWS_BEDROCK_SERVICES_DEFAULT_REGION when not configured
+    asserts:
+      - notExists:
+          path: data.AWS_BEDROCK_SERVICES_DEFAULT_REGION
+
+  - it: should set AWS_BEDROCK_SERVICES_DEFAULT_REGION when configured
+    set:
+      bedrock.default.region: us-east-1
+    asserts:
+      - equal:
+          path: data.AWS_BEDROCK_SERVICES_DEFAULT_REGION
+          value: us-east-1
+
+  # ---- Bedrock inference overrides ----
+
+  - it: should not set per-service Bedrock inference env vars when not configured
+    asserts:
+      - notExists:
+          path: data.AWS_BEDROCK_INFERENCE_ASSUME_ROLE_ARN
+      - notExists:
+          path: data.BEDROCK_INFERENCE_REGION
+      - notExists:
+          path: data.BEDROCK_ANTHROPIC_MODEL
+
+  - it: should set Bedrock inference per-service overrides when configured
+    set:
+      bedrock.inference.assumeRoleArn: arn:aws:iam::123456789012:role/inference-role
+      bedrock.inference.region: us-west-2
+      bedrock.inference.anthropicModel: anthropic.claude-sonnet-4-6
+    asserts:
+      - equal:
+          path: data.AWS_BEDROCK_INFERENCE_ASSUME_ROLE_ARN
+          value: arn:aws:iam::123456789012:role/inference-role
+      - equal:
+          path: data.BEDROCK_INFERENCE_REGION
+          value: us-west-2
+      - equal:
+          path: data.BEDROCK_ANTHROPIC_MODEL
+          value: anthropic.claude-sonnet-4-6
+
+  # ---- Redis ----
 
   - it: should contain default Redis configuration
-    set:
-      global.platformExternalDomain: test.example.com
-      global.mcpDomain: mcp.test.example.com
-      database.host: mysql
-      database.name: db
-      database.username: user
     asserts:
       - equal:
           path: data.AGENT_BACKEND_REDIS_HOST
@@ -221,75 +312,8 @@ tests:
           path: data.AGENT_BACKEND_REDIS_TLS
           value: "false"
 
-  - it: should set AGENT_BACKEND_DB_TLS to false by default
-    set:
-      global.platformExternalDomain: test.example.com
-      global.mcpDomain: mcp.test.example.com
-      database.host: mysql
-      database.name: db
-      database.username: user
-    asserts:
-      - equal:
-          path: data.AGENT_BACKEND_DB_TLS
-          value: "false"
-      - equal:
-          path: data.AGENT_BACKEND_DB_TLS_CA_VERIFY
-          value: "true"
-      - notExists:
-          path: data.AGENT_BACKEND_DB_TLS_CA
-
-  - it: should set AGENT_BACKEND_DB_TLS to true when enableTls is set
-    set:
-      global.platformExternalDomain: test.example.com
-      global.mcpDomain: mcp.test.example.com
-      database.host: mysql
-      database.name: db
-      database.username: user
-      database.enableTls: true
-    asserts:
-      - equal:
-          path: data.AGENT_BACKEND_DB_TLS
-          value: "true"
-      - notExists:
-          path: data.AGENT_BACKEND_DB_TLS_CA
-
-  - it: should set AGENT_BACKEND_DB_TLS_CA_VERIFY to false when tlsCaVerify is false
-    set:
-      global.platformExternalDomain: test.example.com
-      global.mcpDomain: mcp.test.example.com
-      database.host: mysql
-      database.name: db
-      database.username: user
-      database.tlsCaVerify: false
-    asserts:
-      - equal:
-          path: data.AGENT_BACKEND_DB_TLS_CA_VERIFY
-          value: "false"
-
-  - it: should set AGENT_BACKEND_DB_TLS_CA when sslCa is provided
-    set:
-      global.platformExternalDomain: test.example.com
-      global.mcpDomain: mcp.test.example.com
-      database.host: mysql
-      database.name: db
-      database.username: user
-      database.enableTls: true
-      database.sslCa: /certs/ca.pem
-    asserts:
-      - equal:
-          path: data.AGENT_BACKEND_DB_TLS
-          value: "true"
-      - equal:
-          path: data.AGENT_BACKEND_DB_TLS_CA
-          value: "/certs/ca.pem"
-
   - it: should contain custom Redis configuration
     set:
-      global.platformExternalDomain: test.example.com
-      global.mcpDomain: mcp.test.example.com
-      database.host: mysql
-      database.name: db
-      database.username: user
       redis.host: redis.example.com
       redis.port: 6380
       redis.db: 5
@@ -308,13 +332,52 @@ tests:
           path: data.AGENT_BACKEND_REDIS_TLS
           value: "true"
 
-  - it: should set NEXTFLOW_DOCS_USE_REDIS_INDEX to false by default
+  # ---- Database TLS ----
+
+  - it: should set AGENT_BACKEND_DB_TLS to false by default
+    asserts:
+      - equal:
+          path: data.AGENT_BACKEND_DB_TLS
+          value: "false"
+      - equal:
+          path: data.AGENT_BACKEND_DB_TLS_CA_VERIFY
+          value: "true"
+      - notExists:
+          path: data.AGENT_BACKEND_DB_TLS_CA
+
+  - it: should set AGENT_BACKEND_DB_TLS to true when enableTls is set
     set:
-      global.platformExternalDomain: test.example.com
-      global.mcpDomain: mcp.test.example.com
-      database.host: mysql
-      database.name: db
-      database.username: user
+      database.enableTls: true
+    asserts:
+      - equal:
+          path: data.AGENT_BACKEND_DB_TLS
+          value: "true"
+      - notExists:
+          path: data.AGENT_BACKEND_DB_TLS_CA
+
+  - it: should set AGENT_BACKEND_DB_TLS_CA_VERIFY to false when tlsCaVerify is false
+    set:
+      database.tlsCaVerify: false
+    asserts:
+      - equal:
+          path: data.AGENT_BACKEND_DB_TLS_CA_VERIFY
+          value: "false"
+
+  - it: should set AGENT_BACKEND_DB_TLS_CA when sslCa is provided
+    set:
+      database.enableTls: true
+      database.sslCa: /certs/ca.pem
+    asserts:
+      - equal:
+          path: data.AGENT_BACKEND_DB_TLS
+          value: "true"
+      - equal:
+          path: data.AGENT_BACKEND_DB_TLS_CA
+          value: "/certs/ca.pem"
+
+  # ---- Nextflow docs Redis index ----
+
+  - it: should set NEXTFLOW_DOCS_USE_REDIS_INDEX to false by default
     asserts:
       - equal:
           path: data.NEXTFLOW_DOCS_USE_REDIS_INDEX
@@ -322,76 +385,60 @@ tests:
 
   - it: should set NEXTFLOW_DOCS_USE_REDIS_INDEX when enabled
     set:
-      global.platformExternalDomain: test.example.com
-      global.mcpDomain: mcp.test.example.com
-      database.host: mysql
-      database.name: db
-      database.username: user
       nextflowDocs.useRedisIndex: true
     asserts:
       - equal:
           path: data.NEXTFLOW_DOCS_USE_REDIS_INDEX
           value: "true"
 
-  - it: should not set AWS_BEDROCK_SERVICES_DEFAULT_ASSUME_ROLE_ARN by default
+  # ---- Validation failures ----
+
+  - it: should fail when inference.provider is not set
     set:
-      global.platformExternalDomain: test.example.com
-      global.mcpDomain: mcp.test.example.com
-      database.host: mysql
-      database.name: db
-      database.username: user
+      inference.provider: ""
+    asserts:
+      - failedTemplate:
+          errorPattern: "inference.provider is required"
+
+  - it: should fail when inference.provider has an unsupported value
+    set:
+      inference.provider: vertex
+    asserts:
+      - failedTemplate:
+          errorPattern: "is not supported"
+
+  - it: should fail when embeddings.provider has an unsupported value
+    set:
+      embeddings.provider: vertex
+    asserts:
+      - failedTemplate:
+          errorPattern: "is not supported"
+
+  - it: should fail when sandbox.provider has an unsupported value
+    set:
+      sandbox.provider: vertex
+    asserts:
+      - failedTemplate:
+          errorPattern: "is not supported"
+
+  - it: should fail when inference.provider is anthropic but no apiKey is configured
+    set:
+      inference.provider: anthropic
+    asserts:
+      - failedTemplate:
+          errorPattern: "neither anthropic.apiKey nor anthropic.existingSecretName is set"
+
+  - it: should not fail when inference.provider is anthropic and existingSecretName is configured
+    set:
+      inference.provider: anthropic
+      anthropic.existingSecretName: my-anthropic-secret
+    asserts:
+      - isKind:
+          of: ConfigMap
+
+  - it: should not render AGENTCORE_AGENT_ARN when sandbox.provider is bedrock but runtimeArn is not set
+    set:
+      sandbox.provider: bedrock
     asserts:
       - notExists:
-          path: data.AWS_BEDROCK_SERVICES_DEFAULT_ASSUME_ROLE_ARN
-
-  - it: should set AWS_BEDROCK_SERVICES_DEFAULT_ASSUME_ROLE_ARN when provided
-    set:
-      global.platformExternalDomain: test.example.com
-      global.mcpDomain: mcp.test.example.com
-      database.host: mysql
-      database.name: db
-      database.username: user
-      bedrockAssumeRoleArn: arn:aws:iam::123456789012:role/bedrock-cross-account
-    asserts:
-      - equal:
-          path: data.AWS_BEDROCK_SERVICES_DEFAULT_ASSUME_ROLE_ARN
-          value: arn:aws:iam::123456789012:role/bedrock-cross-account
-
-  - it: should not set BEDROCK_ANTHROPIC_MODEL by default
-    set:
-      global.platformExternalDomain: test.example.com
-      global.mcpDomain: mcp.test.example.com
-      database.host: mysql
-      database.name: db
-      database.username: user
-    asserts:
-      - notExists:
-          path: data.BEDROCK_ANTHROPIC_MODEL
-
-  - it: should set BEDROCK_ANTHROPIC_MODEL when provided
-    set:
-      global.platformExternalDomain: test.example.com
-      global.mcpDomain: mcp.test.example.com
-      database.host: mysql
-      database.name: db
-      database.username: user
-      bedrockAnthropicModel: anthropic.claude-sonnet-4-6
-    asserts:
-      - equal:
-          path: data.BEDROCK_ANTHROPIC_MODEL
-          value: anthropic.claude-sonnet-4-6
-
-  - it: should include AgentCore runtime ARN when provided
-    set:
-      global.platformExternalDomain: test.example.com
-      global.mcpDomain: mcp.test.example.com
-      database.host: mysql
-      database.name: db
-      database.username: user
-      bedrockAgentCoreArn: arn:aws:bedrock-agentcore:eu-west-2:123456789012:runtime/example-runtime
-    asserts:
-      - equal:
           path: data.AGENTCORE_AGENT_ARN
-          value: arn:aws:bedrock-agentcore:eu-west-2:123456789012:runtime/example-runtime
-      - notExists:
-          path: data.AGENTCORE_REGION

--- a/charts/platform/charts/agent-backend/tests/configmap_test.yaml
+++ b/charts/platform/charts/agent-backend/tests/configmap_test.yaml
@@ -170,9 +170,8 @@ tests:
       - equal:
           path: data.NEXTFLOW_DOCS_BEDROCK_MODEL_ID
           value: amazon.titan-embed-text-v2:0
-      - equal:
+      - notExists:
           path: data.NEXTFLOW_DOCS_BEDROCK_DIMENSIONS
-          value: "1024"
       - notExists:
           path: data.AWS_BEDROCK_EMBEDDINGS_ASSUME_ROLE_ARN
       - notExists:
@@ -184,7 +183,6 @@ tests:
       bedrock.embeddings.assumeRoleArn: arn:aws:iam::123456789012:role/embeddings-role
       bedrock.embeddings.region: eu-west-2
       bedrock.embeddings.model: amazon.titan-embed-text-v2:0
-      bedrock.embeddings.dimensions: "1024"
     asserts:
       - equal:
           path: data.AWS_BEDROCK_EMBEDDINGS_ASSUME_ROLE_ARN
@@ -195,9 +193,8 @@ tests:
       - equal:
           path: data.NEXTFLOW_DOCS_BEDROCK_MODEL_ID
           value: amazon.titan-embed-text-v2:0
-      - equal:
+      - notExists:
           path: data.NEXTFLOW_DOCS_BEDROCK_DIMENSIONS
-          value: "1024"
 
   # ---- Provider routing: sandbox (optional) ----
 

--- a/charts/platform/charts/agent-backend/tests/deployment_test.yaml
+++ b/charts/platform/charts/agent-backend/tests/deployment_test.yaml
@@ -591,7 +591,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: private/nf-tower-enterprise/agent-backend:v9.9.9
+          value: ai/agent-backend/backend:v9.9.9
 
   - it: should evaluate templates in azure override fields for the agent-backend container
     template: deployment.yaml

--- a/charts/platform/charts/agent-backend/tests/deployment_test.yaml
+++ b/charts/platform/charts/agent-backend/tests/deployment_test.yaml
@@ -25,6 +25,8 @@ templates:
 chart:
   version: 1.2.3
   appVersion: "v9.9.9"
+set:
+  inference.provider: bedrock
 tests:
   - it: should render a Deployment with default values
     template: deployment.yaml
@@ -32,7 +34,7 @@ tests:
       global.platformServiceAddress: '{{ printf "%s-platform-backend" .Release.Name | lower }}'
       global.platformServicePort: 8080
       database.password: test-db-password
-      anthropicApiKey: test-anthropic-key
+      anthropic.apiKey: test-anthropic-key
       tokenEncryptionKey: test-token-encryption-key
     asserts:
       - matchSnapshot: {}
@@ -342,8 +344,8 @@ tests:
   - it: should use external secret for anthropic API key
     template: deployment.yaml
     set:
-      anthropicApiKeyExistingSecretName: my-anthropic-secret
-      anthropicApiKeyExistingSecretKey: api-key
+      anthropic.existingSecretName: my-anthropic-secret
+      anthropic.existingSecretKey: api-key
     asserts:
       - equal:
           path: spec.template.spec.containers[0].env[1]
@@ -357,7 +359,7 @@ tests:
   - it: should use default key when anthropic external secret is set without custom key
     template: deployment.yaml
     set:
-      anthropicApiKeyExistingSecretName: my-anthropic-secret
+      anthropic.existingSecretName: my-anthropic-secret
     asserts:
       - equal:
           path: spec.template.spec.containers[0].env[1]
@@ -371,7 +373,7 @@ tests:
   - it: should configure main container with env before envFrom
     template: deployment.yaml
     set:
-      anthropicApiKey: test-anthropic-key
+      anthropic.apiKey: test-anthropic-key
       tokenEncryptionKey: test-token-encryption-key
     asserts:
       - equal:

--- a/charts/platform/charts/agent-backend/tests/secret_test.yaml
+++ b/charts/platform/charts/agent-backend/tests/secret_test.yaml
@@ -27,7 +27,7 @@ tests:
   - it: should render a Secret with default values
     set:
       database.password: test-db-password
-      anthropicApiKey: test-anthropic-key
+      anthropic.apiKey: test-anthropic-key
       tokenEncryptionKey: test-token-encryption-key
     asserts:
       - hasDocuments:
@@ -52,14 +52,14 @@ tests:
 
   - it: should include ANTHROPIC_API_KEY when not using external secret
     set:
-      anthropicApiKey: sk-ant-test123
+      anthropic.apiKey: sk-ant-test123
     asserts:
       - isNotNull:
           path: data.ANTHROPIC_API_KEY
 
   - it: should NOT include ANTHROPIC_API_KEY when using external secret
     set:
-      anthropicApiKeyExistingSecretName: my-anthropic-secret
+      anthropic.existingSecretName: my-anthropic-secret
     asserts:
       - isNull:
           path: data.ANTHROPIC_API_KEY

--- a/charts/platform/charts/agent-backend/values.yaml
+++ b/charts/platform/charts/agent-backend/values.yaml
@@ -203,7 +203,7 @@ image:
   # -- Container image registry
   registry: ""
   # -- Container image repository
-  repository: private/nf-tower-enterprise/agent-backend
+  repository: ai/agent-backend/backend
   # -- Container image tag
   # @default -- `"{{ .chart.AppVersion }}"`
   tag: ""

--- a/charts/platform/charts/agent-backend/values.yaml
+++ b/charts/platform/charts/agent-backend/values.yaml
@@ -184,11 +184,6 @@ redis:
   # @default -- `"AGENT_BACKEND_REDIS_PASSWORD"`
   existingSecretKey: ""
 
-nextflowDocs:
-  # -- Use a Redis-backed vector index for the Nextflow documentation knowledge base.
-  # Disabled by default.
-  useRedisIndex: false
-
 # -- Token encryption key (must be a valid Fernet key). Define the value as a String or a Secret,
 # not both at the same time. If not defined, a random Fernet key will be auto-generated at each
 # deployment.

--- a/charts/platform/charts/agent-backend/values.yaml
+++ b/charts/platform/charts/agent-backend/values.yaml
@@ -80,6 +80,68 @@ global:
   #   kubectl create secret docker-registry mycreds --docker-server='cr.example.com' --docker-username='robot$robotnamehere' --docker-password='passwordhere' --dry-run=client -o yaml
   # https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-secret-by-providing-credentials-on-the-command-line
 
+# ---- Service routing: which provider handles each capability ----
+inference:
+  # -- Inference provider. One of: "bedrock", "anthropic". Required.
+  provider: ""
+
+embeddings:
+  # -- Embeddings provider. One of: "bedrock". When empty, embeddings are disabled.
+  provider: ""
+
+sandbox:
+  # -- Sandbox provider. One of: "bedrock". When empty, sandbox is disabled.
+  provider: ""
+
+# ---- Provider configuration ----
+bedrock:
+  # -- Default credentials/region applied to any Bedrock-backed service that does not set its own.
+  default:
+    # -- Default IAM role ARN to assume for all Bedrock services (cross-account access).
+    assumeRoleArn: ""
+    # -- Default AWS region for all Bedrock services.
+    region: ""
+
+  # -- Inference-specific Bedrock overrides. Each field maps to one env var; leave empty to omit
+  # and let the backend fall back to bedrock.default.*
+  inference:
+    # -- IAM role ARN for Bedrock inference (overrides bedrock.default.assumeRoleArn).
+    assumeRoleArn: ""
+    # -- AWS region for Bedrock inference (overrides bedrock.default.region).
+    region: ""
+    # -- Anthropic inference profile ARN to use on Bedrock (e.g. a custom or cross-region profile).
+    anthropicModel: ""
+
+  # -- Embeddings-specific Bedrock overrides.
+  embeddings:
+    # -- IAM role ARN for Bedrock embeddings (overrides bedrock.default.assumeRoleArn).
+    assumeRoleArn: ""
+    # -- AWS region for Bedrock embeddings (overrides bedrock.default.region).
+    region: ""
+    # -- Bedrock model ID used for embeddings.
+    model: "amazon.titan-embed-text-v2:0"
+    # -- Embedding vector dimensions expected from the configured Bedrock model.
+    dimensions: "1024"
+
+  # -- Sandbox (AgentCore) Bedrock configuration.
+  sandbox:
+    # -- IAM role ARN for AgentCore (overrides bedrock.default.assumeRoleArn).
+    assumeRoleArn: ""
+    # -- AWS region for AgentCore.
+    region: ""
+    # -- AWS Bedrock AgentCore runtime ARN for sandbox sessions.
+    runtimeArn: ""
+
+anthropic:
+  # -- Anthropic API key. Set this OR existingSecretName, not both.
+  apiKey: ""
+  # -- Name of an existing Secret containing the Anthropic API key.
+  # Note: the Secret must already exist in the same namespace at the time of deployment
+  existingSecretName: ""
+  # -- Key in the existing Secret containing the Anthropic API key
+  # @default -- `"ANTHROPIC_API_KEY"`
+  existingSecretKey: ""
+
 database:
   # -- MySQL database hostname
   host: ""
@@ -124,42 +186,10 @@ redis:
   # @default -- `"AGENT_BACKEND_REDIS_PASSWORD"`
   existingSecretKey: ""
 
-# -- AWS Bedrock AgentCore runtime ARN for sandbox sessions
-bedrockAgentCoreArn: ""
-
-# -- Optional IAM role ARN that the Agent Backend assumes for cross-account Bedrock access.
-# Leave empty to let the pod directly use the AWS credentials provided to it (single-account setup).
-bedrockAssumeRoleArn: ""
-
-# -- Override the Anthropic model used on Bedrock by specifying an inference profile ARN. You can
-# create a custom inference profile that uses the Anthropic model you want or use the default
-# inference profile for the model provided by AWS. When doing cross-account access with
-# `bedrockAssumeRoleArn`, you may want to specify an inference profile ARN on the account where the
-# hop role is defined
-bedrockAnthropicModel: ""
-
-embeddings:
-  bedrock:
-    # -- AWS region where the Bedrock model is hosted
-    region: ""
-    # -- Bedrock model ID used for embeddings
-    modelId: "amazon.titan-embed-text-v2:0"
-    # -- Embedding vector dimensions expected from the configured Bedrock model
-    dimensions: "1024"
-
 nextflowDocs:
   # -- Use a Redis-backed vector index for the Nextflow documentation knowledge base.
   # Disabled by default.
   useRedisIndex: false
-
-# -- Anthropic API key. Define the value as a String or a Secret, not both at the same time
-anthropicApiKey: ""
-# -- Name of an existing Secret containing the Anthropic API key.
-# Note: the Secret must already exist in the same namespace at the time of deployment
-anthropicApiKeyExistingSecretName: ""
-# -- Key in the existing Secret containing the Anthropic API key
-# @default -- `"ANTHROPIC_API_KEY"`
-anthropicApiKeyExistingSecretKey: ""
 
 # -- Token encryption key (must be a valid Fernet key). Define the value as a String or a Secret,
 # not both at the same time. If not defined, a random Fernet key will be auto-generated at each

--- a/charts/platform/charts/agent-backend/values.yaml
+++ b/charts/platform/charts/agent-backend/values.yaml
@@ -120,8 +120,6 @@ bedrock:
     region: ""
     # -- Bedrock model ID used for embeddings.
     model: "amazon.titan-embed-text-v2:0"
-    # -- Embedding vector dimensions expected from the configured Bedrock model.
-    dimensions: "1024"
 
   # -- Sandbox (AgentCore) Bedrock configuration.
   sandbox:

--- a/charts/platform/charts/agent-backend/values.yaml
+++ b/charts/platform/charts/agent-backend/values.yaml
@@ -80,7 +80,7 @@ global:
   #   kubectl create secret docker-registry mycreds --docker-server='cr.example.com' --docker-username='robot$robotnamehere' --docker-password='passwordhere' --dry-run=client -o yaml
   # https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-secret-by-providing-credentials-on-the-command-line
 
-# ---- Service routing: which provider handles each capability ----
+# Service routing: define which provider handles each capability.
 inference:
   # -- Inference provider. One of: "bedrock", "anthropic". Required.
   provider: ""
@@ -93,37 +93,41 @@ sandbox:
   # -- Sandbox provider. One of: "bedrock". When empty, sandbox is disabled.
   provider: ""
 
-# ---- Provider configuration ----
+# Provider configuration blocks. Required when the corresponding provider is selected above.
 bedrock:
-  # -- Default credentials/region applied to any Bedrock-backed service that does not set its own.
+  # Default credentials/region applied to any Bedrock-backed service that does not set its own.
   default:
-    # -- Default IAM role ARN to assume for all Bedrock services (cross-account access).
+    # -- Optional default IAM role ARN to assume before invoking the Bedrock APIs.
     assumeRoleArn: ""
-    # -- Default AWS region for all Bedrock services.
+    # -- Default AWS region to use for all Bedrock services.
     region: ""
 
-  # -- Inference-specific Bedrock overrides. Each field maps to one env var; leave empty to omit
+  # Inference-specific Bedrock overrides. Each field maps to one env var; leave empty to omit
   # and let the backend fall back to bedrock.default.*
   inference:
-    # -- IAM role ARN for Bedrock inference (overrides bedrock.default.assumeRoleArn).
+    # -- Optional IAM role ARN to assume for Bedrock inference (overrides
+    # bedrock.default.assumeRoleArn).
     assumeRoleArn: ""
     # -- AWS region for Bedrock inference (overrides bedrock.default.region).
     region: ""
-    # -- Anthropic inference profile ARN to use on Bedrock (e.g. a custom or cross-region profile).
+    # -- Anthropic inference profile ARN to use on Bedrock (e.g. a custom or
+    # cross-region/cross-account profile).
     anthropicModel: ""
 
-  # -- Embeddings-specific Bedrock overrides.
+  # Embeddings-specific Bedrock overrides.
   embeddings:
-    # -- IAM role ARN for Bedrock embeddings (overrides bedrock.default.assumeRoleArn).
+    # -- Optional IAM role ARN to assume for Bedrock embeddings (overrides
+    # bedrock.default.assumeRoleArn).
     assumeRoleArn: ""
     # -- AWS region for Bedrock embeddings (overrides bedrock.default.region).
     region: ""
     # -- Bedrock model ID used for embeddings.
     model: "amazon.titan-embed-text-v2:0"
 
-  # -- Sandbox (AgentCore) Bedrock configuration.
+  # Sandbox (AWS Bedrock AgentCore) configuration.
   sandbox:
-    # -- IAM role ARN for AgentCore (overrides bedrock.default.assumeRoleArn).
+    # -- Optional IAM role ARN to assume before invoking AgentCore (overrides
+    # bedrock.default.assumeRoleArn).
     assumeRoleArn: ""
     # -- AWS region for AgentCore.
     region: ""

--- a/charts/platform/charts/mcp/CHANGELOG.md
+++ b/charts/platform/charts/mcp/CHANGELOG.md
@@ -13,7 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Bump appVersion to 1.3.0.
 - Update image paths in the README and values.yaml - the chart does not hardcode `cr.seqera.io` as the registry, customers are invited to vendor the images to their private registry as well as the charts.
+- `TOWER_API_ENDPOINT` now uses the internal platform service address and port (`global.platformServiceAddress`/`global.platformServicePort`) instead of the external domain, so MCP communicates with the platform over the cluster-internal network, skipping the ingress layer and removing traffic from the platform frontend container.
 
 ## [0.4.0] - 2026-05-05
 

--- a/charts/platform/charts/mcp/CHANGELOG.md
+++ b/charts/platform/charts/mcp/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add link to [Seqera AI prerequisites](https://docs.seqera.io/platform-enterprise/seqera-ai/prerequisites) documentation in the README.
 
+### Changed
+
+- Update image paths in the README and values.yaml - the chart does not hardcode `cr.seqera.io` as the registry, customers are invited to vendor the images to their private registry as well as the charts.
+
 ## [0.4.0] - 2026-05-05
 
 - **Enhancement**: allow global configuration of Ingress options. A new `global.ingress` block (`enabled`, `path`, `defaultPathType`, `ingressClassName`, `annotations`, `extraLabels`, `tls`) lets cluster-wide Ingress defaults be set once at the parent and propagate to every subchart, removing the need to repeat controller-wide config per subchart. `enabled` is OR-merged; scalar fields fall back to global when local is unset; `annotations` and `extraLabels` are merged with local winning on key collision; `tls` is concatenated (useful for a single wildcard certificate across all services).

--- a/charts/platform/charts/mcp/CHANGELOG.md
+++ b/charts/platform/charts/mcp/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - 2026-05-11
+
+### Added
+
+- Add link to [Seqera AI prerequisites](https://docs.seqera.io/platform-enterprise/seqera-ai/prerequisites) documentation in the README.
+
 ## [0.4.0] - 2026-05-05
 
 - **Enhancement**: allow global configuration of Ingress options. A new `global.ingress` block (`enabled`, `path`, `defaultPathType`, `ingressClassName`, `annotations`, `extraLabels`, `tls`) lets cluster-wide Ingress defaults be set once at the parent and propagate to every subchart, removing the need to repeat controller-wide config per subchart. `enabled` is OR-merged; scalar fields fall back to global when local is unset; `annotations` and `extraLabels` are merged with local winning on key collision; `tls` is concatenated (useful for a single wildcard certificate across all services).

--- a/charts/platform/charts/mcp/Chart.yaml
+++ b/charts/platform/charts/mcp/Chart.yaml
@@ -23,7 +23,7 @@ description: |
   RAG-based natural language interactions.
 type: application
 version: 0.4.1
-appVersion: "1.1.0"
+appVersion: "1.3.0"
 maintainers:
   - name: Seqera Labs
     email: devops@seqera.io

--- a/charts/platform/charts/mcp/Chart.yaml
+++ b/charts/platform/charts/mcp/Chart.yaml
@@ -22,7 +22,7 @@ description: |
   Wave container provisioning, bioinformatics data, and nf-core modules through intelligent
   RAG-based natural language interactions.
 type: application
-version: 0.4.0
+version: 0.4.1
 appVersion: "1.1.0"
 maintainers:
   - name: Seqera Labs

--- a/charts/platform/charts/mcp/README.md
+++ b/charts/platform/charts/mcp/README.md
@@ -88,7 +88,7 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | oauth.jwtSeedSecretName | string | `""` | Name of an existing Secret containing the JWT seed, as an alternative to the string field. Note: the Secret must already exist in the same namespace at the time of deployment |
 | oauth.jwtSeedSecretKey | string | `"MCP_OAUTH_JWT_SECRET"` | Key in the existing Secret containing the JWT seed |
 | image.registry | string | `""` | Container image registry |
-| image.repository | string | `"private/nf-tower-enterprise/mcp"` | Container image repository |
+| image.repository | string | `"ai/mcp/server"` | Container image repository |
 | image.tag | string | `"{{ .chart.AppVersion }}"` | Container image tag |
 | image.digest | string | `""` | Container image digest in the format `sha256:1234abcdef` |
 | image.pullPolicy | string | `"IfNotPresent"` | imagePullPolicy for the container Ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images |

--- a/charts/platform/charts/mcp/README.md
+++ b/charts/platform/charts/mcp/README.md
@@ -4,13 +4,15 @@ A Model Context Protocol (MCP) server that provides comprehensive access to the 
 Wave container provisioning, bioinformatics data, and nf-core modules through intelligent
 RAG-based natural language interactions.
 
-![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
+![Version: 0.4.1](https://img.shields.io/badge/Version-0.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
 > The public API SHOULD NOT be considered stable.
 
 ## Requirements and configuration
+
+For a full list of prerequisites needed to deploy Seqera AI, refer to the [Seqera AI prerequisites](https://docs.seqera.io/platform-enterprise/seqera-ai/prerequisites) documentation.
 
 The chart does not automatically define `cr.seqera.io` as the registry where to take the images from: instructions are available to [vendor the Seqera container images to your private registry](https://docs.seqera.io/platform-enterprise/enterprise/prerequisites/common#vendoring-seqera-container-images-to-your-own-registry).
 
@@ -38,7 +40,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/mcp \
-  --version 0.4.0 \
+  --version 0.4.1 \
   --namespace my-namespace \
   --create-namespace
 ```

--- a/charts/platform/charts/mcp/README.md
+++ b/charts/platform/charts/mcp/README.md
@@ -4,7 +4,7 @@ A Model Context Protocol (MCP) server that provides comprehensive access to the 
 Wave container provisioning, bioinformatics data, and nf-core modules through intelligent
 RAG-based natural language interactions.
 
-![Version: 0.4.1](https://img.shields.io/badge/Version-0.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
+![Version: 0.4.1](https://img.shields.io/badge/Version-0.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.0](https://img.shields.io/badge/AppVersion-1.3.0-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -29,7 +29,7 @@ The required values to set in order to have a working installation are:
 
 The Helm chart comes with several requirement checks that will validate the provided configuration before proceeding with the installation.
 
-By default the chart selects the application images defined in the `appVersion` field of the `Chart.yaml` file, currently set as `1.1.0`.
+By default the chart selects the application images defined in the `appVersion` field of the `Chart.yaml` file, currently set as `1.3.0`.
 
 When a sensitive value is required (e.g. the database password), you can either provide it directly in the values file or reference an existing Kubernetes Secret containing the value. The key names to use in the provided Secret are specified in the values file comments.
 Sensitive values provided as plain text by the user are always stored in a Kubernetes Secret created by the chart. When an external Secret is used instead, the chart instructs the components to read the sensitive value from the external Secret directly, without further storing copies of the sensitive value in the chart-created Secret.

--- a/charts/platform/charts/mcp/README.md.gotmpl
+++ b/charts/platform/charts/mcp/README.md.gotmpl
@@ -9,6 +9,8 @@
 
 ## Requirements and configuration
 
+For a full list of prerequisites needed to deploy Seqera AI, refer to the [Seqera AI prerequisites](https://docs.seqera.io/platform-enterprise/seqera-ai/prerequisites) documentation.
+
 The chart does not automatically define `cr.seqera.io` as the registry where to take the images from: instructions are available to [vendor the Seqera container images to your private registry](https://docs.seqera.io/platform-enterprise/enterprise/prerequisites/common#vendoring-seqera-container-images-to-your-own-registry).
 
 The required values to set in order to have a working installation are:

--- a/charts/platform/charts/mcp/templates/configmap.yaml
+++ b/charts/platform/charts/mcp/templates/configmap.yaml
@@ -34,7 +34,7 @@ data:
   MCP_SERVER_URL: {{ printf "https://%s" (tpl .Values.global.mcpDomain $) | quote }}
   MICRONAUT_ENVIRONMENTS: {{ .Values.micronautEnvironments | join "," | quote }}
 
-  TOWER_API_ENDPOINT: {{ printf "https://%s/api" (tpl .Values.global.platformExternalDomain $) | quote }}
+  TOWER_API_ENDPOINT: {{ printf "http://%s:%s" (tpl .Values.global.platformServiceAddress $) (toString .Values.global.platformServicePort) | quote }}
   HUB_API_ENDPOINT: {{ tpl .Values.hubApiEndpoint $ | quote }}
   WAVE_API_ENDPOINT: {{ tpl .Values.waveApiEndpoint $ | quote }}
   REGISTRY_API_ENDPOINT: {{ tpl .Values.registryApiEndpoint $ | quote }}

--- a/charts/platform/charts/mcp/tests/__snapshot__/configmap_test.yaml.snap
+++ b/charts/platform/charts/mcp/tests/__snapshot__/configmap_test.yaml.snap
@@ -9,7 +9,7 @@ should render a ConfigMap with default values:
       MICRONAUT_ENVIRONMENTS: oauth-platform
       MICRONAUT_SERVER_PORT: "6010"
       REGISTRY_API_ENDPOINT: https://registry.nextflow.io
-      TOWER_API_ENDPOINT: https://test.example.com/api
+      TOWER_API_ENDPOINT: http://release-name-platform-backend:8080
       WAVE_API_ENDPOINT: https://wave.seqera.io
     kind: ConfigMap
     metadata:

--- a/charts/platform/charts/mcp/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/platform/charts/mcp/tests/__snapshot__/deployment_test.yaml.snap
@@ -46,7 +46,7 @@ should render a Deployment with default values:
               envFrom:
                 - configMapRef:
                     name: release-name-mcp
-              image: private/nf-tower-enterprise/mcp:v9.9.9
+              image: ai/mcp/server:v9.9.9
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 failureThreshold: 10

--- a/charts/platform/charts/mcp/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/platform/charts/mcp/tests/__snapshot__/deployment_test.yaml.snap
@@ -21,7 +21,7 @@ should render a Deployment with default values:
       template:
         metadata:
           annotations:
-            checksum/configmap: 16f769ed028fde925ece3abfcb4bf4d07ef7afa2bfb2516c2f683e336d5af811
+            checksum/configmap: 131d459188a558e18ce5b09f1d9f3d992733e6fbe2278b6b8ab48e068461bfa4
             checksum/secret: c02f86a51632209a540a8a0e36bd7bf3aadaf054e628be683b4c60c100b3e3b5
           labels:
             app.kubernetes.io/component: mcp

--- a/charts/platform/charts/mcp/tests/configmap_test.yaml
+++ b/charts/platform/charts/mcp/tests/configmap_test.yaml
@@ -27,6 +27,8 @@ tests:
   - it: should render a ConfigMap with default values
     set:
       global.platformExternalDomain: test.example.com
+      global.platformServiceAddress: "release-name-platform-backend"
+      global.platformServicePort: 8080
     asserts:
       - isKind:
           of: ConfigMap
@@ -51,6 +53,8 @@ tests:
 
   - it: should include OAuth settings in configmap
     set:
+      global.platformServiceAddress: "platform-backend"
+      global.platformServicePort: 8080
       oauth:
         issuerUrl: https://auth.example.com
         audience: mcp
@@ -61,7 +65,7 @@ tests:
             MICRONAUT_SERVER_PORT: "6010"
             MCP_SERVER_URL: "https://mcp.example.com"
             MICRONAUT_ENVIRONMENTS: "oauth-platform"
-            TOWER_API_ENDPOINT: "https://example.com/api"
+            TOWER_API_ENDPOINT: "http://platform-backend:8080"
             HUB_API_ENDPOINT: "https://hub.seqera.io"
             WAVE_API_ENDPOINT: "https://wave.seqera.io"
             REGISTRY_API_ENDPOINT: "https://registry.nextflow.io"
@@ -71,6 +75,8 @@ tests:
   - it: should template values in configmap
     set:
       global.platformExternalDomain: example.com
+      global.platformServiceAddress: "platform-backend"
+      global.platformServicePort: 8080
       global.mcpDomain: mcp.example.com
       hubApiEndpoint: "https://hub.{{ .Values.global.platformExternalDomain }}"
       waveApiEndpoint: "https://wave.{{ .Values.global.platformExternalDomain }}"
@@ -85,7 +91,7 @@ tests:
             MICRONAUT_SERVER_PORT: "6010"
             MCP_SERVER_URL: "https://mcp.example.com"
             MICRONAUT_ENVIRONMENTS: "oauth-platform"
-            TOWER_API_ENDPOINT: "https://example.com/api"
+            TOWER_API_ENDPOINT: "http://platform-backend:8080"
             HUB_API_ENDPOINT: "https://hub.example.com"
             WAVE_API_ENDPOINT: "https://wave.example.com"
             REGISTRY_API_ENDPOINT: "https://registry.example.com"

--- a/charts/platform/charts/mcp/values.yaml
+++ b/charts/platform/charts/mcp/values.yaml
@@ -143,7 +143,7 @@ image:
   # -- Container image registry
   registry: ""
   # -- Container image repository
-  repository: private/nf-tower-enterprise/mcp
+  repository: ai/mcp/server
   # -- Container image tag
   # @default -- `"{{ .chart.AppVersion }}"`
   tag: ""

--- a/charts/platform/charts/pipeline-optimization/CHANGELOG.md
+++ b/charts/platform/charts/pipeline-optimization/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.7] - 2026-05-12
+
+### Changed
+
+- Update image paths in the README and values.yaml - the chart does not hardcode `cr.seqera.io` as the registry, customers are invited to vendor the images to their private registry as well as the charts.
+
 ## [2.0.6] - 2026-05-05
 
 ### Changed

--- a/charts/platform/charts/pipeline-optimization/Chart.yaml
+++ b/charts/platform/charts/pipeline-optimization/Chart.yaml
@@ -23,7 +23,7 @@ maintainers:
     email: devops@seqera.io
     url: https://seqera.io
 type: application
-version: 2.0.6
+version: 2.0.7
 appVersion: "0.4.13"
 dependencies:
   - name: common

--- a/charts/platform/charts/pipeline-optimization/README.md
+++ b/charts/platform/charts/pipeline-optimization/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart to deploy the Seqera Pipeline Optimization service (referred to as Groundswell in Platform configuration files).
 
-![Version: 2.0.6](https://img.shields.io/badge/Version-2.0.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.13](https://img.shields.io/badge/AppVersion-0.4.13-informational?style=flat-square)
+![Version: 2.0.7](https://img.shields.io/badge/Version-2.0.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.13](https://img.shields.io/badge/AppVersion-0.4.13-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -37,7 +37,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/pipeline-optimization \
-  --version 2.0.6 \
+  --version 2.0.7 \
   --namespace my-namespace \
   --create-namespace
 ```
@@ -87,13 +87,13 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | platformDatabase.sslCert | string | `""` | Path to a client certificate file for mutual TLS authentication |
 | platformDatabase.sslKey | string | `""` | Path to a client key file for mutual TLS authentication |
 | image.registry | string | `""` | Pipeline Optimization container image registry |
-| image.repository | string | `"private/nf-tower-enterprise/groundswell"` | Pipeline Optimization container image repository |
+| image.repository | string | `"enterprise/platform/groundswell"` | Pipeline Optimization container image repository |
 | image.tag | string | `"{{ .chart.AppVersion }}"` | Pipeline Optimization container image tag |
 | image.digest | string | `""` | Pipeline Optimization container image digest in the format `sha256:1234abcdef` |
 | image.pullPolicy | string | `"IfNotPresent"` | imagePullPolicy for the Pipeline Optimization container Ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images |
 | image.pullSecrets | list | `[]` | List of imagePullSecrets Secrets must be created in the same namespace, for example using the .extraDeploy array Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ |
 | dbMigrationInitContainer.image.registry | string | `""` | Migrate DB init container image registry |
-| dbMigrationInitContainer.image.repository | string | `"private/nf-tower-enterprise/groundswell"` | Migrate DB init container image repository |
+| dbMigrationInitContainer.image.repository | string | `"enterprise/platform/groundswell"` | Migrate DB init container image repository |
 | dbMigrationInitContainer.image.tag | string | `"{{ .chart.AppVersion }}"` | Migrate DB init container image tag |
 | dbMigrationInitContainer.image.digest | string | `""` | Migrate DB init container image digest in the format `sha256:1234abcdef` |
 | dbMigrationInitContainer.image.pullPolicy | string | `"IfNotPresent"` | imagePullPolicy for the Migrate DB init container Ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images |

--- a/charts/platform/charts/pipeline-optimization/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/platform/charts/pipeline-optimization/tests/__snapshot__/deployment_test.yaml.snap
@@ -17,7 +17,7 @@ should produce a Deployment resource with minimal values:
         envFrom:
           - configMapRef:
               name: release-name-pipeline-optimization
-        image: private/nf-tower-enterprise/groundswell:v9.9.9
+        image: enterprise/platform/groundswell:v9.9.9
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10
@@ -150,7 +150,7 @@ should produce a Deployment resource with minimal values:
         envFrom:
           - configMapRef:
               name: release-name-pipeline-optimization
-        image: private/nf-tower-enterprise/groundswell:v9.9.9
+        image: enterprise/platform/groundswell:v9.9.9
         imagePullPolicy: IfNotPresent
         name: migrate-db
     securityContext:
@@ -221,7 +221,7 @@ should render the deployment with the correct checksums, labels and annotations:
               envFrom:
                 - configMapRef:
                     name: release-name-pipeline-optimization
-              image: private/nf-tower-enterprise/groundswell:9.9.9
+              image: enterprise/platform/groundswell:9.9.9
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 failureThreshold: 10
@@ -354,7 +354,7 @@ should render the deployment with the correct checksums, labels and annotations:
               envFrom:
                 - configMapRef:
                     name: release-name-pipeline-optimization
-              image: private/nf-tower-enterprise/groundswell:9.9.9
+              image: enterprise/platform/groundswell:9.9.9
               imagePullPolicy: IfNotPresent
               name: migrate-db
           securityContext:

--- a/charts/platform/charts/pipeline-optimization/tests/deployment_test.yaml
+++ b/charts/platform/charts/pipeline-optimization/tests/deployment_test.yaml
@@ -692,7 +692,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: private/nf-tower-enterprise/groundswell:v9.9.9
+          value: enterprise/platform/groundswell:v9.9.9
 
   - it: should evaluate templates in azure override fields for the pipeline-optimization container
     template: deployment.yaml
@@ -735,7 +735,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.initContainers[2].image
-          value: private/nf-tower-enterprise/groundswell:v9.9.9
+          value: enterprise/platform/groundswell:v9.9.9
 
   - it: should evaluate templates in azure override fields for migrate-db initContainer
     template: deployment.yaml

--- a/charts/platform/charts/pipeline-optimization/values.yaml
+++ b/charts/platform/charts/pipeline-optimization/values.yaml
@@ -117,7 +117,7 @@ image:
   # -- Pipeline Optimization container image registry
   registry: ""
   # -- Pipeline Optimization container image repository
-  repository: private/nf-tower-enterprise/groundswell
+  repository: enterprise/platform/groundswell
   # -- Pipeline Optimization container image tag
   # @default -- `"{{ .chart.AppVersion }}"`
   tag: ""
@@ -140,7 +140,7 @@ dbMigrationInitContainer:
     # -- Migrate DB init container image registry
     registry: ""
     # -- Migrate DB init container image repository
-    repository: private/nf-tower-enterprise/groundswell
+    repository: enterprise/platform/groundswell
     # -- Migrate DB init container image tag
     # @default -- `"{{ .chart.AppVersion }}"`
     tag: ""

--- a/charts/platform/charts/portal-web/CHANGELOG.md
+++ b/charts/platform/charts/portal-web/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this chart will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.3.1] - 2026-05-11
+
+### Added
+
+- Add link to [Seqera AI prerequisites](https://docs.seqera.io/platform-enterprise/seqera-ai/prerequisites) documentation in the README.
+
 ## [0.3.0] - 2026-05-05
 
 - **Enhancement**: allow global configuration of Ingress options. A new `global.ingress` block (`enabled`, `path`, `defaultPathType`, `ingressClassName`, `annotations`, `extraLabels`, `tls`) lets cluster-wide Ingress defaults be set once at the parent and propagate to every subchart, removing the need to repeat controller-wide config per subchart. `enabled` is OR-merged; scalar fields fall back to global when local is unset; `annotations` and `extraLabels` are merged with local winning on key collision; `tls` is concatenated (useful for a single wildcard certificate across all services).

--- a/charts/platform/charts/portal-web/CHANGELOG.md
+++ b/charts/platform/charts/portal-web/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Add link to [Seqera AI prerequisites](https://docs.seqera.io/platform-enterprise/seqera-ai/prerequisites) documentation in the README.
 
+### Changed
+
+- Update image paths in the README and values.yaml - the chart does not hardcode `cr.seqera.io` as the registry, customers are invited to vendor the images to their private registry as well as the charts.
+
 ## [0.3.0] - 2026-05-05
 
 - **Enhancement**: allow global configuration of Ingress options. A new `global.ingress` block (`enabled`, `path`, `defaultPathType`, `ingressClassName`, `annotations`, `extraLabels`, `tls`) lets cluster-wide Ingress defaults be set once at the parent and propagate to every subchart, removing the need to repeat controller-wide config per subchart. `enabled` is OR-merged; scalar fields fall back to global when local is unset; `annotations` and `extraLabels` are merged with local winning on key collision; `tls` is concatenated (useful for a single wildcard certificate across all services).

--- a/charts/platform/charts/portal-web/Chart.yaml
+++ b/charts/platform/charts/portal-web/Chart.yaml
@@ -19,7 +19,7 @@ apiVersion: v2
 name: portal-web
 description: Portal web frontend for Seqera Platform
 type: application
-version: 0.3.0
+version: 0.3.1
 appVersion: "0.1.0"
 maintainers:
   - name: Seqera Labs

--- a/charts/platform/charts/portal-web/README.md
+++ b/charts/platform/charts/portal-web/README.md
@@ -71,7 +71,7 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | global.imageCredentials | list | `[]` | Optional credentials to log in and fetch images from a private registry. These credentials are shared with all the subcharts automatically |
 | global.imageCredentialsSecrets | list | `[]` | Optional list of existing Secrets containing image pull credentials to use for pulling images from private registries. These Secrets are shared with all the subcharts automatically |
 | image.registry | string | `""` | Container image registry |
-| image.repository | string | `"private/nf-tower-enterprise/portal-web"` | Container image repository |
+| image.repository | string | `"ai/portal/web"` | Container image repository |
 | image.tag | string | `"{{ .chart.AppVersion }}"` | Container image tag |
 | image.digest | string | `""` | Container image digest in the format `sha256:1234abcdef` |
 | image.pullPolicy | string | `"IfNotPresent"` | imagePullPolicy for the container Ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images |

--- a/charts/platform/charts/portal-web/README.md
+++ b/charts/platform/charts/portal-web/README.md
@@ -2,13 +2,15 @@
 
 Portal web frontend for Seqera Platform
 
-![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
 > The public API SHOULD NOT be considered stable.
 
 ## Requirements and configuration
+
+For a full list of prerequisites needed to deploy Seqera AI, refer to the [Seqera AI prerequisites](https://docs.seqera.io/platform-enterprise/seqera-ai/prerequisites) documentation.
 
 The chart does not automatically define `cr.seqera.io` as the registry where to take the images from: instructions are available to [vendor the Seqera container images to your private registry](https://docs.seqera.io/platform-enterprise/enterprise/prerequisites/common#vendoring-seqera-container-images-to-your-own-registry).
 
@@ -32,7 +34,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/portal-web \
-  --version 0.3.0 \
+  --version 0.3.1 \
   --namespace my-namespace \
   --create-namespace
 ```

--- a/charts/platform/charts/portal-web/README.md.gotmpl
+++ b/charts/platform/charts/portal-web/README.md.gotmpl
@@ -9,6 +9,8 @@
 
 ## Requirements and configuration
 
+For a full list of prerequisites needed to deploy Seqera AI, refer to the [Seqera AI prerequisites](https://docs.seqera.io/platform-enterprise/seqera-ai/prerequisites) documentation.
+
 The chart does not automatically define `cr.seqera.io` as the registry where to take the images from: instructions are available to [vendor the Seqera container images to your private registry](https://docs.seqera.io/platform-enterprise/enterprise/prerequisites/common#vendoring-seqera-container-images-to-your-own-registry).
 
 The required values to set in order to have a working installation are:

--- a/charts/platform/charts/portal-web/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/platform/charts/portal-web/tests/__snapshot__/deployment_test.yaml.snap
@@ -35,7 +35,7 @@ should render a Deployment with default values:
             - envFrom:
                 - configMapRef:
                     name: release-name-portal-web
-              image: private/nf-tower-enterprise/portal-web:v9.9.9
+              image: ai/portal/web:v9.9.9
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 failureThreshold: 3

--- a/charts/platform/charts/portal-web/values.yaml
+++ b/charts/platform/charts/portal-web/values.yaml
@@ -84,7 +84,7 @@ image:
   # -- Container image registry
   registry: ""
   # -- Container image repository
-  repository: private/nf-tower-enterprise/portal-web
+  repository: ai/portal/web
   # -- Container image tag
   # @default -- `"{{ .chart.AppVersion }}"`
   tag: ""

--- a/charts/platform/charts/studios/CHANGELOG.md
+++ b/charts/platform/charts/studios/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.1] - 2026-05-12
+
+### Changed
+
+- Update image paths in the README and values.yaml - the chart does not hardcode `cr.seqera.io` as the registry, customers are invited to vendor the images to their private registry as well as the charts.
+
 ## [1.3.0] - 2026-05-05
 
 - **Enhancement**: allow global configuration of Ingress options. A new `global.ingress` block (`enabled`, `path`, `defaultPathType`, `ingressClassName`, `annotations`, `extraLabels`, `tls`) lets cluster-wide Ingress defaults be set once at the parent and propagate to every subchart, removing the need to repeat controller-wide config per subchart. `enabled` is OR-merged; scalar fields fall back to global when local is unset; `annotations` and `extraLabels` are merged with local winning on key collision; `tls` is concatenated (useful for a single wildcard certificate across all services).

--- a/charts/platform/charts/studios/Chart.yaml
+++ b/charts/platform/charts/studios/Chart.yaml
@@ -21,7 +21,7 @@ name: studios
 description: Studios is a unified platform for interactive analysis
 sources:
   - https://github.com/seqeralabs/helm-charts/tree/main/seqera/charts/studios
-version: 1.3.0
+version: 1.3.1
 appVersion: "0.11.0"
 maintainers:
   - name: Seqera Labs

--- a/charts/platform/charts/studios/README.md
+++ b/charts/platform/charts/studios/README.md
@@ -2,7 +2,7 @@
 
 Studios is a unified platform for interactive analysis
 
-![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![AppVersion: 0.11.0](https://img.shields.io/badge/AppVersion-0.11.0-informational?style=flat-square)
+![Version: 1.3.1](https://img.shields.io/badge/Version-1.3.1-informational?style=flat-square) ![AppVersion: 0.11.0](https://img.shields.io/badge/AppVersion-0.11.0-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -41,7 +41,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/studios \
-  --version 1.3.0 \
+  --version 1.3.1 \
   --namespace my-namespace \
   --create-namespace
 ```
@@ -92,7 +92,7 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | redis.enableTls | bool | `false` | Enable TLS when connecting to Redis |
 | redis.prefix | string | `"connect:session"` | Key prefix to use when storing Studios sessions in Redis |
 | proxy.image.registry | string | `""` | Proxy container image registry |
-| proxy.image.repository | string | `"private/nf-tower-enterprise/data-studio/connect-proxy"` | Proxy container image repository |
+| proxy.image.repository | string | `"enterprise/platform/data-studio/connect-proxy"` | Proxy container image repository |
 | proxy.image.tag | string | `"{{ .chart.AppVersion }}"` | Proxy container image tag |
 | proxy.image.digest | string | `""` | Proxy container image digest in the format `sha256:1234abcdef` |
 | proxy.image.pullPolicy | string | `"IfNotPresent"` | imagePullPolicy for the Proxy container Ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images |
@@ -132,7 +132,7 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | proxy.containerSecurityContext.capabilities | object | `{"add":["NET_BIND_SERVICE"],"drop":["ALL"]}` | Fine-grained Linux kernel privileges to add or drop for the container |
 | proxy.resources | object | `{}` | Container requests and limits for different resources like CPU or memory |
 | server.image.registry | string | `""` | Server container image registry |
-| server.image.repository | string | `"private/nf-tower-enterprise/data-studio/connect-server"` | Server container image repository |
+| server.image.repository | string | `"enterprise/platform/data-studio/connect-server"` | Server container image repository |
 | server.image.tag | string | `"{{ .chart.AppVersion }}"` | Server container image tag |
 | server.image.digest | string | `""` | Server container image digest in the format `sha256:1234abcdef` |
 | server.image.pullPolicy | string | `"IfNotPresent"` | imagePullPolicy for the Server container Ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images |

--- a/charts/platform/charts/studios/tests/__snapshot__/deployment-proxy_test.yaml.snap
+++ b/charts/platform/charts/studios/tests/__snapshot__/deployment-proxy_test.yaml.snap
@@ -41,7 +41,7 @@ should run using config requested by the user:
                   name: CMContainingExtraEnvVars
               - secretRef:
                   name: SecretContainingExtraEnvVars
-            image: private/nf-tower-enterprise/data-studio/connect-proxy:9.9.9
+            image: enterprise/platform/data-studio/connect-proxy:9.9.9
             imagePullPolicy: Always
             name: proxy
             ports:
@@ -153,7 +153,7 @@ should set the proxy deployment image using the chart version and use sane defau
                     name: release-name-studios-common
                 - configMapRef:
                     name: release-name-studios-proxy
-              image: private/nf-tower-enterprise/data-studio/connect-proxy:9.9.9
+              image: enterprise/platform/data-studio/connect-proxy:9.9.9
               imagePullPolicy: IfNotPresent
               name: proxy
               ports:

--- a/charts/platform/charts/studios/tests/__snapshot__/statefulset-server_test.yaml.snap
+++ b/charts/platform/charts/studios/tests/__snapshot__/statefulset-server_test.yaml.snap
@@ -37,7 +37,7 @@ should run using config requested by the user:
                   name: CMContainingExtraEnvVars
               - secretRef:
                   name: SecretContainingExtraEnvVars
-            image: private/nf-tower-enterprise/data-studio/connect-server:9.9.9
+            image: enterprise/platform/data-studio/connect-server:9.9.9
             imagePullPolicy: Always
             name: server
             securityContext:
@@ -104,7 +104,7 @@ should set the statefulset server image using the chart version and use sane def
                     name: release-name-studios-common
                 - configMapRef:
                     name: release-name-studios-server
-              image: private/nf-tower-enterprise/data-studio/connect-server:9.9.9
+              image: enterprise/platform/data-studio/connect-server:9.9.9
               imagePullPolicy: IfNotPresent
               name: server
               securityContext:

--- a/charts/platform/charts/studios/tests/deployment-proxy_test.yaml
+++ b/charts/platform/charts/studios/tests/deployment-proxy_test.yaml
@@ -53,7 +53,7 @@ tests:
   asserts:
   - equal:
       path: spec.template.spec.containers[0].image
-      value: private/nf-tower-enterprise/data-studio/connect-proxy:1.2.3
+      value: enterprise/platform/data-studio/connect-proxy:1.2.3
 - it: should render the proxy deployment with the specified digest
   template: deployment-proxy.yaml
   set:
@@ -63,7 +63,7 @@ tests:
   asserts:
   - equal:
       path: spec.template.spec.containers[0].image
-      value: private/nf-tower-enterprise/data-studio/connect-proxy@sha256:1234abcdef
+      value: enterprise/platform/data-studio/connect-proxy@sha256:1234abcdef
 - it: should render the proxy deployment with the correct checksums
   template: deployment-proxy.yaml
   chart:
@@ -451,7 +451,7 @@ tests:
   asserts:
   - equal:
       path: spec.template.spec.containers[0].image
-      value: my-registry.example.com/private/nf-tower-enterprise/data-studio/connect-proxy@sha256:1234abcdef
+      value: my-registry.example.com/enterprise/platform/data-studio/connect-proxy@sha256:1234abcdef
 - it: should render default caddy-temp-data-volume
   template: deployment-proxy.yaml
   asserts:
@@ -681,7 +681,7 @@ tests:
   asserts:
   - equal:
       path: spec.template.spec.containers[0].image
-      value: private/nf-tower-enterprise/data-studio/connect-proxy:9.9.9
+      value: enterprise/platform/data-studio/connect-proxy:9.9.9
 
 - it: should evaluate templates in azure override fields for the proxy container
   template: deployment-proxy.yaml

--- a/charts/platform/charts/studios/tests/statefulset-server_test.yaml
+++ b/charts/platform/charts/studios/tests/statefulset-server_test.yaml
@@ -50,7 +50,7 @@ tests:
   asserts:
   - equal:
       path: spec.template.spec.containers[0].image
-      value: private/nf-tower-enterprise/data-studio/connect-server:1.2.3
+      value: enterprise/platform/data-studio/connect-server:1.2.3
 - it: should render the server deployment with the specified digest
   template: statefulset-server.yaml
   set:
@@ -60,7 +60,7 @@ tests:
   asserts:
   - equal:
       path: spec.template.spec.containers[0].image
-      value: private/nf-tower-enterprise/data-studio/connect-server@sha256:1234abcdef
+      value: enterprise/platform/data-studio/connect-server@sha256:1234abcdef
 - it: should render the server deployment with the correct checksums
   template: statefulset-server.yaml
   chart:
@@ -510,7 +510,7 @@ tests:
   asserts:
   - equal:
       path: spec.template.spec.containers[0].image
-      value: my-registry.example.com/private/nf-tower-enterprise/data-studio/connect-server@sha256:abcd1234
+      value: my-registry.example.com/enterprise/platform/data-studio/connect-server@sha256:abcd1234
 - it: should render container with correct imagePullPolicy
   template: statefulset-server.yaml
   set:
@@ -602,7 +602,7 @@ tests:
   asserts:
   - equal:
       path: spec.template.spec.containers[0].image
-      value: private/nf-tower-enterprise/data-studio/connect-server:9.9.9
+      value: enterprise/platform/data-studio/connect-server:9.9.9
 
 - it: should evaluate templates in azure override fields for the server container
   template: statefulset-server.yaml

--- a/charts/platform/charts/studios/values.yaml
+++ b/charts/platform/charts/studios/values.yaml
@@ -110,7 +110,7 @@ proxy:
     # -- Proxy container image registry
     registry: ""
     # -- Proxy container image repository
-    repository: private/nf-tower-enterprise/data-studio/connect-proxy
+    repository: enterprise/platform/data-studio/connect-proxy
     # -- Proxy container image tag
     # @default -- `"{{ .chart.AppVersion }}"`
     tag: ""
@@ -281,7 +281,7 @@ server:
     # -- Server container image registry
     registry: ""
     # -- Server container image repository
-    repository: private/nf-tower-enterprise/data-studio/connect-server
+    repository: enterprise/platform/data-studio/connect-server
     # -- Server container image tag
     # @default -- `"{{ .chart.AppVersion }}"`
     tag: ""

--- a/charts/platform/charts/wave/CHANGELOG.md
+++ b/charts/platform/charts/wave/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2026-05-12
+
+### Changed
+
+- Update image paths in the README and values.yaml - the chart does not hardcode `cr.seqera.io` as the registry, customers are invited to vendor the images to their private registry as well as the charts.
+
 ## [0.2.0] - 2026-05-05
 
 - **Enhancement**: allow global configuration of Ingress options. A new `global.ingress` block (`enabled`, `path`, `defaultPathType`, `ingressClassName`, `annotations`, `extraLabels`, `tls`) lets cluster-wide Ingress defaults be set once at the parent and propagate to every subchart, removing the need to repeat controller-wide config per subchart. `enabled` is OR-merged; scalar fields fall back to global when local is unset; `annotations` and `extraLabels` are merged with local winning on key collision; `tls` is concatenated (useful for a single wildcard certificate across all services).

--- a/charts/platform/charts/wave/Chart.yaml
+++ b/charts/platform/charts/wave/Chart.yaml
@@ -19,7 +19,7 @@ apiVersion: v2
 name: wave
 description: Wave
 type: application
-version: 0.2.0
+version: 0.2.1
 appVersion: "v1.32.4"
 maintainers:
   - name: Seqera Labs

--- a/charts/platform/charts/wave/README.md
+++ b/charts/platform/charts/wave/README.md
@@ -2,7 +2,7 @@
 
 Wave
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.32.4](https://img.shields.io/badge/AppVersion-v1.32.4-informational?style=flat-square)
+![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.32.4](https://img.shields.io/badge/AppVersion-v1.32.4-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -35,7 +35,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/wave \
-  --version 0.2.0 \
+  --version 0.2.1 \
   --namespace my-namespace \
   --create-namespace
 ```
@@ -85,7 +85,7 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | redis.existingSecretName | string | `""` | Name of an existing Secret containing the Redis password, as an alternative to the password field. Note: the Secret must already exist in the same namespace at the time of deployment |
 | redis.existingSecretKey | string | `"REDIS_PASSWORD"` | Key in the existing Secret containing the Redis password |
 | image.registry | string | `""` | Container image registry |
-| image.repository | string | `"private/nf-tower-enterprise/wave"` | Container image repository |
+| image.repository | string | `"enterprise/platform/wave"` | Container image repository |
 | image.tag | string | `"{{ .chart.AppVersion }}"` | Container image tag |
 | image.digest | string | `""` | Container image digest in the format `sha256:1234abcdef` |
 | image.pullPolicy | string | `"IfNotPresent"` | imagePullPolicy for the container Ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images |

--- a/charts/platform/charts/wave/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/platform/charts/wave/tests/__snapshot__/deployment_test.yaml.snap
@@ -41,7 +41,7 @@ should render a Deployment with default values:
               envFrom:
                 - configMapRef:
                     name: release-name-wave
-              image: private/nf-tower-enterprise/wave:v1.32.4
+              image: enterprise/platform/wave:v1.32.4
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 failureThreshold: 10
@@ -78,7 +78,7 @@ should render a Deployment with default values:
                 - sh
                 - -c
                 - '> /tmp/config.yml'
-              image: private/nf-tower-enterprise/wave:v1.32.4
+              image: enterprise/platform/wave:v1.32.4
               imagePullPolicy: IfNotPresent
               name: touch-config-file
               volumeMounts:

--- a/charts/platform/charts/wave/values.yaml
+++ b/charts/platform/charts/wave/values.yaml
@@ -117,7 +117,7 @@ image:
   # -- Container image registry
   registry: ""
   # -- Container image repository
-  repository: private/nf-tower-enterprise/wave
+  repository: enterprise/platform/wave
   # -- Container image tag
   # @default -- `"{{ .chart.AppVersion }}"`
   tag: ""

--- a/charts/platform/examples/README.md
+++ b/charts/platform/examples/README.md
@@ -19,7 +19,7 @@ The following examples demonstrate possible configurations for enabling and cust
 |---------|-------------|
 | [pipeline-optimization/](pipeline-optimization/) | Enabling and configuring the Pipeline Optimization service subchart with database setup and registry access |
 | [studios/](studios/) | Studios subchart configuration for interactive data analysis environments with ingress setup |
-| [seqera-ai](seqera-ai/) | Enabling the Seqera AI agent backend, Model Context Protocol server, and Portal web interface |
+| [seqera-co-scientist](seqera-co-scientist/) | Enabling the Seqera Co-Scientist agent backend, Model Context Protocol server, and Portal web interface |
 
 ## Additional Resources
 

--- a/charts/platform/examples/pipeline-optimization/values.yaml
+++ b/charts/platform/examples/pipeline-optimization/values.yaml
@@ -30,7 +30,7 @@ pipeline-optimization:
     # Container registry where Pipeline Optimization images are stored
     # Options: cr.seqera.io or your private registry
     registry: "cr.seqera.io"
-    repository: "private/nf-tower-enterprise/groundswell"
+    repository: "enterprise/platform/groundswell"
     tag: "" # An empty tag string uses Chart.yaml appVersion
 
   # Database migration init container configuration
@@ -38,7 +38,7 @@ pipeline-optimization:
   dbMigrationInitContainer:
     image:
       registry: "cr.seqera.io"
-      repository: "private/nf-tower-enterprise/groundswell"
+      repository: "enterprise/platform/groundswell"
       tag: "" # An empty tag string uses Chart.yaml appVersion
 
   database:

--- a/charts/platform/examples/seqera-ai
+++ b/charts/platform/examples/seqera-ai
@@ -1,0 +1,1 @@
+seqera-co-scientist

--- a/charts/platform/examples/seqera-co-scientist/README.md
+++ b/charts/platform/examples/seqera-co-scientist/README.md
@@ -1,6 +1,6 @@
-# Seqera AI installation example
+# Seqera Co-Scientist installation example
 
-This example demonstrates how to enable the Seqera AI [Agent backend](../../charts/agent-backend/),
+This example demonstrates how to enable the Seqera Co-Scientist [Agent backend](../../charts/agent-backend/),
 [Model Context Protocol server](../../charts/mcp/), and [Portal web
 interface](../../charts/portal-web/) using the Platform parent Helm chart and enabling
 the respective subcharts. The charts can also be installed without installing the Platform chart,
@@ -20,8 +20,8 @@ key = Fernet.generate_key()
 print(key.decode())
 ```
 
-The example doesn't provide values for the Platform chart, but it can be used as a reference for how to set the values for the Seqera AI components.
+The example doesn't provide values for the Platform chart, but it can be used as a reference for how to set the values for the Seqera Co-Scientist components.
 
-Private registry credentials are required to pull the Seqera AI images. Refer to the
+Private registry credentials are required to pull the Seqera Co-Scientist images. Refer to the
 [VENDORING.md](../../../../VENDORING.md) file for instructions on how to vendor images and charts to
 an internal registry.

--- a/charts/platform/examples/seqera-co-scientist/README.md
+++ b/charts/platform/examples/seqera-co-scientist/README.md
@@ -20,6 +20,19 @@ key = Fernet.generate_key()
 print(key.decode())
 ```
 
+The agent backend requires declaring which provider serves each capability via `inference.provider`,
+`embeddings.provider`, and `sandbox.provider`.
+`inference.provider` is required: supported values: `bedrock` and `anthropic` (inference only).
+Embeddings and sandbox providers are optional (leave empty to disable).
+When using Anthropic for inference, set `anthropic.existingSecretName` (or `anthropic.apiKey`).
+When using Bedrock for any capability, configure the `bedrock` block accordingly: in particular, an
+AWS Bedrock AgentCore runtime ARN must be provided in `bedrock.sandbox.runtimeArn` when sandboxing
+is enabled with `sandbox.provider: bedrock`.
+
+When using AWS Bedrock services, the application can optionally be provided with IAM roles to assume
+before invoking the bedrock APIs. This is useful to allow the application to access Bedrock
+resources in a different account.
+
 The example doesn't provide values for the Platform chart, but it can be used as a reference for how to set the values for the Seqera Co-Scientist components.
 
 Private registry credentials are required to pull the Seqera Co-Scientist images. Refer to the

--- a/charts/platform/examples/seqera-co-scientist/values.yaml
+++ b/charts/platform/examples/seqera-co-scientist/values.yaml
@@ -1,6 +1,6 @@
 global:
   platformExternalDomain: platform.example.com
-  # The domains where Seqera AI applications will be exposed are automatically derived from the
+  # The domains where Seqera Co-Scientist applications will be exposed are automatically derived from the
   # `platformExternalDomain` value, but they can be overridden by setting the following values:
   # mcpDomain: mcp.platform.example.com
   # portalDomain: ai.platform.example.com

--- a/charts/platform/examples/seqera-co-scientist/values.yaml
+++ b/charts/platform/examples/seqera-co-scientist/values.yaml
@@ -11,6 +11,32 @@ global:
 agent-backend:
   enabled: true
 
+  # -- Which provider serves each capability. inference.provider is required.
+  # embeddings and sandbox are optional; leave empty to disable the feature.
+  inference:
+    provider: anthropic   # "bedrock" or "anthropic"
+
+  embeddings:
+    provider: bedrock     # "bedrock", or leave empty to disable
+
+  sandbox:
+    provider: bedrock     # "bedrock", or leave empty to disable
+
+  # Bedrock configuration (required when any provider above is "bedrock")
+  bedrock:
+    # Default credentials applied to all Bedrock-backed services unless overridden per-service.
+    default:
+      assumeRoleArn: arn:aws:iam::123456789012:role/bedrock-cross-account-role
+      region: us-east-1
+
+    sandbox:
+      # AgentCore runtime ARN: required when sandbox.provider is "bedrock".
+      runtimeArn: arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/my-runtime
+
+  # Anthropic configuration (required when inference.provider is "anthropic")
+  anthropic:
+    existingSecretName: my-already-created-secret
+
   database:
     host: my-db.example.com
     name: agent_backend_db_name
@@ -20,8 +46,6 @@ agent-backend:
   redis:
     host: my-redis.example.com
     existingSecretName: my-already-created-secret
-
-  anthropicApiKeyExistingSecretName: my-already-created-secret
 
   # The following token can be automatically created by the helm chart if not provided, but it
   # should be set explicitly when using the chart with Kustomize, otherwise it will be regenerated

--- a/charts/platform/tests/__snapshot__/deployment-backend_test.yaml.snap
+++ b/charts/platform/tests/__snapshot__/deployment-backend_test.yaml.snap
@@ -36,7 +36,7 @@ should produce a Deployment resource with minimal values:
               name: release-name-platform-backend
           - configMapRef:
               name: release-name-platform-shared-backend-cron
-        image: private/nf-tower-enterprise/backend:v9.9.9
+        image: enterprise/platform/backend:v9.9.9
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10
@@ -277,7 +277,7 @@ should render the backend deployment with the correct checksums, labels and anno
                     name: release-name-platform-backend
                 - configMapRef:
                     name: release-name-platform-shared-backend-cron
-              image: private/nf-tower-enterprise/backend:9.9.9
+              image: enterprise/platform/backend:9.9.9
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 failureThreshold: 10

--- a/charts/platform/tests/__snapshot__/deployment-cron_test.yaml.snap
+++ b/charts/platform/tests/__snapshot__/deployment-cron_test.yaml.snap
@@ -31,7 +31,7 @@ should produce a Deployment resource with minimal values:
               name: release-name-platform-cron
           - configMapRef:
               name: release-name-platform-shared-backend-cron
-        image: private/nf-tower-enterprise/backend:v9.9.9
+        image: enterprise/platform/backend:v9.9.9
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10
@@ -163,7 +163,7 @@ should produce a Deployment resource with minimal values:
               name: release-name-platform-shared-backend-cron
           - secretRef:
               name: release-name-platform-backend
-        image: private/nf-tower-enterprise/migrate-db:v9.9.9
+        image: enterprise/platform/migrate-db:v9.9.9
         imagePullPolicy: IfNotPresent
         name: migrate-db
         securityContext:
@@ -268,7 +268,7 @@ should render the cron deployment with the correct checksums, labels and annotat
                     name: release-name-platform-cron
                 - configMapRef:
                     name: release-name-platform-shared-backend-cron
-              image: private/nf-tower-enterprise/backend:9.9.9
+              image: enterprise/platform/backend:9.9.9
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 failureThreshold: 10
@@ -400,7 +400,7 @@ should render the cron deployment with the correct checksums, labels and annotat
                     name: release-name-platform-shared-backend-cron
                 - secretRef:
                     name: release-name-platform-backend
-              image: private/nf-tower-enterprise/migrate-db:9.9.9
+              image: enterprise/platform/migrate-db:9.9.9
               imagePullPolicy: IfNotPresent
               name: migrate-db
               securityContext:

--- a/charts/platform/tests/__snapshot__/deployment-frontend_test.yaml.snap
+++ b/charts/platform/tests/__snapshot__/deployment-frontend_test.yaml.snap
@@ -38,7 +38,7 @@ should produce a Deployment resource with minimal values:
                 - name: NGINX_LISTEN_PORT
                   value: "8083"
               envFrom: null
-              image: private/nf-tower-enterprise/frontend:v9.9.9-unprivileged
+              image: enterprise/platform/frontend:v9.9.9-unprivileged
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 failureThreshold: 10
@@ -133,7 +133,7 @@ should render the frontend deployment with the correct labels and annotations:
                 - name: NGINX_LISTEN_PORT
                   value: "8083"
               envFrom: null
-              image: private/nf-tower-enterprise/frontend:9.9.9-unprivileged
+              image: enterprise/platform/frontend:9.9.9-unprivileged
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 failureThreshold: 10

--- a/charts/platform/tests/deployment-backend_test.yaml
+++ b/charts/platform/tests/deployment-backend_test.yaml
@@ -46,7 +46,7 @@ tests:
   asserts:
   - equal:
       path: spec.template.spec.containers[0].image
-      value: private/nf-tower-enterprise/backend:9.0.0
+      value: enterprise/platform/backend:9.0.0
 
 - it: should render the backend deployment with the specified digest, overriding the tag
   template: deployment-backend.yaml
@@ -58,7 +58,7 @@ tests:
   asserts:
   - equal:
       path: spec.template.spec.containers[0].image
-      value: private/nf-tower-enterprise/backend@sha256:1234abcdef
+      value: enterprise/platform/backend@sha256:1234abcdef
 
 - it: should render the backend deployment with the correct checksums, labels and annotations
   template: deployment-backend.yaml
@@ -1039,7 +1039,7 @@ tests:
   asserts:
   - equal:
       path: spec.template.spec.containers[0].image
-      value: private/nf-tower-enterprise/backend:v9.9.9
+      value: enterprise/platform/backend:v9.9.9
 
 - it: should prefer azure override over custom backend.image when both are set
   template: deployment-backend.yaml

--- a/charts/platform/tests/deployment-cron_test.yaml
+++ b/charts/platform/tests/deployment-cron_test.yaml
@@ -45,7 +45,7 @@ tests:
   asserts:
   - equal:
       path: spec.template.spec.containers[0].image
-      value: private/nf-tower-enterprise/backend:9.0.0
+      value: enterprise/platform/backend:9.0.0
 - it: should render the cron deployment with the specified digest, overriding the tag
   template: deployment-cron.yaml
   set:
@@ -56,7 +56,7 @@ tests:
   asserts:
   - equal:
       path: spec.template.spec.containers[0].image
-      value: private/nf-tower-enterprise/backend@sha256:1234abcdef
+      value: enterprise/platform/backend@sha256:1234abcdef
 - it: should render the cron deployment with the correct checksums, labels and annotations
   template: deployment-cron.yaml
   chart:
@@ -292,7 +292,7 @@ tests:
       value: migrate-db
   - equal:
       path: spec.template.spec.initContainers[2].image
-      value: private/nf-tower-enterprise/migrate-db:v9.9.9
+      value: enterprise/platform/migrate-db:v9.9.9
   - equal:
       path: spec.template.spec.initContainers[0].env
       value:
@@ -959,7 +959,7 @@ tests:
   asserts:
   - equal:
       path: spec.template.spec.containers[0].image
-      value: private/nf-tower-enterprise/backend:v9.9.9
+      value: enterprise/platform/backend:v9.9.9
 
 - it: should prefer azure override over custom cron.image when both are set
   template: deployment-cron.yaml
@@ -1022,7 +1022,7 @@ tests:
   asserts:
   - equal:
       path: spec.template.spec.initContainers[2].image
-      value: private/nf-tower-enterprise/migrate-db:v9.9.9
+      value: enterprise/platform/migrate-db:v9.9.9
 
 - it: should use azure override with digest for the migrate-db initContainer
   template: deployment-cron.yaml

--- a/charts/platform/tests/deployment-frontend_test.yaml
+++ b/charts/platform/tests/deployment-frontend_test.yaml
@@ -35,7 +35,7 @@ tests:
   asserts:
   - equal:
       path: spec.template.spec.containers[0].image
-      value: private/nf-tower-enterprise/frontend:9.0.0
+      value: enterprise/platform/frontend:9.0.0
 - it: should render the frontend deployment with a tag version ending with -unprivileged depending on the chart appVersion
   chart:
     version: 1.2.3
@@ -43,7 +43,7 @@ tests:
   asserts:
   - equal:
       path: spec.template.spec.containers[0].image
-      value: private/nf-tower-enterprise/frontend:9.8.7-unprivileged
+      value: enterprise/platform/frontend:9.8.7-unprivileged
 - it: should render the frontend deployment with the specified digest, overriding the tag
   set:
     frontend:
@@ -53,7 +53,7 @@ tests:
   asserts:
   - equal:
       path: spec.template.spec.containers[0].image
-      value: private/nf-tower-enterprise/frontend@sha256:1234abcdef
+      value: enterprise/platform/frontend@sha256:1234abcdef
 - it: should render the frontend deployment with the correct labels and annotations
   chart:
     version: 9.9.9+test
@@ -414,7 +414,7 @@ tests:
   asserts:
   - equal:
       path: spec.template.spec.containers[0].image
-      value: private/nf-tower-enterprise/frontend:v9.9.9-unprivileged
+      value: enterprise/platform/frontend:v9.9.9-unprivileged
 
 - it: should prefer azure override over custom frontend.image when both are set
   set:

--- a/charts/platform/values.yaml
+++ b/charts/platform/values.yaml
@@ -497,7 +497,7 @@ backend:
     # -- Backend container image registry
     registry: ""
     # -- Backend container image repository
-    repository: private/nf-tower-enterprise/backend
+    repository: enterprise/platform/backend
     # -- Backend container image tag
     # @default -- `"{{ .chart.AppVersion }}"`
     tag: ""
@@ -710,7 +710,7 @@ frontend:
     # -- Frontend container image registry
     registry: ""
     # -- Frontend container image repository
-    repository: private/nf-tower-enterprise/frontend
+    repository: enterprise/platform/frontend
     # -- Specify a tag to override the version defined in .Chart.appVersion
     # @default -- `"{{ .chart.AppVersion }}-unprivileged"`
     tag: ""
@@ -914,7 +914,7 @@ cron:
     # -- Cron container image registry
     registry: ""
     # -- Cron container image repository
-    repository: private/nf-tower-enterprise/backend
+    repository: enterprise/platform/backend
     # -- Cron container image tag
     # @default -- `"{{ .chart.AppVersion }}"`
     tag: ""
@@ -1114,7 +1114,7 @@ cron:
       # -- Database migration container image registry
       registry: ""
       # -- Database migration container image repository
-      repository: private/nf-tower-enterprise/migrate-db
+      repository: enterprise/platform/migrate-db
       # -- Specify a tag to override the version defined in .Chart.appVersion
       # @default -- `"{{ .chart.AppVersion }}"`
       tag: ""

--- a/marketplace/azure/platform/Makefile
+++ b/marketplace/azure/platform/Makefile
@@ -4,7 +4,7 @@ SRC_REGISTRY ?= cr.seqera.io
 
 # Optional image overrides as registry/repository:tag.
 # When set, these take precedence over the appVersion from Chart.yaml.
-# Example: IMAGE_BACKEND=cr.seqera.io/private/nf-tower-enterprise/backend:24.1.0
+# Example: IMAGE_BACKEND=cr.seqera.io/enterprise/platform/backend:v25.3.6
 IMAGE_BACKEND ?=
 IMAGE_FRONTEND ?=
 IMAGE_CRON_MIGRATEDB ?=
@@ -42,7 +42,7 @@ copy-images:
 	 if [ -n "$(IMAGE_BACKEND)" ]; then \
 	   SRC_BACKEND="$(IMAGE_BACKEND)"; \
 	 else \
-	   SRC_BACKEND="$(SRC_REGISTRY)/private/nf-tower-enterprise/backend:$${PLATFORM_TAG}"; \
+	   SRC_BACKEND="$(SRC_REGISTRY)/enterprise/platform/backend:$${PLATFORM_TAG}"; \
 	 fi && \
 	 DST_BACKEND_TAG=$$(echo "$${SRC_BACKEND}" | rev | cut -d: -f1 | rev) && \
 	 echo -n "[1/6] $${SRC_BACKEND} → $(REGISTRY)/$(IMAGE_PREFIX)/platform/backend:$${DST_BACKEND_TAG} ... " && \
@@ -55,7 +55,7 @@ copy-images:
 	   SRC_FRONTEND="$(IMAGE_FRONTEND)"; \
 	   DST_FRONTEND_TAG=$$(echo "$${SRC_FRONTEND}" | rev | cut -d: -f1 | rev); \
 	 else \
-	   SRC_FRONTEND="$(SRC_REGISTRY)/private/nf-tower-enterprise/frontend:$${PLATFORM_TAG}-unprivileged"; \
+	   SRC_FRONTEND="$(SRC_REGISTRY)/enterprise/platform/frontend:$${PLATFORM_TAG}-unprivileged"; \
 	   DST_FRONTEND_TAG="$${PLATFORM_TAG}"; \
 	 fi && \
 	 echo -n "[2/6] $${SRC_FRONTEND} → $(REGISTRY)/$(IMAGE_PREFIX)/platform/frontend:$${DST_FRONTEND_TAG} ... " && \
@@ -67,7 +67,7 @@ copy-images:
 	 if [ -n "$(IMAGE_CRON_MIGRATEDB)" ]; then \
 	   SRC_MIGRATEDB="$(IMAGE_CRON_MIGRATEDB)"; \
 	 else \
-	   SRC_MIGRATEDB="$(SRC_REGISTRY)/private/nf-tower-enterprise/migrate-db:$${PLATFORM_TAG}"; \
+	   SRC_MIGRATEDB="$(SRC_REGISTRY)/enterprise/platform/migrate-db:$${PLATFORM_TAG}"; \
 	 fi && \
 	 DST_MIGRATEDB_TAG=$$(echo "$${SRC_MIGRATEDB}" | rev | cut -d: -f1 | rev) && \
 	 echo -n "[3/6] $${SRC_MIGRATEDB} → $(REGISTRY)/$(IMAGE_PREFIX)/platform/migrate-db:$${DST_MIGRATEDB_TAG} ... " && \
@@ -79,7 +79,7 @@ copy-images:
 	 if [ -n "$(IMAGE_STUDIOS_PROXY)" ]; then \
 	   SRC_STUDIOS_PROXY="$(IMAGE_STUDIOS_PROXY)"; \
 	 else \
-	   SRC_STUDIOS_PROXY="$(SRC_REGISTRY)/private/nf-tower-enterprise/data-studio/connect-proxy:$${STUDIOS_TAG}"; \
+	   SRC_STUDIOS_PROXY="$(SRC_REGISTRY)/enterprise/platform/data-studio/connect-proxy:$${STUDIOS_TAG}"; \
 	 fi && \
 	 DST_STUDIOS_PROXY_TAG=$$(echo "$${SRC_STUDIOS_PROXY}" | rev | cut -d: -f1 | rev) && \
 	 echo -n "[4/6] $${SRC_STUDIOS_PROXY} → $(REGISTRY)/$(IMAGE_PREFIX)/studios/connect-proxy:$${DST_STUDIOS_PROXY_TAG} ... " && \
@@ -91,7 +91,7 @@ copy-images:
 	 if [ -n "$(IMAGE_STUDIOS_SERVER)" ]; then \
 	   SRC_STUDIOS_SERVER="$(IMAGE_STUDIOS_SERVER)"; \
 	 else \
-	   SRC_STUDIOS_SERVER="$(SRC_REGISTRY)/private/nf-tower-enterprise/data-studio/connect-server:$${STUDIOS_TAG}"; \
+	   SRC_STUDIOS_SERVER="$(SRC_REGISTRY)/enterprise/platform/data-studio/connect-server:$${STUDIOS_TAG}"; \
 	 fi && \
 	 DST_STUDIOS_SERVER_TAG=$$(echo "$${SRC_STUDIOS_SERVER}" | rev | cut -d: -f1 | rev) && \
 	 echo -n "[5/6] $${SRC_STUDIOS_SERVER} → $(REGISTRY)/$(IMAGE_PREFIX)/studios/connect-server:$${DST_STUDIOS_SERVER_TAG} ... " && \
@@ -103,7 +103,7 @@ copy-images:
 	 if [ -n "$(IMAGE_PIPELINE_OPTIMIZATION)" ]; then \
 	   SRC_PIPEOPT="$(IMAGE_PIPELINE_OPTIMIZATION)"; \
 	 else \
-	   SRC_PIPEOPT="$(SRC_REGISTRY)/private/nf-tower-enterprise/groundswell:$${PIPEOPT_TAG}"; \
+	   SRC_PIPEOPT="$(SRC_REGISTRY)/enterprise/platform/groundswell:$${PIPEOPT_TAG}"; \
 	 fi && \
 	 DST_PIPEOPT_TAG=$$(echo "$${SRC_PIPEOPT}" | rev | cut -d: -f1 | rev) && \
 	 echo -n "[6/6] $${SRC_PIPEOPT} → $(REGISTRY)/$(IMAGE_PREFIX)/pipeline-optimization/groundswell:$${DST_PIPEOPT_TAG} ... " && \


### PR DESCRIPTION
@endre-seqera I reorganized the providers section inside the agent-backend chart, let me know how it looks.

I made the inference service the only mandatory one (which controls `USE_BEDROCK_INFERENCE`: if `bedrock` is selected, that variable is set to `true`, if anthropic is selected, that variable is set to false).
How would we switch between future inference providers though?