### PR TITLE
fix: update portal web endpoint schema to https in platform

### DIFF
--- a/charts/platform/CHANGELOG.md
+++ b/charts/platform/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.33.5] - 2026-05-14
+
+### Fixed
+
+- Use proper https:// schema in `TOWER_SEQERA_AI_PORTAL_URL` env var value.
+
 ## [0.33.4] - 2026-05-14
 
 ### Fixed

--- a/charts/platform/Chart.yaml
+++ b/charts/platform/Chart.yaml
@@ -37,7 +37,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.33.4
+version: 0.33.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/platform/README.md
+++ b/charts/platform/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart to deploy Seqera Platform (also referred to as Tower) on Kubernetes.
 
-![Version: 0.33.3](https://img.shields.io/badge/Version-0.33.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v25.3.4](https://img.shields.io/badge/AppVersion-v25.3.4-informational?style=flat-square)
+![Version: 0.33.5](https://img.shields.io/badge/Version-0.33.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v25.3.4](https://img.shields.io/badge/AppVersion-v25.3.4-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -41,7 +41,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/platform \
-  --version 0.33.3 \
+  --version 0.33.5 \
   --namespace my-namespace \
   --create-namespace
 ```

--- a/charts/platform/templates/configmap.yaml
+++ b/charts/platform/templates/configmap.yaml
@@ -43,7 +43,7 @@ data:
 {{- include "platform.studios.toolsEnvVars" . | nindent 2 }}
 {{- end }}
 {{- if (index .Values "portal-web" "enabled") }}
-  TOWER_SEQERA_AI_PORTAL_URL: {{ printf "http://%s" (tpl .Values.global.portalWebDomain $) | quote }}
+  TOWER_SEQERA_AI_PORTAL_URL: {{ printf "https://%s" (tpl .Values.global.portalWebDomain $) | quote }}
 {{- end }}
 ---
 kind: ConfigMap

--- a/charts/platform/tests/__snapshot__/configmap_test.yaml.snap
+++ b/charts/platform/tests/__snapshot__/configmap_test.yaml.snap
@@ -40,7 +40,7 @@ should render Studios tools environment variables when studios is enabled with d
       TOWER_DATA_STUDIO_TEMPLATES_XPRA_TOOL: xpra
       TOWER_DATA_STUDIO_WAVE_CUSTOM_IMAGE_REGISTRY: ""
       TOWER_DATA_STUDIO_WAVE_CUSTOM_IMAGE_REPOSITORY: ""
-      TOWER_SEQERA_AI_PORTAL_URL: http://ai.example.com
+      TOWER_SEQERA_AI_PORTAL_URL: https://ai.example.com
     kind: ConfigMap
     metadata:
       annotations: {}
@@ -98,7 +98,7 @@ should render custom Studios tool when provided:
       TOWER_DATA_STUDIO_TEMPLATES_XPRA_TOOL: xpra
       TOWER_DATA_STUDIO_WAVE_CUSTOM_IMAGE_REGISTRY: ""
       TOWER_DATA_STUDIO_WAVE_CUSTOM_IMAGE_REPOSITORY: ""
-      TOWER_SEQERA_AI_PORTAL_URL: http://ai.example.com
+      TOWER_SEQERA_AI_PORTAL_URL: https://ai.example.com
     kind: ConfigMap
     metadata:
       annotations: {}
@@ -164,7 +164,7 @@ should render custom Studios tool with deprecated and experimental versions when
       TOWER_DATA_STUDIO_TEMPLATES_XPRA_TOOL: xpra
       TOWER_DATA_STUDIO_WAVE_CUSTOM_IMAGE_REGISTRY: ""
       TOWER_DATA_STUDIO_WAVE_CUSTOM_IMAGE_REPOSITORY: ""
-      TOWER_SEQERA_AI_PORTAL_URL: http://ai.example.com
+      TOWER_SEQERA_AI_PORTAL_URL: https://ai.example.com
     kind: ConfigMap
     metadata:
       annotations: {}

--- a/charts/platform/tests/__snapshot__/deployment-backend_test.yaml.snap
+++ b/charts/platform/tests/__snapshot__/deployment-backend_test.yaml.snap
@@ -225,7 +225,7 @@ should render the backend deployment with the correct checksums, labels and anno
       template:
         metadata:
           annotations:
-            checksum/configmap: 196b3b267b33da4a661d272d6a7e5b92f13f24886a2d1c61c1a4534f7bc416f4
+            checksum/configmap: e8cdbc296baf4e08c9a7cc3f4eb72a77786caea93ed5f5c8edfa60ab2cc8e4fa
             checksum/secret: d3b5ca20c437b2faa4af1b549c817ee78cc2a992f86741120f01bd93a30d4873
             common-annotation-key: common-annotation-value
             pod-annotation-key: pod-annotation-value

--- a/charts/platform/tests/__snapshot__/deployment-cron_test.yaml.snap
+++ b/charts/platform/tests/__snapshot__/deployment-cron_test.yaml.snap
@@ -221,7 +221,7 @@ should render the cron deployment with the correct checksums, labels and annotat
       template:
         metadata:
           annotations:
-            checksum/configmap: 196b3b267b33da4a661d272d6a7e5b92f13f24886a2d1c61c1a4534f7bc416f4
+            checksum/configmap: e8cdbc296baf4e08c9a7cc3f4eb72a77786caea93ed5f5c8edfa60ab2cc8e4fa
             checksum/secret: d3b5ca20c437b2faa4af1b549c817ee78cc2a992f86741120f01bd93a30d4873
             common-annotation-key: common-annotation-value
             pod-annotation-key: pod-annotation-value

--- a/charts/platform/tests/configmap_test.yaml
+++ b/charts/platform/tests/configmap_test.yaml
@@ -409,7 +409,7 @@ tests:
   asserts:
   - equal:
       path: data.TOWER_SEQERA_AI_PORTAL_URL
-      value: http://ai.example.com
+      value: https://ai.example.com
 
 - it: should render TOWER_SEQERA_AI_PORTAL_URL using a custom portalWebDomain when portal-web is enabled
   documentSelector:
@@ -423,7 +423,7 @@ tests:
   asserts:
   - equal:
       path: data.TOWER_SEQERA_AI_PORTAL_URL
-      value: http://portal.custom.example.org
+      value: https://portal.custom.example.org
 
 - it: should not render TOWER_SEQERA_AI_PORTAL_URL when portal-web is disabled
   documentSelector:
@@ -458,7 +458,7 @@ tests:
         GROUNDSWELL_SERVER_URL: http://RELEASE-NAME-pipeline-optimization:8090
         MICRONAUT_ENVIRONMENTS: prod,redis,ha,oauth-client,wave,groundswell
         TOWER_DATA_EXPLORER_ENABLED: 'false'
-        TOWER_SEQERA_AI_PORTAL_URL: http://ai.example.com
+        TOWER_SEQERA_AI_PORTAL_URL: https://ai.example.com
 
 - it: should render TOWER_OIDC_PEM_PATH in the shared-backend-cron configmap regardless of studios.enabled
   documentSelector:


### PR DESCRIPTION
I noticed that platform backend v25.3 was failing with an error due to the schema not being https