### PR TITLE
refactor: consistent naming for redis database index

### DIFF
--- a/charts/platform/CHANGELOG.md
+++ b/charts/platform/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.33.7] - 2026-05-15
+
+### Changed
+
+- Update agent-backend to 1.0.2 (rename `redis.db` to `redis.database`, with fallback).
+- Update wave to 0.2.3 (rename `redis.db` to `redis.database`, was not referenced in templates yet).
+
 ## [0.33.6] - 2026-05-14
 
 ### Changed

--- a/charts/platform/Chart.lock
+++ b/charts/platform/Chart.lock
@@ -13,15 +13,15 @@ dependencies:
   version: 1.4.1
 - name: wave
   repository: file://charts/wave
-  version: 0.2.2
+  version: 0.2.3
 - name: mcp
   repository: file://charts/mcp
   version: 0.4.1
 - name: agent-backend
   repository: file://charts/agent-backend
-  version: 1.0.1
+  version: 1.0.2
 - name: portal-web
   repository: file://charts/portal-web
   version: 0.3.2
-digest: sha256:13bf2abdc12ad0782eab052065837ee5b5edee59ae03fc8d2b3bc576548475b1
-generated: "2026-05-12T12:30:11.733560019+02:00"
+digest: sha256:314337355882cd7799e4582cd7ccc6bcda2811bbcb3a759d79c041a48d166b1d
+generated: "2026-05-15T13:00:51.669433+02:00"

--- a/charts/platform/Chart.yaml
+++ b/charts/platform/Chart.yaml
@@ -37,7 +37,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.33.6
+version: 0.33.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/platform/README.md
+++ b/charts/platform/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart to deploy Seqera Platform (also referred to as Tower) on Kubernetes.
 
-![Version: 0.33.6](https://img.shields.io/badge/Version-0.33.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v25.3.4](https://img.shields.io/badge/AppVersion-v25.3.4-informational?style=flat-square)
+![Version: 0.33.7](https://img.shields.io/badge/Version-0.33.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v25.3.4](https://img.shields.io/badge/AppVersion-v25.3.4-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -41,7 +41,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/platform \
-  --version 0.33.6 \
+  --version 0.33.7 \
   --namespace my-namespace \
   --create-namespace
 ```

--- a/charts/platform/charts/agent-backend/CHANGELOG.md
+++ b/charts/platform/charts/agent-backend/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] - 2026-05-15
+
+### Changed
+
+- Rename `redis.db` to `redis.database` for consistency with other charts. The old `redis.db` key is still accepted as a fallback.
+
 ## [1.0.1] - 2026-05-14
 
 ### Changed

--- a/charts/platform/charts/agent-backend/Chart.yaml
+++ b/charts/platform/charts/agent-backend/Chart.yaml
@@ -19,7 +19,7 @@ apiVersion: v2
 name: agent-backend
 description: Backend service for Seqera CLI AI capabilities
 type: application
-version: 1.0.1
+version: 1.0.2
 appVersion: "1.10.0"
 maintainers:
   - name: Seqera Labs

--- a/charts/platform/charts/agent-backend/README.md
+++ b/charts/platform/charts/agent-backend/README.md
@@ -2,7 +2,7 @@
 
 Backend service for Seqera CLI AI capabilities
 
-![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.10.0](https://img.shields.io/badge/AppVersion-1.10.0-informational?style=flat-square)
+![Version: 1.0.2](https://img.shields.io/badge/Version-1.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.10.0](https://img.shields.io/badge/AppVersion-1.10.0-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -45,7 +45,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/agent-backend \
-  --version 1.0.1 \
+  --version 1.0.2 \
   --namespace my-namespace \
   --create-namespace
 ```
@@ -110,7 +110,7 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | database.sslCa | string | `""` | Path to a CA certificate file for server certificate verification |
 | redis.host | string | `""` | Redis hostname |
 | redis.port | int | `6379` | Redis port |
-| redis.db | int | `0` | Redis database index |
+| redis.database | int | `0` | Redis database index |
 | redis.enableTls | bool | `false` | Enable TLS when connecting to Redis |
 | redis.password | string | `""` | Redis password |
 | redis.existingSecretName | string | `""` | Name of an existing Secret containing the Redis password, as an alternative to the password field. Note: the Secret must already exist in the same namespace at the time of deployment |

--- a/charts/platform/charts/agent-backend/templates/configmap.yaml
+++ b/charts/platform/charts/agent-backend/templates/configmap.yaml
@@ -48,7 +48,7 @@ data:
 
   AGENT_BACKEND_REDIS_HOST: {{ tpl .Values.redis.host . | quote }}
   AGENT_BACKEND_REDIS_PORT: {{ .Values.redis.port | quote }}
-  AGENT_BACKEND_REDIS_DB: {{ .Values.redis.db | quote }}
+  AGENT_BACKEND_REDIS_DB: {{ coalesce .Values.redis.database .Values.redis.db | default 0 | quote }}
   AGENT_BACKEND_REDIS_TLS: {{ .Values.redis.enableTls | quote }}
 
 {{- include "agent-backend.validateProviders" . | nindent 0 }}

--- a/charts/platform/charts/agent-backend/tests/configmap_test.yaml
+++ b/charts/platform/charts/agent-backend/tests/configmap_test.yaml
@@ -313,7 +313,7 @@ tests:
     set:
       redis.host: redis.example.com
       redis.port: 6380
-      redis.db: 5
+      redis.database: 5
       redis.enableTls: true
     asserts:
       - equal:

--- a/charts/platform/charts/agent-backend/values.yaml
+++ b/charts/platform/charts/agent-backend/values.yaml
@@ -176,7 +176,7 @@ redis:
   # -- Redis port
   port: 6379
   # -- Redis database index
-  db: 0
+  database: 0
   # -- Enable TLS when connecting to Redis
   enableTls: false
   # -- Redis password

--- a/charts/platform/charts/wave/CHANGELOG.md
+++ b/charts/platform/charts/wave/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.3] - 2026-05-15
+
+### Changed
+
+- Rename `redis.db` to `redis.database` for consistency with other charts (value was not actually referenced in any wave template yet).
+
 ## [0.2.2] - 2026-05-13
 
 ### Changed

--- a/charts/platform/charts/wave/Chart.yaml
+++ b/charts/platform/charts/wave/Chart.yaml
@@ -19,7 +19,7 @@ apiVersion: v2
 name: wave
 description: Wave
 type: application
-version: 0.2.2
+version: 0.2.3
 appVersion: "v1.32.4"
 maintainers:
   - name: Seqera Labs

--- a/charts/platform/charts/wave/README.md
+++ b/charts/platform/charts/wave/README.md
@@ -2,7 +2,7 @@
 
 Wave
 
-![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.32.4](https://img.shields.io/badge/AppVersion-v1.32.4-informational?style=flat-square)
+![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.32.4](https://img.shields.io/badge/AppVersion-v1.32.4-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -35,7 +35,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/wave \
-  --version 0.2.2 \
+  --version 0.2.3 \
   --namespace my-namespace \
   --create-namespace
 ```
@@ -79,7 +79,7 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | database.enableTls | bool | `false` | Enable TLS for the PostgreSQL database connection |
 | redis.host | string | `""` | Redis hostname |
 | redis.port | int | `6379` | Redis port |
-| redis.db | int | `0` | Redis database index |
+| redis.database | int | `0` | Redis database index |
 | redis.enableTls | bool | `false` | Enable TLS when connecting to Redis |
 | redis.password | string | `""` | Redis password |
 | redis.existingSecretName | string | `""` | Name of an existing Secret containing the Redis password, as an alternative to the password field. Note: the Secret must already exist in the same namespace at the time of deployment |

--- a/charts/platform/charts/wave/values.yaml
+++ b/charts/platform/charts/wave/values.yaml
@@ -101,7 +101,7 @@ redis:
   # -- Redis port
   port: 6379
   # -- Redis database index
-  db: 0
+  database: 0
   # -- Enable TLS when connecting to Redis
   enableTls: false
   # -- Redis password


### PR DESCRIPTION
## Changes
Rename `redis.db` to `redis.database` across charts for consistency (studios chart already used `redis.database`)

Standardises the Redis database index key to redis.database in agent-backend and wave, matching the existing convention in studios. 
- The old redis.db key continues to work in agent-backend via a coalesce fallback, so existing deployments are not broken.
- In the wave charts the value was not used, referenced yet
Charts bumped: agent-backend → 1.0.2, wave → 0.2.3, platform → 0.33.7