### PR TITLE
docs: Update image URIs to new repo paths on cr.seqera.io

### DIFF
--- a/VENDORING.md
+++ b/VENDORING.md
@@ -6,7 +6,7 @@ internal OCI registry.
 
 Seqera images are hosted on `cr.seqera.io`. Similarly, we recommend vendoring (replicating) images
 into your own internal container registry. Refer to the [Seqera
-documentation](https://docs.seqera.io/platform-enterprise/enterprise/prerequisites/common#vendoring-seqera-container-images-to-your-own-registry)
+documentation](https://docs.seqera.io/platform-enterprise/enterprise/configuration/mirroring)
 for more information.
 
 ## Automatic replication via Container Registry feature - recommended approach

--- a/charts/platform/CHANGELOG.md
+++ b/charts/platform/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `agent-backend` to 1.0.0: provider configuration redesigned to support multiple LLM providers. See [agent-backend CHANGELOG](charts/agent-backend/CHANGELOG.md) for the full migration guide.
 - `agent-backend`: remove redundant Anthropic validation from NOTES.txt, add `bedrock.sandbox.runtimeArn` required validator, replace `NEXTFLOW_DOCS_USE_REDIS_INDEX` with `NEXTFLOW_DOCS_TOOL`.
+- Update image paths in the README and values.yaml - the chart does not hardcode `cr.seqera.io` as the registry, customers are invited to vendor the images to their private registry as well as the charts.
 
 ## [0.33.0] - 2026-04-30
 

--- a/charts/platform/Chart.lock
+++ b/charts/platform/Chart.lock
@@ -7,21 +7,21 @@ dependencies:
   version: 2.1.2
 - name: pipeline-optimization
   repository: file://charts/pipeline-optimization
-  version: 2.0.6
+  version: 2.0.7
 - name: studios
   repository: file://charts/studios
-  version: 1.3.0
+  version: 1.3.1
 - name: wave
   repository: file://charts/wave
-  version: 0.2.0
+  version: 0.2.1
 - name: mcp
   repository: file://charts/mcp
-  version: 0.4.0
+  version: 0.4.1
 - name: agent-backend
   repository: file://charts/agent-backend
   version: 1.0.0
 - name: portal-web
   repository: file://charts/portal-web
-  version: 0.3.0
-digest: sha256:d4ba08956b47827aea9dcea7d448a74e8cd6dc14a151146044c0ac9408853cc7
-generated: "2026-05-11T14:55:23.188503804+02:00"
+  version: 0.3.1
+digest: sha256:13bf2abdc12ad0782eab052065837ee5b5edee59ae03fc8d2b3bc576548475b1
+generated: "2026-05-12T12:30:11.733560019+02:00"

--- a/charts/platform/README.md
+++ b/charts/platform/README.md
@@ -198,7 +198,7 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | redis.existingSecretKey | string | `"TOWER_REDIS_PASSWORD"` | Key in the existing Secret containing the password for Redis |
 | redis.enableTls | bool | `false` | Enable TLS when connecting to Redis |
 | backend.image.registry | string | `""` | Backend container image registry |
-| backend.image.repository | string | `"private/nf-tower-enterprise/backend"` | Backend container image repository |
+| backend.image.repository | string | `"enterprise/platform/backend"` | Backend container image repository |
 | backend.image.tag | string | `"{{ .chart.AppVersion }}"` | Backend container image tag |
 | backend.image.digest | string | `""` | Backend container image digest in the format `sha256:1234abcdef` |
 | backend.image.pullPolicy | string | `"IfNotPresent"` | imagePullPolicy for the backend container Ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images |
@@ -255,7 +255,7 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | backend.livenessProbe.failureThreshold | int | `10` | Consecutive failures before restarting the container |
 | backend.livenessProbe.successThreshold | int | `1` | Typically 1 (usually ignored) |
 | frontend.image.registry | string | `""` | Frontend container image registry |
-| frontend.image.repository | string | `"private/nf-tower-enterprise/frontend"` | Frontend container image repository |
+| frontend.image.repository | string | `"enterprise/platform/frontend"` | Frontend container image repository |
 | frontend.image.tag | string | `"{{ .chart.AppVersion }}-unprivileged"` | Specify a tag to override the version defined in .Chart.appVersion |
 | frontend.image.digest | string | `""` | Frontend container image digest in the format `sha256:1234abcdef` |
 | frontend.image.pullPolicy | string | `"IfNotPresent"` | imagePullPolicy for the frontend container Ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images |
@@ -312,7 +312,7 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | frontend.livenessProbe.failureThreshold | int | `10` | Consecutive failures before restarting the container |
 | frontend.livenessProbe.successThreshold | int | `1` | Typically 1 (usually ignored) |
 | cron.image.registry | string | `""` | Cron container image registry |
-| cron.image.repository | string | `"private/nf-tower-enterprise/backend"` | Cron container image repository |
+| cron.image.repository | string | `"enterprise/platform/backend"` | Cron container image repository |
 | cron.image.tag | string | `"{{ .chart.AppVersion }}"` | Cron container image tag |
 | cron.image.digest | string | `""` | Cron container image digest in the format `sha256:1234abcdef` |
 | cron.image.pullPolicy | string | `"IfNotPresent"` | imagePullPolicy for the cron container Ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images |
@@ -370,7 +370,7 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | cron.livenessProbe.failureThreshold | int | `10` | Consecutive failures before restarting the container |
 | cron.livenessProbe.successThreshold | int | `1` | Typically 1 (usually ignored) |
 | cron.dbMigrationInitContainer.image.registry | string | `""` | Database migration container image registry |
-| cron.dbMigrationInitContainer.image.repository | string | `"private/nf-tower-enterprise/migrate-db"` | Database migration container image repository |
+| cron.dbMigrationInitContainer.image.repository | string | `"enterprise/platform/migrate-db"` | Database migration container image repository |
 | cron.dbMigrationInitContainer.image.tag | string | `"{{ .chart.AppVersion }}"` | Specify a tag to override the version defined in .Chart.appVersion |
 | cron.dbMigrationInitContainer.image.digest | string | `""` | Database migration container image digest in the format `sha256:1234abcdef` |
 | cron.dbMigrationInitContainer.image.pullPolicy | string | `"IfNotPresent"` | imagePullPolicy for the database migration init container Ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images |

--- a/charts/platform/charts/agent-backend/CHANGELOG.md
+++ b/charts/platform/charts/agent-backend/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove redundant Anthropic API key validation from `NOTES.txt`; fully covered by `validateProviders` in `_helpers.tpl`.
 - Add validator: `sandbox.provider: bedrock` now requires `bedrock.sandbox.runtimeArn` to be set.
 - Replace deprecated `NEXTFLOW_DOCS_USE_REDIS_INDEX` env var with `NEXTFLOW_DOCS_TOOL` (`memory` when `embeddings.provider` is set, `disabled` otherwise). Remove `nextflowDocs.useRedisIndex` value.
+- Update image paths in the README and values.yaml - the chart does not hardcode `cr.seqera.io` as the registry, customers are invited to vendor the images to their private registry as well as the charts.
 
 ## [0.5.0] - 2026-05-05
 

--- a/charts/platform/charts/agent-backend/README.md
+++ b/charts/platform/charts/agent-backend/README.md
@@ -119,12 +119,11 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | redis.password | string | `""` | Redis password |
 | redis.existingSecretName | string | `""` | Name of an existing Secret containing the Redis password, as an alternative to the password field. Note: the Secret must already exist in the same namespace at the time of deployment |
 | redis.existingSecretKey | string | `"AGENT_BACKEND_REDIS_PASSWORD"` | Key in the existing Secret containing the Redis password |
-| nextflowDocs.useRedisIndex | bool | `false` | Use a Redis-backed vector index for the Nextflow documentation knowledge base. Disabled by default. |
 | tokenEncryptionKey | string | `""` | Token encryption key (must be a valid Fernet key). Define the value as a String or a Secret, not both at the same time. If not defined, a random Fernet key will be auto-generated at each deployment. WARNING: Always explicitly set this value or use an existing secret when using Kustomize. Auto-generated random values are incompatible with Kustomize. When upgrading releases via Kustomize, Helm cannot query the cluster to check if a secret already exists, causing it to regenerate a new random value on each upgrade |
 | tokenEncryptionKeyExistingSecretName | string | `""` | Name of an existing Secret containing the token encryption key. Note: the Secret must already exist in the same namespace at the time of deployment |
 | tokenEncryptionKeyExistingSecretKey | string | `"AGENT_BACKEND_TOKEN_ENCRYPTION_KEY"` | Key in the existing Secret containing the token encryption key |
 | image.registry | string | `""` | Container image registry |
-| image.repository | string | `"private/nf-tower-enterprise/agent-backend"` | Container image repository |
+| image.repository | string | `"ai/agent-backend/backend"` | Container image repository |
 | image.tag | string | `"{{ .chart.AppVersion }}"` | Container image tag |
 | image.digest | string | `""` | Container image digest in the format `sha256:1234abcdef` |
 | image.pullPolicy | string | `"IfNotPresent"` | imagePullPolicy for the container Ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images |

--- a/charts/platform/charts/agent-backend/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/platform/charts/agent-backend/tests/__snapshot__/deployment_test.yaml.snap
@@ -51,7 +51,7 @@ should render a Deployment with default values:
               envFrom:
                 - configMapRef:
                     name: release-name-agent-backend
-              image: private/nf-tower-enterprise/agent-backend:v9.9.9
+              image: ai/agent-backend/backend:v9.9.9
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 failureThreshold: 10
@@ -167,7 +167,7 @@ should render a Deployment with default values:
               envFrom:
                 - configMapRef:
                     name: release-name-agent-backend
-              image: private/nf-tower-enterprise/agent-backend:v9.9.9
+              image: ai/agent-backend/backend:v9.9.9
               imagePullPolicy: IfNotPresent
               name: init
               resources:

--- a/charts/platform/charts/agent-backend/tests/deployment_test.yaml
+++ b/charts/platform/charts/agent-backend/tests/deployment_test.yaml
@@ -591,7 +591,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: private/nf-tower-enterprise/agent-backend:v9.9.9
+          value: ai/agent-backend/backend:v9.9.9
 
   - it: should evaluate templates in azure override fields for the agent-backend container
     template: deployment.yaml

--- a/charts/platform/charts/agent-backend/values.yaml
+++ b/charts/platform/charts/agent-backend/values.yaml
@@ -203,7 +203,7 @@ image:
   # -- Container image registry
   registry: ""
   # -- Container image repository
-  repository: private/nf-tower-enterprise/agent-backend
+  repository: ai/agent-backend/backend
   # -- Container image tag
   # @default -- `"{{ .chart.AppVersion }}"`
   tag: ""

--- a/charts/platform/charts/mcp/CHANGELOG.md
+++ b/charts/platform/charts/mcp/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add link to [Seqera AI prerequisites](https://docs.seqera.io/platform-enterprise/seqera-ai/prerequisites) documentation in the README.
 
+### Changed
+
+- Update image paths in the README and values.yaml - the chart does not hardcode `cr.seqera.io` as the registry, customers are invited to vendor the images to their private registry as well as the charts.
+
 ## [0.4.0] - 2026-05-05
 
 - **Enhancement**: allow global configuration of Ingress options. A new `global.ingress` block (`enabled`, `path`, `defaultPathType`, `ingressClassName`, `annotations`, `extraLabels`, `tls`) lets cluster-wide Ingress defaults be set once at the parent and propagate to every subchart, removing the need to repeat controller-wide config per subchart. `enabled` is OR-merged; scalar fields fall back to global when local is unset; `annotations` and `extraLabels` are merged with local winning on key collision; `tls` is concatenated (useful for a single wildcard certificate across all services).

--- a/charts/platform/charts/mcp/README.md
+++ b/charts/platform/charts/mcp/README.md
@@ -88,7 +88,7 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | oauth.jwtSeedSecretName | string | `""` | Name of an existing Secret containing the JWT seed, as an alternative to the string field. Note: the Secret must already exist in the same namespace at the time of deployment |
 | oauth.jwtSeedSecretKey | string | `"MCP_OAUTH_JWT_SECRET"` | Key in the existing Secret containing the JWT seed |
 | image.registry | string | `""` | Container image registry |
-| image.repository | string | `"private/nf-tower-enterprise/mcp"` | Container image repository |
+| image.repository | string | `"ai/mcp/server"` | Container image repository |
 | image.tag | string | `"{{ .chart.AppVersion }}"` | Container image tag |
 | image.digest | string | `""` | Container image digest in the format `sha256:1234abcdef` |
 | image.pullPolicy | string | `"IfNotPresent"` | imagePullPolicy for the container Ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images |

--- a/charts/platform/charts/mcp/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/platform/charts/mcp/tests/__snapshot__/deployment_test.yaml.snap
@@ -46,7 +46,7 @@ should render a Deployment with default values:
               envFrom:
                 - configMapRef:
                     name: release-name-mcp
-              image: private/nf-tower-enterprise/mcp:v9.9.9
+              image: ai/mcp/server:v9.9.9
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 failureThreshold: 10

--- a/charts/platform/charts/mcp/values.yaml
+++ b/charts/platform/charts/mcp/values.yaml
@@ -143,7 +143,7 @@ image:
   # -- Container image registry
   registry: ""
   # -- Container image repository
-  repository: private/nf-tower-enterprise/mcp
+  repository: ai/mcp/server
   # -- Container image tag
   # @default -- `"{{ .chart.AppVersion }}"`
   tag: ""

--- a/charts/platform/charts/pipeline-optimization/CHANGELOG.md
+++ b/charts/platform/charts/pipeline-optimization/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.7] - 2026-05-12
+
+### Changed
+
+- Update image paths in the README and values.yaml - the chart does not hardcode `cr.seqera.io` as the registry, customers are invited to vendor the images to their private registry as well as the charts.
+
 ## [2.0.6] - 2026-05-05
 
 ### Changed

--- a/charts/platform/charts/pipeline-optimization/Chart.yaml
+++ b/charts/platform/charts/pipeline-optimization/Chart.yaml
@@ -23,7 +23,7 @@ maintainers:
     email: devops@seqera.io
     url: https://seqera.io
 type: application
-version: 2.0.6
+version: 2.0.7
 appVersion: "0.4.13"
 dependencies:
   - name: common

--- a/charts/platform/charts/pipeline-optimization/README.md
+++ b/charts/platform/charts/pipeline-optimization/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart to deploy the Seqera Pipeline Optimization service (referred to as Groundswell in Platform configuration files).
 
-![Version: 2.0.6](https://img.shields.io/badge/Version-2.0.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.13](https://img.shields.io/badge/AppVersion-0.4.13-informational?style=flat-square)
+![Version: 2.0.7](https://img.shields.io/badge/Version-2.0.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.13](https://img.shields.io/badge/AppVersion-0.4.13-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -37,7 +37,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/pipeline-optimization \
-  --version 2.0.6 \
+  --version 2.0.7 \
   --namespace my-namespace \
   --create-namespace
 ```
@@ -87,13 +87,13 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | platformDatabase.sslCert | string | `""` | Path to a client certificate file for mutual TLS authentication |
 | platformDatabase.sslKey | string | `""` | Path to a client key file for mutual TLS authentication |
 | image.registry | string | `""` | Pipeline Optimization container image registry |
-| image.repository | string | `"private/nf-tower-enterprise/groundswell"` | Pipeline Optimization container image repository |
+| image.repository | string | `"enterprise/platform/groundswell"` | Pipeline Optimization container image repository |
 | image.tag | string | `"{{ .chart.AppVersion }}"` | Pipeline Optimization container image tag |
 | image.digest | string | `""` | Pipeline Optimization container image digest in the format `sha256:1234abcdef` |
 | image.pullPolicy | string | `"IfNotPresent"` | imagePullPolicy for the Pipeline Optimization container Ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images |
 | image.pullSecrets | list | `[]` | List of imagePullSecrets Secrets must be created in the same namespace, for example using the .extraDeploy array Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ |
 | dbMigrationInitContainer.image.registry | string | `""` | Migrate DB init container image registry |
-| dbMigrationInitContainer.image.repository | string | `"private/nf-tower-enterprise/groundswell"` | Migrate DB init container image repository |
+| dbMigrationInitContainer.image.repository | string | `"enterprise/platform/groundswell"` | Migrate DB init container image repository |
 | dbMigrationInitContainer.image.tag | string | `"{{ .chart.AppVersion }}"` | Migrate DB init container image tag |
 | dbMigrationInitContainer.image.digest | string | `""` | Migrate DB init container image digest in the format `sha256:1234abcdef` |
 | dbMigrationInitContainer.image.pullPolicy | string | `"IfNotPresent"` | imagePullPolicy for the Migrate DB init container Ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images |

--- a/charts/platform/charts/pipeline-optimization/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/platform/charts/pipeline-optimization/tests/__snapshot__/deployment_test.yaml.snap
@@ -17,7 +17,7 @@ should produce a Deployment resource with minimal values:
         envFrom:
           - configMapRef:
               name: release-name-pipeline-optimization
-        image: private/nf-tower-enterprise/groundswell:v9.9.9
+        image: enterprise/platform/groundswell:v9.9.9
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10
@@ -150,7 +150,7 @@ should produce a Deployment resource with minimal values:
         envFrom:
           - configMapRef:
               name: release-name-pipeline-optimization
-        image: private/nf-tower-enterprise/groundswell:v9.9.9
+        image: enterprise/platform/groundswell:v9.9.9
         imagePullPolicy: IfNotPresent
         name: migrate-db
     securityContext:
@@ -221,7 +221,7 @@ should render the deployment with the correct checksums, labels and annotations:
               envFrom:
                 - configMapRef:
                     name: release-name-pipeline-optimization
-              image: private/nf-tower-enterprise/groundswell:9.9.9
+              image: enterprise/platform/groundswell:9.9.9
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 failureThreshold: 10
@@ -354,7 +354,7 @@ should render the deployment with the correct checksums, labels and annotations:
               envFrom:
                 - configMapRef:
                     name: release-name-pipeline-optimization
-              image: private/nf-tower-enterprise/groundswell:9.9.9
+              image: enterprise/platform/groundswell:9.9.9
               imagePullPolicy: IfNotPresent
               name: migrate-db
           securityContext:

--- a/charts/platform/charts/pipeline-optimization/tests/deployment_test.yaml
+++ b/charts/platform/charts/pipeline-optimization/tests/deployment_test.yaml
@@ -692,7 +692,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: private/nf-tower-enterprise/groundswell:v9.9.9
+          value: enterprise/platform/groundswell:v9.9.9
 
   - it: should evaluate templates in azure override fields for the pipeline-optimization container
     template: deployment.yaml
@@ -735,7 +735,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.initContainers[2].image
-          value: private/nf-tower-enterprise/groundswell:v9.9.9
+          value: enterprise/platform/groundswell:v9.9.9
 
   - it: should evaluate templates in azure override fields for migrate-db initContainer
     template: deployment.yaml

--- a/charts/platform/charts/pipeline-optimization/values.yaml
+++ b/charts/platform/charts/pipeline-optimization/values.yaml
@@ -117,7 +117,7 @@ image:
   # -- Pipeline Optimization container image registry
   registry: ""
   # -- Pipeline Optimization container image repository
-  repository: private/nf-tower-enterprise/groundswell
+  repository: enterprise/platform/groundswell
   # -- Pipeline Optimization container image tag
   # @default -- `"{{ .chart.AppVersion }}"`
   tag: ""
@@ -140,7 +140,7 @@ dbMigrationInitContainer:
     # -- Migrate DB init container image registry
     registry: ""
     # -- Migrate DB init container image repository
-    repository: private/nf-tower-enterprise/groundswell
+    repository: enterprise/platform/groundswell
     # -- Migrate DB init container image tag
     # @default -- `"{{ .chart.AppVersion }}"`
     tag: ""

--- a/charts/platform/charts/portal-web/CHANGELOG.md
+++ b/charts/platform/charts/portal-web/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Add link to [Seqera AI prerequisites](https://docs.seqera.io/platform-enterprise/seqera-ai/prerequisites) documentation in the README.
 
+### Changed
+
+- Update image paths in the README and values.yaml - the chart does not hardcode `cr.seqera.io` as the registry, customers are invited to vendor the images to their private registry as well as the charts.
+
 ## [0.3.0] - 2026-05-05
 
 - **Enhancement**: allow global configuration of Ingress options. A new `global.ingress` block (`enabled`, `path`, `defaultPathType`, `ingressClassName`, `annotations`, `extraLabels`, `tls`) lets cluster-wide Ingress defaults be set once at the parent and propagate to every subchart, removing the need to repeat controller-wide config per subchart. `enabled` is OR-merged; scalar fields fall back to global when local is unset; `annotations` and `extraLabels` are merged with local winning on key collision; `tls` is concatenated (useful for a single wildcard certificate across all services).

--- a/charts/platform/charts/portal-web/README.md
+++ b/charts/platform/charts/portal-web/README.md
@@ -71,7 +71,7 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | global.imageCredentials | list | `[]` | Optional credentials to log in and fetch images from a private registry. These credentials are shared with all the subcharts automatically |
 | global.imageCredentialsSecrets | list | `[]` | Optional list of existing Secrets containing image pull credentials to use for pulling images from private registries. These Secrets are shared with all the subcharts automatically |
 | image.registry | string | `""` | Container image registry |
-| image.repository | string | `"private/nf-tower-enterprise/portal-web"` | Container image repository |
+| image.repository | string | `"ai/portal/web"` | Container image repository |
 | image.tag | string | `"{{ .chart.AppVersion }}"` | Container image tag |
 | image.digest | string | `""` | Container image digest in the format `sha256:1234abcdef` |
 | image.pullPolicy | string | `"IfNotPresent"` | imagePullPolicy for the container Ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images |

--- a/charts/platform/charts/portal-web/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/platform/charts/portal-web/tests/__snapshot__/deployment_test.yaml.snap
@@ -35,7 +35,7 @@ should render a Deployment with default values:
             - envFrom:
                 - configMapRef:
                     name: release-name-portal-web
-              image: private/nf-tower-enterprise/portal-web:v9.9.9
+              image: ai/portal/web:v9.9.9
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 failureThreshold: 3

--- a/charts/platform/charts/portal-web/values.yaml
+++ b/charts/platform/charts/portal-web/values.yaml
@@ -84,7 +84,7 @@ image:
   # -- Container image registry
   registry: ""
   # -- Container image repository
-  repository: private/nf-tower-enterprise/portal-web
+  repository: ai/portal/web
   # -- Container image tag
   # @default -- `"{{ .chart.AppVersion }}"`
   tag: ""

--- a/charts/platform/charts/studios/CHANGELOG.md
+++ b/charts/platform/charts/studios/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.1] - 2026-05-12
+
+### Changed
+
+- Update image paths in the README and values.yaml - the chart does not hardcode `cr.seqera.io` as the registry, customers are invited to vendor the images to their private registry as well as the charts.
+
 ## [1.3.0] - 2026-05-05
 
 - **Enhancement**: allow global configuration of Ingress options. A new `global.ingress` block (`enabled`, `path`, `defaultPathType`, `ingressClassName`, `annotations`, `extraLabels`, `tls`) lets cluster-wide Ingress defaults be set once at the parent and propagate to every subchart, removing the need to repeat controller-wide config per subchart. `enabled` is OR-merged; scalar fields fall back to global when local is unset; `annotations` and `extraLabels` are merged with local winning on key collision; `tls` is concatenated (useful for a single wildcard certificate across all services).

--- a/charts/platform/charts/studios/Chart.yaml
+++ b/charts/platform/charts/studios/Chart.yaml
@@ -21,7 +21,7 @@ name: studios
 description: Studios is a unified platform for interactive analysis
 sources:
   - https://github.com/seqeralabs/helm-charts/tree/main/seqera/charts/studios
-version: 1.3.0
+version: 1.3.1
 appVersion: "0.11.0"
 maintainers:
   - name: Seqera Labs

--- a/charts/platform/charts/studios/README.md
+++ b/charts/platform/charts/studios/README.md
@@ -2,7 +2,7 @@
 
 Studios is a unified platform for interactive analysis
 
-![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![AppVersion: 0.11.0](https://img.shields.io/badge/AppVersion-0.11.0-informational?style=flat-square)
+![Version: 1.3.1](https://img.shields.io/badge/Version-1.3.1-informational?style=flat-square) ![AppVersion: 0.11.0](https://img.shields.io/badge/AppVersion-0.11.0-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -41,7 +41,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/studios \
-  --version 1.3.0 \
+  --version 1.3.1 \
   --namespace my-namespace \
   --create-namespace
 ```
@@ -92,7 +92,7 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | redis.enableTls | bool | `false` | Enable TLS when connecting to Redis |
 | redis.prefix | string | `"connect:session"` | Key prefix to use when storing Studios sessions in Redis |
 | proxy.image.registry | string | `""` | Proxy container image registry |
-| proxy.image.repository | string | `"private/nf-tower-enterprise/data-studio/connect-proxy"` | Proxy container image repository |
+| proxy.image.repository | string | `"enterprise/platform/data-studio/connect-proxy"` | Proxy container image repository |
 | proxy.image.tag | string | `"{{ .chart.AppVersion }}"` | Proxy container image tag |
 | proxy.image.digest | string | `""` | Proxy container image digest in the format `sha256:1234abcdef` |
 | proxy.image.pullPolicy | string | `"IfNotPresent"` | imagePullPolicy for the Proxy container Ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images |
@@ -132,7 +132,7 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | proxy.containerSecurityContext.capabilities | object | `{"add":["NET_BIND_SERVICE"],"drop":["ALL"]}` | Fine-grained Linux kernel privileges to add or drop for the container |
 | proxy.resources | object | `{}` | Container requests and limits for different resources like CPU or memory |
 | server.image.registry | string | `""` | Server container image registry |
-| server.image.repository | string | `"private/nf-tower-enterprise/data-studio/connect-server"` | Server container image repository |
+| server.image.repository | string | `"enterprise/platform/data-studio/connect-server"` | Server container image repository |
 | server.image.tag | string | `"{{ .chart.AppVersion }}"` | Server container image tag |
 | server.image.digest | string | `""` | Server container image digest in the format `sha256:1234abcdef` |
 | server.image.pullPolicy | string | `"IfNotPresent"` | imagePullPolicy for the Server container Ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images |

--- a/charts/platform/charts/studios/tests/__snapshot__/deployment-proxy_test.yaml.snap
+++ b/charts/platform/charts/studios/tests/__snapshot__/deployment-proxy_test.yaml.snap
@@ -41,7 +41,7 @@ should run using config requested by the user:
                   name: CMContainingExtraEnvVars
               - secretRef:
                   name: SecretContainingExtraEnvVars
-            image: private/nf-tower-enterprise/data-studio/connect-proxy:9.9.9
+            image: enterprise/platform/data-studio/connect-proxy:9.9.9
             imagePullPolicy: Always
             name: proxy
             ports:
@@ -153,7 +153,7 @@ should set the proxy deployment image using the chart version and use sane defau
                     name: release-name-studios-common
                 - configMapRef:
                     name: release-name-studios-proxy
-              image: private/nf-tower-enterprise/data-studio/connect-proxy:9.9.9
+              image: enterprise/platform/data-studio/connect-proxy:9.9.9
               imagePullPolicy: IfNotPresent
               name: proxy
               ports:

--- a/charts/platform/charts/studios/tests/__snapshot__/statefulset-server_test.yaml.snap
+++ b/charts/platform/charts/studios/tests/__snapshot__/statefulset-server_test.yaml.snap
@@ -37,7 +37,7 @@ should run using config requested by the user:
                   name: CMContainingExtraEnvVars
               - secretRef:
                   name: SecretContainingExtraEnvVars
-            image: private/nf-tower-enterprise/data-studio/connect-server:9.9.9
+            image: enterprise/platform/data-studio/connect-server:9.9.9
             imagePullPolicy: Always
             name: server
             securityContext:
@@ -104,7 +104,7 @@ should set the statefulset server image using the chart version and use sane def
                     name: release-name-studios-common
                 - configMapRef:
                     name: release-name-studios-server
-              image: private/nf-tower-enterprise/data-studio/connect-server:9.9.9
+              image: enterprise/platform/data-studio/connect-server:9.9.9
               imagePullPolicy: IfNotPresent
               name: server
               securityContext:

--- a/charts/platform/charts/studios/tests/deployment-proxy_test.yaml
+++ b/charts/platform/charts/studios/tests/deployment-proxy_test.yaml
@@ -53,7 +53,7 @@ tests:
   asserts:
   - equal:
       path: spec.template.spec.containers[0].image
-      value: private/nf-tower-enterprise/data-studio/connect-proxy:1.2.3
+      value: enterprise/platform/data-studio/connect-proxy:1.2.3
 - it: should render the proxy deployment with the specified digest
   template: deployment-proxy.yaml
   set:
@@ -63,7 +63,7 @@ tests:
   asserts:
   - equal:
       path: spec.template.spec.containers[0].image
-      value: private/nf-tower-enterprise/data-studio/connect-proxy@sha256:1234abcdef
+      value: enterprise/platform/data-studio/connect-proxy@sha256:1234abcdef
 - it: should render the proxy deployment with the correct checksums
   template: deployment-proxy.yaml
   chart:
@@ -451,7 +451,7 @@ tests:
   asserts:
   - equal:
       path: spec.template.spec.containers[0].image
-      value: my-registry.example.com/private/nf-tower-enterprise/data-studio/connect-proxy@sha256:1234abcdef
+      value: my-registry.example.com/enterprise/platform/data-studio/connect-proxy@sha256:1234abcdef
 - it: should render default caddy-temp-data-volume
   template: deployment-proxy.yaml
   asserts:
@@ -681,7 +681,7 @@ tests:
   asserts:
   - equal:
       path: spec.template.spec.containers[0].image
-      value: private/nf-tower-enterprise/data-studio/connect-proxy:9.9.9
+      value: enterprise/platform/data-studio/connect-proxy:9.9.9
 
 - it: should evaluate templates in azure override fields for the proxy container
   template: deployment-proxy.yaml

--- a/charts/platform/charts/studios/tests/statefulset-server_test.yaml
+++ b/charts/platform/charts/studios/tests/statefulset-server_test.yaml
@@ -50,7 +50,7 @@ tests:
   asserts:
   - equal:
       path: spec.template.spec.containers[0].image
-      value: private/nf-tower-enterprise/data-studio/connect-server:1.2.3
+      value: enterprise/platform/data-studio/connect-server:1.2.3
 - it: should render the server deployment with the specified digest
   template: statefulset-server.yaml
   set:
@@ -60,7 +60,7 @@ tests:
   asserts:
   - equal:
       path: spec.template.spec.containers[0].image
-      value: private/nf-tower-enterprise/data-studio/connect-server@sha256:1234abcdef
+      value: enterprise/platform/data-studio/connect-server@sha256:1234abcdef
 - it: should render the server deployment with the correct checksums
   template: statefulset-server.yaml
   chart:
@@ -510,7 +510,7 @@ tests:
   asserts:
   - equal:
       path: spec.template.spec.containers[0].image
-      value: my-registry.example.com/private/nf-tower-enterprise/data-studio/connect-server@sha256:abcd1234
+      value: my-registry.example.com/enterprise/platform/data-studio/connect-server@sha256:abcd1234
 - it: should render container with correct imagePullPolicy
   template: statefulset-server.yaml
   set:
@@ -602,7 +602,7 @@ tests:
   asserts:
   - equal:
       path: spec.template.spec.containers[0].image
-      value: private/nf-tower-enterprise/data-studio/connect-server:9.9.9
+      value: enterprise/platform/data-studio/connect-server:9.9.9
 
 - it: should evaluate templates in azure override fields for the server container
   template: statefulset-server.yaml

--- a/charts/platform/charts/studios/values.yaml
+++ b/charts/platform/charts/studios/values.yaml
@@ -110,7 +110,7 @@ proxy:
     # -- Proxy container image registry
     registry: ""
     # -- Proxy container image repository
-    repository: private/nf-tower-enterprise/data-studio/connect-proxy
+    repository: enterprise/platform/data-studio/connect-proxy
     # -- Proxy container image tag
     # @default -- `"{{ .chart.AppVersion }}"`
     tag: ""
@@ -281,7 +281,7 @@ server:
     # -- Server container image registry
     registry: ""
     # -- Server container image repository
-    repository: private/nf-tower-enterprise/data-studio/connect-server
+    repository: enterprise/platform/data-studio/connect-server
     # -- Server container image tag
     # @default -- `"{{ .chart.AppVersion }}"`
     tag: ""

--- a/charts/platform/charts/wave/CHANGELOG.md
+++ b/charts/platform/charts/wave/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2026-05-12
+
+### Changed
+
+- Update image paths in the README and values.yaml - the chart does not hardcode `cr.seqera.io` as the registry, customers are invited to vendor the images to their private registry as well as the charts.
+
 ## [0.2.0] - 2026-05-05
 
 - **Enhancement**: allow global configuration of Ingress options. A new `global.ingress` block (`enabled`, `path`, `defaultPathType`, `ingressClassName`, `annotations`, `extraLabels`, `tls`) lets cluster-wide Ingress defaults be set once at the parent and propagate to every subchart, removing the need to repeat controller-wide config per subchart. `enabled` is OR-merged; scalar fields fall back to global when local is unset; `annotations` and `extraLabels` are merged with local winning on key collision; `tls` is concatenated (useful for a single wildcard certificate across all services).

--- a/charts/platform/charts/wave/Chart.yaml
+++ b/charts/platform/charts/wave/Chart.yaml
@@ -19,7 +19,7 @@ apiVersion: v2
 name: wave
 description: Wave
 type: application
-version: 0.2.0
+version: 0.2.1
 appVersion: "v1.32.4"
 maintainers:
   - name: Seqera Labs

--- a/charts/platform/charts/wave/README.md
+++ b/charts/platform/charts/wave/README.md
@@ -2,7 +2,7 @@
 
 Wave
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.32.4](https://img.shields.io/badge/AppVersion-v1.32.4-informational?style=flat-square)
+![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.32.4](https://img.shields.io/badge/AppVersion-v1.32.4-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -35,7 +35,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/wave \
-  --version 0.2.0 \
+  --version 0.2.1 \
   --namespace my-namespace \
   --create-namespace
 ```
@@ -85,7 +85,7 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | redis.existingSecretName | string | `""` | Name of an existing Secret containing the Redis password, as an alternative to the password field. Note: the Secret must already exist in the same namespace at the time of deployment |
 | redis.existingSecretKey | string | `"REDIS_PASSWORD"` | Key in the existing Secret containing the Redis password |
 | image.registry | string | `""` | Container image registry |
-| image.repository | string | `"private/nf-tower-enterprise/wave"` | Container image repository |
+| image.repository | string | `"enterprise/platform/wave"` | Container image repository |
 | image.tag | string | `"{{ .chart.AppVersion }}"` | Container image tag |
 | image.digest | string | `""` | Container image digest in the format `sha256:1234abcdef` |
 | image.pullPolicy | string | `"IfNotPresent"` | imagePullPolicy for the container Ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images |

--- a/charts/platform/charts/wave/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/platform/charts/wave/tests/__snapshot__/deployment_test.yaml.snap
@@ -41,7 +41,7 @@ should render a Deployment with default values:
               envFrom:
                 - configMapRef:
                     name: release-name-wave
-              image: private/nf-tower-enterprise/wave:v1.32.4
+              image: enterprise/platform/wave:v1.32.4
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 failureThreshold: 10
@@ -78,7 +78,7 @@ should render a Deployment with default values:
                 - sh
                 - -c
                 - '> /tmp/config.yml'
-              image: private/nf-tower-enterprise/wave:v1.32.4
+              image: enterprise/platform/wave:v1.32.4
               imagePullPolicy: IfNotPresent
               name: touch-config-file
               volumeMounts:

--- a/charts/platform/charts/wave/values.yaml
+++ b/charts/platform/charts/wave/values.yaml
@@ -117,7 +117,7 @@ image:
   # -- Container image registry
   registry: ""
   # -- Container image repository
-  repository: private/nf-tower-enterprise/wave
+  repository: enterprise/platform/wave
   # -- Container image tag
   # @default -- `"{{ .chart.AppVersion }}"`
   tag: ""

--- a/charts/platform/examples/pipeline-optimization/values.yaml
+++ b/charts/platform/examples/pipeline-optimization/values.yaml
@@ -30,7 +30,7 @@ pipeline-optimization:
     # Container registry where Pipeline Optimization images are stored
     # Options: cr.seqera.io or your private registry
     registry: "cr.seqera.io"
-    repository: "private/nf-tower-enterprise/groundswell"
+    repository: "enterprise/platform/groundswell"
     tag: "" # An empty tag string uses Chart.yaml appVersion
 
   # Database migration init container configuration
@@ -38,7 +38,7 @@ pipeline-optimization:
   dbMigrationInitContainer:
     image:
       registry: "cr.seqera.io"
-      repository: "private/nf-tower-enterprise/groundswell"
+      repository: "enterprise/platform/groundswell"
       tag: "" # An empty tag string uses Chart.yaml appVersion
 
   database:

--- a/charts/platform/tests/__snapshot__/deployment-backend_test.yaml.snap
+++ b/charts/platform/tests/__snapshot__/deployment-backend_test.yaml.snap
@@ -36,7 +36,7 @@ should produce a Deployment resource with minimal values:
               name: release-name-platform-backend
           - configMapRef:
               name: release-name-platform-shared-backend-cron
-        image: private/nf-tower-enterprise/backend:v9.9.9
+        image: enterprise/platform/backend:v9.9.9
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10
@@ -277,7 +277,7 @@ should render the backend deployment with the correct checksums, labels and anno
                     name: release-name-platform-backend
                 - configMapRef:
                     name: release-name-platform-shared-backend-cron
-              image: private/nf-tower-enterprise/backend:9.9.9
+              image: enterprise/platform/backend:9.9.9
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 failureThreshold: 10

--- a/charts/platform/tests/__snapshot__/deployment-cron_test.yaml.snap
+++ b/charts/platform/tests/__snapshot__/deployment-cron_test.yaml.snap
@@ -31,7 +31,7 @@ should produce a Deployment resource with minimal values:
               name: release-name-platform-cron
           - configMapRef:
               name: release-name-platform-shared-backend-cron
-        image: private/nf-tower-enterprise/backend:v9.9.9
+        image: enterprise/platform/backend:v9.9.9
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10
@@ -163,7 +163,7 @@ should produce a Deployment resource with minimal values:
               name: release-name-platform-shared-backend-cron
           - secretRef:
               name: release-name-platform-backend
-        image: private/nf-tower-enterprise/migrate-db:v9.9.9
+        image: enterprise/platform/migrate-db:v9.9.9
         imagePullPolicy: IfNotPresent
         name: migrate-db
         securityContext:
@@ -268,7 +268,7 @@ should render the cron deployment with the correct checksums, labels and annotat
                     name: release-name-platform-cron
                 - configMapRef:
                     name: release-name-platform-shared-backend-cron
-              image: private/nf-tower-enterprise/backend:9.9.9
+              image: enterprise/platform/backend:9.9.9
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 failureThreshold: 10
@@ -400,7 +400,7 @@ should render the cron deployment with the correct checksums, labels and annotat
                     name: release-name-platform-shared-backend-cron
                 - secretRef:
                     name: release-name-platform-backend
-              image: private/nf-tower-enterprise/migrate-db:9.9.9
+              image: enterprise/platform/migrate-db:9.9.9
               imagePullPolicy: IfNotPresent
               name: migrate-db
               securityContext:

--- a/charts/platform/tests/__snapshot__/deployment-frontend_test.yaml.snap
+++ b/charts/platform/tests/__snapshot__/deployment-frontend_test.yaml.snap
@@ -38,7 +38,7 @@ should produce a Deployment resource with minimal values:
                 - name: NGINX_LISTEN_PORT
                   value: "8083"
               envFrom: null
-              image: private/nf-tower-enterprise/frontend:v9.9.9-unprivileged
+              image: enterprise/platform/frontend:v9.9.9-unprivileged
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 failureThreshold: 10
@@ -133,7 +133,7 @@ should render the frontend deployment with the correct labels and annotations:
                 - name: NGINX_LISTEN_PORT
                   value: "8083"
               envFrom: null
-              image: private/nf-tower-enterprise/frontend:9.9.9-unprivileged
+              image: enterprise/platform/frontend:9.9.9-unprivileged
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 failureThreshold: 10

--- a/charts/platform/tests/deployment-backend_test.yaml
+++ b/charts/platform/tests/deployment-backend_test.yaml
@@ -46,7 +46,7 @@ tests:
   asserts:
   - equal:
       path: spec.template.spec.containers[0].image
-      value: private/nf-tower-enterprise/backend:9.0.0
+      value: enterprise/platform/backend:9.0.0
 
 - it: should render the backend deployment with the specified digest, overriding the tag
   template: deployment-backend.yaml
@@ -58,7 +58,7 @@ tests:
   asserts:
   - equal:
       path: spec.template.spec.containers[0].image
-      value: private/nf-tower-enterprise/backend@sha256:1234abcdef
+      value: enterprise/platform/backend@sha256:1234abcdef
 
 - it: should render the backend deployment with the correct checksums, labels and annotations
   template: deployment-backend.yaml
@@ -1039,7 +1039,7 @@ tests:
   asserts:
   - equal:
       path: spec.template.spec.containers[0].image
-      value: private/nf-tower-enterprise/backend:v9.9.9
+      value: enterprise/platform/backend:v9.9.9
 
 - it: should prefer azure override over custom backend.image when both are set
   template: deployment-backend.yaml

--- a/charts/platform/tests/deployment-cron_test.yaml
+++ b/charts/platform/tests/deployment-cron_test.yaml
@@ -45,7 +45,7 @@ tests:
   asserts:
   - equal:
       path: spec.template.spec.containers[0].image
-      value: private/nf-tower-enterprise/backend:9.0.0
+      value: enterprise/platform/backend:9.0.0
 - it: should render the cron deployment with the specified digest, overriding the tag
   template: deployment-cron.yaml
   set:
@@ -56,7 +56,7 @@ tests:
   asserts:
   - equal:
       path: spec.template.spec.containers[0].image
-      value: private/nf-tower-enterprise/backend@sha256:1234abcdef
+      value: enterprise/platform/backend@sha256:1234abcdef
 - it: should render the cron deployment with the correct checksums, labels and annotations
   template: deployment-cron.yaml
   chart:
@@ -292,7 +292,7 @@ tests:
       value: migrate-db
   - equal:
       path: spec.template.spec.initContainers[2].image
-      value: private/nf-tower-enterprise/migrate-db:v9.9.9
+      value: enterprise/platform/migrate-db:v9.9.9
   - equal:
       path: spec.template.spec.initContainers[0].env
       value:
@@ -959,7 +959,7 @@ tests:
   asserts:
   - equal:
       path: spec.template.spec.containers[0].image
-      value: private/nf-tower-enterprise/backend:v9.9.9
+      value: enterprise/platform/backend:v9.9.9
 
 - it: should prefer azure override over custom cron.image when both are set
   template: deployment-cron.yaml
@@ -1022,7 +1022,7 @@ tests:
   asserts:
   - equal:
       path: spec.template.spec.initContainers[2].image
-      value: private/nf-tower-enterprise/migrate-db:v9.9.9
+      value: enterprise/platform/migrate-db:v9.9.9
 
 - it: should use azure override with digest for the migrate-db initContainer
   template: deployment-cron.yaml

--- a/charts/platform/tests/deployment-frontend_test.yaml
+++ b/charts/platform/tests/deployment-frontend_test.yaml
@@ -35,7 +35,7 @@ tests:
   asserts:
   - equal:
       path: spec.template.spec.containers[0].image
-      value: private/nf-tower-enterprise/frontend:9.0.0
+      value: enterprise/platform/frontend:9.0.0
 - it: should render the frontend deployment with a tag version ending with -unprivileged depending on the chart appVersion
   chart:
     version: 1.2.3
@@ -43,7 +43,7 @@ tests:
   asserts:
   - equal:
       path: spec.template.spec.containers[0].image
-      value: private/nf-tower-enterprise/frontend:9.8.7-unprivileged
+      value: enterprise/platform/frontend:9.8.7-unprivileged
 - it: should render the frontend deployment with the specified digest, overriding the tag
   set:
     frontend:
@@ -53,7 +53,7 @@ tests:
   asserts:
   - equal:
       path: spec.template.spec.containers[0].image
-      value: private/nf-tower-enterprise/frontend@sha256:1234abcdef
+      value: enterprise/platform/frontend@sha256:1234abcdef
 - it: should render the frontend deployment with the correct labels and annotations
   chart:
     version: 9.9.9+test
@@ -414,7 +414,7 @@ tests:
   asserts:
   - equal:
       path: spec.template.spec.containers[0].image
-      value: private/nf-tower-enterprise/frontend:v9.9.9-unprivileged
+      value: enterprise/platform/frontend:v9.9.9-unprivileged
 
 - it: should prefer azure override over custom frontend.image when both are set
   set:

--- a/charts/platform/values.yaml
+++ b/charts/platform/values.yaml
@@ -497,7 +497,7 @@ backend:
     # -- Backend container image registry
     registry: ""
     # -- Backend container image repository
-    repository: private/nf-tower-enterprise/backend
+    repository: enterprise/platform/backend
     # -- Backend container image tag
     # @default -- `"{{ .chart.AppVersion }}"`
     tag: ""
@@ -710,7 +710,7 @@ frontend:
     # -- Frontend container image registry
     registry: ""
     # -- Frontend container image repository
-    repository: private/nf-tower-enterprise/frontend
+    repository: enterprise/platform/frontend
     # -- Specify a tag to override the version defined in .Chart.appVersion
     # @default -- `"{{ .chart.AppVersion }}-unprivileged"`
     tag: ""
@@ -914,7 +914,7 @@ cron:
     # -- Cron container image registry
     registry: ""
     # -- Cron container image repository
-    repository: private/nf-tower-enterprise/backend
+    repository: enterprise/platform/backend
     # -- Cron container image tag
     # @default -- `"{{ .chart.AppVersion }}"`
     tag: ""
@@ -1114,7 +1114,7 @@ cron:
       # -- Database migration container image registry
       registry: ""
       # -- Database migration container image repository
-      repository: private/nf-tower-enterprise/migrate-db
+      repository: enterprise/platform/migrate-db
       # -- Specify a tag to override the version defined in .Chart.appVersion
       # @default -- `"{{ .chart.AppVersion }}"`
       tag: ""

--- a/marketplace/azure/platform/Makefile
+++ b/marketplace/azure/platform/Makefile
@@ -4,7 +4,7 @@ SRC_REGISTRY ?= cr.seqera.io
 
 # Optional image overrides as registry/repository:tag.
 # When set, these take precedence over the appVersion from Chart.yaml.
-# Example: IMAGE_BACKEND=cr.seqera.io/private/nf-tower-enterprise/backend:24.1.0
+# Example: IMAGE_BACKEND=cr.seqera.io/enterprise/platform/backend:v25.3.6
 IMAGE_BACKEND ?=
 IMAGE_FRONTEND ?=
 IMAGE_CRON_MIGRATEDB ?=
@@ -42,7 +42,7 @@ copy-images:
 	 if [ -n "$(IMAGE_BACKEND)" ]; then \
 	   SRC_BACKEND="$(IMAGE_BACKEND)"; \
 	 else \
-	   SRC_BACKEND="$(SRC_REGISTRY)/private/nf-tower-enterprise/backend:$${PLATFORM_TAG}"; \
+	   SRC_BACKEND="$(SRC_REGISTRY)/enterprise/platform/backend:$${PLATFORM_TAG}"; \
 	 fi && \
 	 DST_BACKEND_TAG=$$(echo "$${SRC_BACKEND}" | rev | cut -d: -f1 | rev) && \
 	 echo -n "[1/6] $${SRC_BACKEND} → $(REGISTRY)/$(IMAGE_PREFIX)/platform/backend:$${DST_BACKEND_TAG} ... " && \
@@ -55,7 +55,7 @@ copy-images:
 	   SRC_FRONTEND="$(IMAGE_FRONTEND)"; \
 	   DST_FRONTEND_TAG=$$(echo "$${SRC_FRONTEND}" | rev | cut -d: -f1 | rev); \
 	 else \
-	   SRC_FRONTEND="$(SRC_REGISTRY)/private/nf-tower-enterprise/frontend:$${PLATFORM_TAG}-unprivileged"; \
+	   SRC_FRONTEND="$(SRC_REGISTRY)/enterprise/platform/frontend:$${PLATFORM_TAG}-unprivileged"; \
 	   DST_FRONTEND_TAG="$${PLATFORM_TAG}"; \
 	 fi && \
 	 echo -n "[2/6] $${SRC_FRONTEND} → $(REGISTRY)/$(IMAGE_PREFIX)/platform/frontend:$${DST_FRONTEND_TAG} ... " && \
@@ -67,7 +67,7 @@ copy-images:
 	 if [ -n "$(IMAGE_CRON_MIGRATEDB)" ]; then \
 	   SRC_MIGRATEDB="$(IMAGE_CRON_MIGRATEDB)"; \
 	 else \
-	   SRC_MIGRATEDB="$(SRC_REGISTRY)/private/nf-tower-enterprise/migrate-db:$${PLATFORM_TAG}"; \
+	   SRC_MIGRATEDB="$(SRC_REGISTRY)/enterprise/platform/migrate-db:$${PLATFORM_TAG}"; \
 	 fi && \
 	 DST_MIGRATEDB_TAG=$$(echo "$${SRC_MIGRATEDB}" | rev | cut -d: -f1 | rev) && \
 	 echo -n "[3/6] $${SRC_MIGRATEDB} → $(REGISTRY)/$(IMAGE_PREFIX)/platform/migrate-db:$${DST_MIGRATEDB_TAG} ... " && \
@@ -79,7 +79,7 @@ copy-images:
 	 if [ -n "$(IMAGE_STUDIOS_PROXY)" ]; then \
 	   SRC_STUDIOS_PROXY="$(IMAGE_STUDIOS_PROXY)"; \
 	 else \
-	   SRC_STUDIOS_PROXY="$(SRC_REGISTRY)/private/nf-tower-enterprise/data-studio/connect-proxy:$${STUDIOS_TAG}"; \
+	   SRC_STUDIOS_PROXY="$(SRC_REGISTRY)/enterprise/platform/data-studio/connect-proxy:$${STUDIOS_TAG}"; \
 	 fi && \
 	 DST_STUDIOS_PROXY_TAG=$$(echo "$${SRC_STUDIOS_PROXY}" | rev | cut -d: -f1 | rev) && \
 	 echo -n "[4/6] $${SRC_STUDIOS_PROXY} → $(REGISTRY)/$(IMAGE_PREFIX)/studios/connect-proxy:$${DST_STUDIOS_PROXY_TAG} ... " && \
@@ -91,7 +91,7 @@ copy-images:
 	 if [ -n "$(IMAGE_STUDIOS_SERVER)" ]; then \
 	   SRC_STUDIOS_SERVER="$(IMAGE_STUDIOS_SERVER)"; \
 	 else \
-	   SRC_STUDIOS_SERVER="$(SRC_REGISTRY)/private/nf-tower-enterprise/data-studio/connect-server:$${STUDIOS_TAG}"; \
+	   SRC_STUDIOS_SERVER="$(SRC_REGISTRY)/enterprise/platform/data-studio/connect-server:$${STUDIOS_TAG}"; \
 	 fi && \
 	 DST_STUDIOS_SERVER_TAG=$$(echo "$${SRC_STUDIOS_SERVER}" | rev | cut -d: -f1 | rev) && \
 	 echo -n "[5/6] $${SRC_STUDIOS_SERVER} → $(REGISTRY)/$(IMAGE_PREFIX)/studios/connect-server:$${DST_STUDIOS_SERVER_TAG} ... " && \
@@ -103,7 +103,7 @@ copy-images:
 	 if [ -n "$(IMAGE_PIPELINE_OPTIMIZATION)" ]; then \
 	   SRC_PIPEOPT="$(IMAGE_PIPELINE_OPTIMIZATION)"; \
 	 else \
-	   SRC_PIPEOPT="$(SRC_REGISTRY)/private/nf-tower-enterprise/groundswell:$${PIPEOPT_TAG}"; \
+	   SRC_PIPEOPT="$(SRC_REGISTRY)/enterprise/platform/groundswell:$${PIPEOPT_TAG}"; \
 	 fi && \
 	 DST_PIPEOPT_TAG=$$(echo "$${SRC_PIPEOPT}" | rev | cut -d: -f1 | rev) && \
 	 echo -n "[6/6] $${SRC_PIPEOPT} → $(REGISTRY)/$(IMAGE_PREFIX)/pipeline-optimization/groundswell:$${DST_PIPEOPT_TAG} ... " && \


### PR DESCRIPTION
Reflect announced deprecation of cr.seqera.io/private in favor of cr.seqera.io/enterprise and cr.seqera.io/ai projects.