### PR TITLE
chore: Fetch the gh-pages branch before running chart-releaser

### DIFF
--- a/.github/workflows/build-helm-charts.yaml
+++ b/.github/workflows/build-helm-charts.yaml
@@ -171,6 +171,8 @@ jobs:
           # are hosted as GitHub Release assets (uploaded in the previous step);
           # cr uses this directory to discover which charts to include and queries
           # the GitHub API to resolve each one to its release-asset URL.
+          git fetch origin gh-pages
+
           mkdir -p .cr-release-packages .cr-index
           for chart in $charts_to_package; do
             chart_name=$(yq -r '.name' ${chart}/Chart.yaml)


### PR DESCRIPTION
See the failure on yesterday's action: https://github.com/seqeralabs/helm-charts/actions/runs/25740378194/job/75588770408#step:13:39