### PR TITLE
docs: Rename Seqera AI to Seqera Co-Scientist

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ Currently, it includes charts for:
   Nextflow pipelines running on Platform - internally referred to as Groundswell.
 - [Seqera MCP](./charts/platform/charts/mcp/README.md): Model Context Protocol (MCP) server to allow LLMs to
   interact with Seqera products.
-- [Seqera AI Backend](./charts/platform/charts/agent-backend/README.md): Backend service for Seqera CLI AI
+- [Agent Backend](./charts/platform/charts/agent-backend/README.md): Backend service for Seqera Co-Scientist CLI
   capabilities.
-- [Seqera Portal web interface](./charts/platform/charts/portal-web/README.md): Web service for Seqera AI
+- [Portal](./charts/platform/charts/portal-web/README.md): Web service for Seqera Co-Scientist
 - [Seqera Common](./charts/common/README.md): Library chart with shared resources and configurations
 
 The Platform chart is the main chart, and other charts can be deployed as sub-charts of Platform.

--- a/charts/platform/CHANGELOG.md
+++ b/charts/platform/CHANGELOG.md
@@ -189,8 +189,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **BREAKING** Bump MCP subchart to 0.2.0: removed support for custom OAuth provider. MCP now exclusively uses Seqera Platform as the OAuth provider. Removed values: `oauth.clientId`, `oauth.clientSecretString`, `oauth.clientSecretExistingSecretName`, `oauth.clientSecretExistingSecretKey`
-- Add Seqera AI installation example
-- Refine Seqera AI and MCP wording in documentation
+- Add Seqera Co-Scientist installation example
+- Refine Seqera Co-Scientist and MCP wording in documentation
 
 ## [0.28.3] - 2026-03-26
 

--- a/charts/platform/examples/README.md
+++ b/charts/platform/examples/README.md
@@ -19,7 +19,7 @@ The following examples demonstrate possible configurations for enabling and cust
 |---------|-------------|
 | [pipeline-optimization/](pipeline-optimization/) | Enabling and configuring the Pipeline Optimization service subchart with database setup and registry access |
 | [studios/](studios/) | Studios subchart configuration for interactive data analysis environments with ingress setup |
-| [seqera-ai](seqera-ai/) | Enabling the Seqera AI agent backend, Model Context Protocol server, and Portal web interface |
+| [seqera-co-scientist](seqera-co-scientist/) | Enabling the Seqera Co-Scientist agent backend, Model Context Protocol server, and Portal web interface |
 
 ## Additional Resources
 

--- a/charts/platform/examples/seqera-ai
+++ b/charts/platform/examples/seqera-ai
@@ -1,0 +1,1 @@
+seqera-co-scientist

--- a/charts/platform/examples/seqera-co-scientist/README.md
+++ b/charts/platform/examples/seqera-co-scientist/README.md
@@ -1,6 +1,6 @@
-# Seqera AI installation example
+# Seqera Co-Scientist installation example
 
-This example demonstrates how to enable the Seqera AI [Agent backend](../../charts/agent-backend/),
+This example demonstrates how to enable the Seqera Co-Scientist [Agent backend](../../charts/agent-backend/),
 [Model Context Protocol server](../../charts/mcp/), and [Portal web
 interface](../../charts/portal-web/) using the Platform parent Helm chart and enabling
 the respective subcharts. The charts can also be installed without installing the Platform chart,
@@ -20,8 +20,8 @@ key = Fernet.generate_key()
 print(key.decode())
 ```
 
-The example doesn't provide values for the Platform chart, but it can be used as a reference for how to set the values for the Seqera AI components.
+The example doesn't provide values for the Platform chart, but it can be used as a reference for how to set the values for the Seqera Co-Scientist components.
 
-Private registry credentials are required to pull the Seqera AI images. Refer to the
+Private registry credentials are required to pull the Seqera Co-Scientist images. Refer to the
 [VENDORING.md](../../../../VENDORING.md) file for instructions on how to vendor images and charts to
 an internal registry.

--- a/charts/platform/examples/seqera-co-scientist/values.yaml
+++ b/charts/platform/examples/seqera-co-scientist/values.yaml
@@ -1,6 +1,6 @@
 global:
   platformExternalDomain: platform.example.com
-  # The domains where Seqera AI applications will be exposed are automatically derived from the
+  # The domains where Seqera Co-Scientist applications will be exposed are automatically derived from the
   # `platformExternalDomain` value, but they can be overridden by setting the following values:
   # mcpDomain: mcp.platform.example.com
   # portalDomain: ai.platform.example.com


### PR DESCRIPTION
This PR renames Seqera AI to Seqera Co-Scientist throughout the repo, including the `charts/platform/examples/seqera-ai/` (a symlink is added in its place).