### PR TITLE
feat: Make MCP use the platform internal endpoint, bump mcp to 1.3.0

### DIFF
--- a/charts/platform/CHANGELOG.md
+++ b/charts/platform/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `mcp`: Bump app version to 1.3.0.
 - `mcp`: `TOWER_API_ENDPOINT` now uses the internal platform service address and port (`global.platformServiceAddress`/`global.platformServicePort`) instead of the external domain.
 - Bump `agent-backend` to 1.0.0: provider configuration redesigned to support multiple LLM providers. See [agent-backend CHANGELOG](charts/agent-backend/CHANGELOG.md) for the full migration guide.
 - `agent-backend`: remove redundant Anthropic validation from NOTES.txt, add `bedrock.sandbox.runtimeArn` required validator, replace `NEXTFLOW_DOCS_USE_REDIS_INDEX` with `NEXTFLOW_DOCS_TOOL`.

--- a/charts/platform/CHANGELOG.md
+++ b/charts/platform/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `mcp`: `TOWER_API_ENDPOINT` now uses the internal platform service address and port (`global.platformServiceAddress`/`global.platformServicePort`) instead of the external domain.
 - Bump `agent-backend` to 1.0.0: provider configuration redesigned to support multiple LLM providers. See [agent-backend CHANGELOG](charts/agent-backend/CHANGELOG.md) for the full migration guide.
 - `agent-backend`: remove redundant Anthropic validation from NOTES.txt, add `bedrock.sandbox.runtimeArn` required validator, replace `NEXTFLOW_DOCS_USE_REDIS_INDEX` with `NEXTFLOW_DOCS_TOOL`.
 - Update image paths in the README and values.yaml - the chart does not hardcode `cr.seqera.io` as the registry, customers are invited to vendor the images to their private registry as well as the charts.

--- a/charts/platform/charts/mcp/CHANGELOG.md
+++ b/charts/platform/charts/mcp/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Bump appVersion to 1.3.0.
 - Update image paths in the README and values.yaml - the chart does not hardcode `cr.seqera.io` as the registry, customers are invited to vendor the images to their private registry as well as the charts.
 - `TOWER_API_ENDPOINT` now uses the internal platform service address and port (`global.platformServiceAddress`/`global.platformServicePort`) instead of the external domain, so MCP communicates with the platform over the cluster-internal network, skipping the ingress layer and removing traffic from the platform frontend container.
 

--- a/charts/platform/charts/mcp/CHANGELOG.md
+++ b/charts/platform/charts/mcp/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update image paths in the README and values.yaml - the chart does not hardcode `cr.seqera.io` as the registry, customers are invited to vendor the images to their private registry as well as the charts.
+- `TOWER_API_ENDPOINT` now uses the internal platform service address and port (`global.platformServiceAddress`/`global.platformServicePort`) instead of the external domain, so MCP communicates with the platform over the cluster-internal network, skipping the ingress layer and removing traffic from the platform frontend container.
 
 ## [0.4.0] - 2026-05-05
 

--- a/charts/platform/charts/mcp/Chart.yaml
+++ b/charts/platform/charts/mcp/Chart.yaml
@@ -23,7 +23,7 @@ description: |
   RAG-based natural language interactions.
 type: application
 version: 0.4.1
-appVersion: "1.1.0"
+appVersion: "1.3.0"
 maintainers:
   - name: Seqera Labs
     email: devops@seqera.io

--- a/charts/platform/charts/mcp/README.md
+++ b/charts/platform/charts/mcp/README.md
@@ -4,7 +4,7 @@ A Model Context Protocol (MCP) server that provides comprehensive access to the 
 Wave container provisioning, bioinformatics data, and nf-core modules through intelligent
 RAG-based natural language interactions.
 
-![Version: 0.4.1](https://img.shields.io/badge/Version-0.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
+![Version: 0.4.1](https://img.shields.io/badge/Version-0.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.0](https://img.shields.io/badge/AppVersion-1.3.0-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -29,7 +29,7 @@ The required values to set in order to have a working installation are:
 
 The Helm chart comes with several requirement checks that will validate the provided configuration before proceeding with the installation.
 
-By default the chart selects the application images defined in the `appVersion` field of the `Chart.yaml` file, currently set as `1.1.0`.
+By default the chart selects the application images defined in the `appVersion` field of the `Chart.yaml` file, currently set as `1.3.0`.
 
 When a sensitive value is required (e.g. the database password), you can either provide it directly in the values file or reference an existing Kubernetes Secret containing the value. The key names to use in the provided Secret are specified in the values file comments.
 Sensitive values provided as plain text by the user are always stored in a Kubernetes Secret created by the chart. When an external Secret is used instead, the chart instructs the components to read the sensitive value from the external Secret directly, without further storing copies of the sensitive value in the chart-created Secret.

--- a/charts/platform/charts/mcp/templates/configmap.yaml
+++ b/charts/platform/charts/mcp/templates/configmap.yaml
@@ -34,7 +34,7 @@ data:
   MCP_SERVER_URL: {{ printf "https://%s" (tpl .Values.global.mcpDomain $) | quote }}
   MICRONAUT_ENVIRONMENTS: {{ .Values.micronautEnvironments | join "," | quote }}
 
-  TOWER_API_ENDPOINT: {{ printf "https://%s/api" (tpl .Values.global.platformExternalDomain $) | quote }}
+  TOWER_API_ENDPOINT: {{ printf "http://%s:%s" (tpl .Values.global.platformServiceAddress $) (toString .Values.global.platformServicePort) | quote }}
   HUB_API_ENDPOINT: {{ tpl .Values.hubApiEndpoint $ | quote }}
   WAVE_API_ENDPOINT: {{ tpl .Values.waveApiEndpoint $ | quote }}
   REGISTRY_API_ENDPOINT: {{ tpl .Values.registryApiEndpoint $ | quote }}

--- a/charts/platform/charts/mcp/tests/__snapshot__/configmap_test.yaml.snap
+++ b/charts/platform/charts/mcp/tests/__snapshot__/configmap_test.yaml.snap
@@ -9,7 +9,7 @@ should render a ConfigMap with default values:
       MICRONAUT_ENVIRONMENTS: oauth-platform
       MICRONAUT_SERVER_PORT: "6010"
       REGISTRY_API_ENDPOINT: https://registry.nextflow.io
-      TOWER_API_ENDPOINT: https://test.example.com/api
+      TOWER_API_ENDPOINT: http://release-name-platform-backend:8080
       WAVE_API_ENDPOINT: https://wave.seqera.io
     kind: ConfigMap
     metadata:

--- a/charts/platform/charts/mcp/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/platform/charts/mcp/tests/__snapshot__/deployment_test.yaml.snap
@@ -21,7 +21,7 @@ should render a Deployment with default values:
       template:
         metadata:
           annotations:
-            checksum/configmap: 16f769ed028fde925ece3abfcb4bf4d07ef7afa2bfb2516c2f683e336d5af811
+            checksum/configmap: 131d459188a558e18ce5b09f1d9f3d992733e6fbe2278b6b8ab48e068461bfa4
             checksum/secret: c02f86a51632209a540a8a0e36bd7bf3aadaf054e628be683b4c60c100b3e3b5
           labels:
             app.kubernetes.io/component: mcp

--- a/charts/platform/charts/mcp/tests/configmap_test.yaml
+++ b/charts/platform/charts/mcp/tests/configmap_test.yaml
@@ -27,6 +27,8 @@ tests:
   - it: should render a ConfigMap with default values
     set:
       global.platformExternalDomain: test.example.com
+      global.platformServiceAddress: "release-name-platform-backend"
+      global.platformServicePort: 8080
     asserts:
       - isKind:
           of: ConfigMap
@@ -51,6 +53,8 @@ tests:
 
   - it: should include OAuth settings in configmap
     set:
+      global.platformServiceAddress: "platform-backend"
+      global.platformServicePort: 8080
       oauth:
         issuerUrl: https://auth.example.com
         audience: mcp
@@ -61,7 +65,7 @@ tests:
             MICRONAUT_SERVER_PORT: "6010"
             MCP_SERVER_URL: "https://mcp.example.com"
             MICRONAUT_ENVIRONMENTS: "oauth-platform"
-            TOWER_API_ENDPOINT: "https://example.com/api"
+            TOWER_API_ENDPOINT: "http://platform-backend:8080"
             HUB_API_ENDPOINT: "https://hub.seqera.io"
             WAVE_API_ENDPOINT: "https://wave.seqera.io"
             REGISTRY_API_ENDPOINT: "https://registry.nextflow.io"
@@ -71,6 +75,8 @@ tests:
   - it: should template values in configmap
     set:
       global.platformExternalDomain: example.com
+      global.platformServiceAddress: "platform-backend"
+      global.platformServicePort: 8080
       global.mcpDomain: mcp.example.com
       hubApiEndpoint: "https://hub.{{ .Values.global.platformExternalDomain }}"
       waveApiEndpoint: "https://wave.{{ .Values.global.platformExternalDomain }}"
@@ -85,7 +91,7 @@ tests:
             MICRONAUT_SERVER_PORT: "6010"
             MCP_SERVER_URL: "https://mcp.example.com"
             MICRONAUT_ENVIRONMENTS: "oauth-platform"
-            TOWER_API_ENDPOINT: "https://example.com/api"
+            TOWER_API_ENDPOINT: "http://platform-backend:8080"
             HUB_API_ENDPOINT: "https://hub.example.com"
             WAVE_API_ENDPOINT: "https://wave.example.com"
             REGISTRY_API_ENDPOINT: "https://registry.example.com"


### PR DESCRIPTION
This PR makes MCP use the platform internal kubernetes service name instead of the public DNS name, skipping several hops and reducing traffic.

Also bump mcp to 1.3.0.