### PR TITLE
fix: add wave to enterprise micronaut environments

### DIFF
--- a/charts/platform/CHANGELOG.md
+++ b/charts/platform/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.33.4] - 2026-05-14
+
+### Fixed
+
+- Add `wave` to the cron pod's `micronautEnvironments` so cron can resolve wave-related configuration in enterprise deployments.
+
 ## [0.33.3] - 2026-05-13
 
 ### Changed

--- a/charts/platform/Chart.yaml
+++ b/charts/platform/Chart.yaml
@@ -37,7 +37,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.33.3
+version: 0.33.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/platform/templates/_helpers.tpl
+++ b/charts/platform/templates/_helpers.tpl
@@ -119,8 +119,8 @@ Build the backend micronaut envs list: add envs if features are requested in oth
 {{- $list = append $list "ha" -}}
 {{- $list = append $list "oauth-client" -}}
   {{/* Add wave to the list of microenvs if waveServerUrl is defined. */}}
-  {{- if not (empty .Values.platform.waveServerUrl) -}}
-{{- $list = append $list "wave" -}}
+  {{- if tpl .Values.platform.waveServerUrl $ -}}
+    {{- $list = append $list "wave" -}}
   {{- end -}}
   {{- /* Add groundswell to the list of microenvs if pipeline-optimization is enabled. */}}
   {{- if (index .Values "pipeline-optimization" "enabled") -}}
@@ -138,7 +138,7 @@ Build the cron micronaut envs list: add envs if features are requested in other 
 {{- $list = append $list "redis" -}}
 {{- $list = append $list "cron" -}}
   {{/* Add wave to the list of microenvs if waveServerUrl is defined. */}}
-  {{- if not (empty .Values.platform.waveServerUrl) -}}
+  {{- if tpl .Values.platform.waveServerUrl $ -}}
 {{- $list = append $list "wave" -}}
   {{- end -}}
 {{- uniq $list | join "," | quote -}}

--- a/charts/platform/templates/_helpers.tpl
+++ b/charts/platform/templates/_helpers.tpl
@@ -137,6 +137,10 @@ Build the cron micronaut envs list: add envs if features are requested in other 
 {{- $list = append $list "prod" -}}
 {{- $list = append $list "redis" -}}
 {{- $list = append $list "cron" -}}
+  {{/* Add wave to the list of microenvs if waveServerUrl is defined. */}}
+  {{- if not (empty .Values.platform.waveServerUrl) -}}
+{{- $list = append $list "wave" -}}
+  {{- end -}}
 {{- uniq $list | join "," | quote -}}
 {{- end -}}
 

--- a/charts/platform/templates/_helpers.tpl
+++ b/charts/platform/templates/_helpers.tpl
@@ -120,7 +120,7 @@ Build the backend micronaut envs list: add envs if features are requested in oth
 {{- $list = append $list "oauth-client" -}}
   {{/* Add wave to the list of microenvs if waveServerUrl is defined. */}}
   {{- if tpl .Values.platform.waveServerUrl $ -}}
-    {{- $list = append $list "wave" -}}
+{{- $list = append $list "wave" -}}
   {{- end -}}
   {{- /* Add groundswell to the list of microenvs if pipeline-optimization is enabled. */}}
   {{- if (index .Values "pipeline-optimization" "enabled") -}}

--- a/charts/platform/tests/__snapshot__/deployment-backend_test.yaml.snap
+++ b/charts/platform/tests/__snapshot__/deployment-backend_test.yaml.snap
@@ -225,7 +225,7 @@ should render the backend deployment with the correct checksums, labels and anno
       template:
         metadata:
           annotations:
-            checksum/configmap: c9a805ab3c4b5dfce03f5b278b9460a812ac4af42e8292b8f0b0999c9df03e8a
+            checksum/configmap: 196b3b267b33da4a661d272d6a7e5b92f13f24886a2d1c61c1a4534f7bc416f4
             checksum/secret: d3b5ca20c437b2faa4af1b549c817ee78cc2a992f86741120f01bd93a30d4873
             common-annotation-key: common-annotation-value
             pod-annotation-key: pod-annotation-value

--- a/charts/platform/tests/__snapshot__/deployment-cron_test.yaml.snap
+++ b/charts/platform/tests/__snapshot__/deployment-cron_test.yaml.snap
@@ -221,7 +221,7 @@ should render the cron deployment with the correct checksums, labels and annotat
       template:
         metadata:
           annotations:
-            checksum/configmap: c9a805ab3c4b5dfce03f5b278b9460a812ac4af42e8292b8f0b0999c9df03e8a
+            checksum/configmap: 196b3b267b33da4a661d272d6a7e5b92f13f24886a2d1c61c1a4534f7bc416f4
             checksum/secret: d3b5ca20c437b2faa4af1b549c817ee78cc2a992f86741120f01bd93a30d4873
             common-annotation-key: common-annotation-value
             pod-annotation-key: pod-annotation-value

--- a/charts/platform/tests/configmap_test.yaml
+++ b/charts/platform/tests/configmap_test.yaml
@@ -39,7 +39,7 @@ tests:
   - equal:
       path: data
       value:
-        MICRONAUT_ENVIRONMENTS: prod,redis,cron
+        MICRONAUT_ENVIRONMENTS: prod,redis,cron,wave
         TOWER_CRON_SERVER_PORT: '8082'
 
 - it: should setup requested micronaut envs for cron when required, in addition to the mandatory ones
@@ -57,7 +57,19 @@ tests:
       of: ConfigMap
   - equal:
       path: data.MICRONAUT_ENVIRONMENTS
-      value: prod,whatever1,whatever2,redis,cron
+      value: prod,whatever1,whatever2,redis,cron,wave
+
+- it: should not include wave in cron micronaut envs when waveServerUrl is empty
+  documentSelector:
+    path: metadata.name
+    value: release-name-platform-cron
+  set:
+    platform:
+      waveServerUrl: ""
+  asserts:
+  - equal:
+      path: data.MICRONAUT_ENVIRONMENTS
+      value: prod,redis,cron
 
 - it: should not include TOWER_DATA_STUDIO_CONNECT_URL when studios is disabled
   documentSelector:

--- a/charts/platform/values.yaml
+++ b/charts/platform/values.yaml
@@ -933,7 +933,7 @@ cron:
     #   - myRegistryKeySecretName
 
   # -- List of Micronaut Environments to enable on the cron pod
-  micronautEnvironments: [prod, redis, cron]
+  micronautEnvironments: [prod, redis, cron, wave]
 
   service:
     # -- Cron Service type.

--- a/charts/platform/values.yaml
+++ b/charts/platform/values.yaml
@@ -933,7 +933,7 @@ cron:
     #   - myRegistryKeySecretName
 
   # -- List of Micronaut Environments to enable on the cron pod
-  micronautEnvironments: [prod, redis, cron, wave]
+  micronautEnvironments: [prod, redis, cron]
 
   service:
     # -- Cron Service type.


### PR DESCRIPTION
I noticed that enterprise stage cron is missing wave micronaut environment. It is required for the proper functionality of studios integration with wave.