### PR TITLE
fix: do not render ANTHROPIC_API_KEY in Secret when apiKey is empty

### DIFF
--- a/charts/platform/CHANGELOG.md
+++ b/charts/platform/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update Platform application version to v26.1.0.
 - Update Studios template naming from RStudio to R-IDE.
+- Update agent-backend to 1.0.4 (do not render `ANTHROPIC_API_KEY` in the Secret when `anthropic.apiKey` is empty and no `existingSecretName` is set).
 
 ## [0.33.8] - 2026-05-22
 

--- a/charts/platform/CHANGELOG.md
+++ b/charts/platform/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update Platform application version to v26.1.0.
 - Update Studios template naming from RStudio to R-IDE.
 - Update agent-backend to 1.0.4 (do not render `ANTHROPIC_API_KEY` in the Secret when `anthropic.apiKey` is empty and no `existingSecretName` is set).
+- Bump bitnami/common to 2.40.0 on platform chart and across all subcharts: agent-backend to 1.0.5, mcp to 0.4.2, pipeline-optimization to 2.0.9, portal-web to 0.3.4, studios to 1.4.2, wave to 0.2.4, seqera-common to 2.1.3.
 
 ## [0.33.8] - 2026-05-22
 

--- a/charts/platform/Chart.lock
+++ b/charts/platform/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.39.0
+  version: 2.40.0
 - name: seqera-common
   repository: file://../seqera-common
   version: 2.1.2
@@ -19,9 +19,9 @@ dependencies:
   version: 0.4.1
 - name: agent-backend
   repository: file://charts/agent-backend
-  version: 1.0.2
+  version: 1.0.4
 - name: portal-web
   repository: file://charts/portal-web
-  version: 0.3.2
-digest: sha256:314337355882cd7799e4582cd7ccc6bcda2811bbcb3a759d79c041a48d166b1d
-generated: "2026-05-15T13:00:51.669433+02:00"
+  version: 0.3.3
+digest: sha256:e700caf7cfaa416ddd63c068fb4f9000b8a9ec17ed3ba45991fc714327086b1b
+generated: "2026-06-01T11:40:48.64805702+02:00"

--- a/charts/platform/charts/agent-backend/CHANGELOG.md
+++ b/charts/platform/charts/agent-backend/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.5] - 2026-06-01
+
+### Changed
+
+- Bump bitnami/common dependency to 2.40.0.
+
 ## [1.0.4] - 2026-05-29
 
 ### Fixed

--- a/charts/platform/charts/agent-backend/CHANGELOG.md
+++ b/charts/platform/charts/agent-backend/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.4] - 2026-05-29
+
+### Fixed
+
+- Do not render `ANTHROPIC_API_KEY` in the Secret when `anthropic.apiKey` is empty and no `existingSecretName` is set.
+
 ## [1.0.3] - 2026-05-22
 
 ### Changed

--- a/charts/platform/charts/agent-backend/Chart.lock
+++ b/charts/platform/charts/agent-backend/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.39.0
+  version: 2.40.0
 - name: seqera-common
   repository: file://../../../seqera-common
   version: 2.1.2
-digest: sha256:3eac4511073f329f614981ce9b91e6cdda035aa007a3aeecd7069958c9ede539
-generated: "2026-05-05T14:17:14.074321992+02:00"
+digest: sha256:c32497a216446a0420343b4dc90d289f834f54aba4dcaa8030b4b1ff81ed41ef
+generated: "2026-06-01T11:41:04.352552776+02:00"

--- a/charts/platform/charts/agent-backend/Chart.yaml
+++ b/charts/platform/charts/agent-backend/Chart.yaml
@@ -19,7 +19,7 @@ apiVersion: v2
 name: agent-backend
 description: Backend service for Seqera CLI AI capabilities
 type: application
-version: 1.0.3
+version: 1.0.4
 appVersion: "1.11.0"
 maintainers:
   - name: Seqera Labs

--- a/charts/platform/charts/agent-backend/Chart.yaml
+++ b/charts/platform/charts/agent-backend/Chart.yaml
@@ -19,7 +19,7 @@ apiVersion: v2
 name: agent-backend
 description: Backend service for Seqera CLI AI capabilities
 type: application
-version: 1.0.4
+version: 1.0.5
 appVersion: "1.11.0"
 maintainers:
   - name: Seqera Labs

--- a/charts/platform/charts/agent-backend/README.md
+++ b/charts/platform/charts/agent-backend/README.md
@@ -2,7 +2,7 @@
 
 Backend service for Seqera CLI AI capabilities
 
-![Version: 1.0.3](https://img.shields.io/badge/Version-1.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.11.0](https://img.shields.io/badge/AppVersion-1.11.0-informational?style=flat-square)
+![Version: 1.0.4](https://img.shields.io/badge/Version-1.0.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.11.0](https://img.shields.io/badge/AppVersion-1.11.0-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -45,7 +45,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/agent-backend \
-  --version 1.0.3 \
+  --version 1.0.4 \
   --namespace my-namespace \
   --create-namespace
 ```

--- a/charts/platform/charts/agent-backend/README.md
+++ b/charts/platform/charts/agent-backend/README.md
@@ -2,7 +2,7 @@
 
 Backend service for Seqera CLI AI capabilities
 
-![Version: 1.0.4](https://img.shields.io/badge/Version-1.0.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.11.0](https://img.shields.io/badge/AppVersion-1.11.0-informational?style=flat-square)
+![Version: 1.0.5](https://img.shields.io/badge/Version-1.0.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.11.0](https://img.shields.io/badge/AppVersion-1.11.0-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -45,7 +45,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/agent-backend \
-  --version 1.0.4 \
+  --version 1.0.5 \
   --namespace my-namespace \
   --create-namespace
 ```

--- a/charts/platform/charts/agent-backend/templates/secret.yaml
+++ b/charts/platform/charts/agent-backend/templates/secret.yaml
@@ -38,7 +38,7 @@ data:
 {{- if not (include "agent-backend.database.existingSecret" .) }}
   AGENT_BACKEND_DB_PASSWORD: {{ include "common.secrets.passwords.manage" (dict "secret" (include "agent-backend.database.existingSecret.secretName" .) "key" (include "agent-backend.database.existingSecret.secretKey" .) "providedValues" (list "database.password") "context" $ "honorProvidedValues" true) }}
 {{- end }}
-{{- if not (include "agent-backend.anthropic.existingSecret" .) }}
+{{- if and (not (include "agent-backend.anthropic.existingSecret" .)) .Values.anthropic.apiKey }}
   ANTHROPIC_API_KEY: {{ include "common.secrets.passwords.manage" (dict "secret" (include "agent-backend.anthropic.existingSecret.secretName" .) "key" (include "agent-backend.anthropic.existingSecret.secretKey" .) "providedValues" (list "anthropic.apiKey") "context" $ "honorProvidedValues" true) }}
 {{- end }}
 {{- if not (include "agent-backend.tokenEncryptionKey.existingSecret" .) }}

--- a/charts/platform/charts/agent-backend/tests/secret_test.yaml
+++ b/charts/platform/charts/agent-backend/tests/secret_test.yaml
@@ -57,6 +57,11 @@ tests:
       - isNotNull:
           path: data.ANTHROPIC_API_KEY
 
+  - it: should NOT include ANTHROPIC_API_KEY when anthropic.apiKey is empty and no existingSecret is set
+    asserts:
+      - isNull:
+          path: data.ANTHROPIC_API_KEY
+
   - it: should NOT include ANTHROPIC_API_KEY when using external secret
     set:
       anthropic.existingSecretName: my-anthropic-secret

--- a/charts/platform/charts/mcp/CHANGELOG.md
+++ b/charts/platform/charts/mcp/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.2] - 2026-06-01
+
+### Changed
+
+- Bump bitnami/common dependency to 2.40.0.
+
 ## [0.4.1] - 2026-05-11
 
 ### Added

--- a/charts/platform/charts/mcp/Chart.lock
+++ b/charts/platform/charts/mcp/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.39.0
+  version: 2.40.0
 - name: seqera-common
   repository: file://../../../seqera-common
   version: 2.1.2
-digest: sha256:b66829bad11b646116b1ac6fc712849c4231dfbb6641380100f3282e06ab9a39
-generated: "2026-05-05T14:17:42.984593108+02:00"
+digest: sha256:6ba9920dedbfbf65d95efe62ede376e3bb4f28872727d78a2d1920918ebae991
+generated: "2026-06-01T11:41:25.783680785+02:00"

--- a/charts/platform/charts/mcp/Chart.yaml
+++ b/charts/platform/charts/mcp/Chart.yaml
@@ -22,7 +22,7 @@ description: |
   Wave container provisioning, bioinformatics data, and nf-core modules through intelligent
   RAG-based natural language interactions.
 type: application
-version: 0.4.1
+version: 0.4.2
 appVersion: "1.3.0"
 maintainers:
   - name: Seqera Labs

--- a/charts/platform/charts/mcp/README.md
+++ b/charts/platform/charts/mcp/README.md
@@ -4,7 +4,7 @@ A Model Context Protocol (MCP) server that provides comprehensive access to the 
 Wave container provisioning, bioinformatics data, and nf-core modules through intelligent
 RAG-based natural language interactions.
 
-![Version: 0.4.1](https://img.shields.io/badge/Version-0.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.0](https://img.shields.io/badge/AppVersion-1.3.0-informational?style=flat-square)
+![Version: 0.4.2](https://img.shields.io/badge/Version-0.4.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.0](https://img.shields.io/badge/AppVersion-1.3.0-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -40,7 +40,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/mcp \
-  --version 0.4.1 \
+  --version 0.4.2 \
   --namespace my-namespace \
   --create-namespace
 ```

--- a/charts/platform/charts/pipeline-optimization/CHANGELOG.md
+++ b/charts/platform/charts/pipeline-optimization/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.9] - 2026-06-01
+
+### Changed
+
+- Bump bitnami/common dependency to 2.40.0.
+
 ## [2.0.8] - 2026-05-13
 
 ### Changed

--- a/charts/platform/charts/pipeline-optimization/Chart.lock
+++ b/charts/platform/charts/pipeline-optimization/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.39.0
+  version: 2.40.0
 - name: seqera-common
   repository: file://../../../seqera-common
   version: 2.1.2
-digest: sha256:3eac4511073f329f614981ce9b91e6cdda035aa007a3aeecd7069958c9ede539
-generated: "2026-05-05T14:18:13.372479516+02:00"
+digest: sha256:c32497a216446a0420343b4dc90d289f834f54aba4dcaa8030b4b1ff81ed41ef
+generated: "2026-06-01T11:41:51.83485533+02:00"

--- a/charts/platform/charts/pipeline-optimization/Chart.yaml
+++ b/charts/platform/charts/pipeline-optimization/Chart.yaml
@@ -23,7 +23,7 @@ maintainers:
     email: devops@seqera.io
     url: https://seqera.io
 type: application
-version: 2.0.8
+version: 2.0.9
 appVersion: "0.4.13"
 dependencies:
   - name: common

--- a/charts/platform/charts/pipeline-optimization/README.md
+++ b/charts/platform/charts/pipeline-optimization/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart to deploy the Seqera Pipeline Optimization service (referred to as Groundswell in Platform configuration files).
 
-![Version: 2.0.8](https://img.shields.io/badge/Version-2.0.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.13](https://img.shields.io/badge/AppVersion-0.4.13-informational?style=flat-square)
+![Version: 2.0.9](https://img.shields.io/badge/Version-2.0.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.13](https://img.shields.io/badge/AppVersion-0.4.13-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -37,7 +37,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/pipeline-optimization \
-  --version 2.0.8 \
+  --version 2.0.9 \
   --namespace my-namespace \
   --create-namespace
 ```

--- a/charts/platform/charts/portal-web/CHANGELOG.md
+++ b/charts/platform/charts/portal-web/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this chart will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.3.4] - 2026-06-01
+
+### Changed
+
+- Bump bitnami/common dependency to 2.40.0.
+
 ## [0.3.3] - 2026-05-22
 
 ### Changed

--- a/charts/platform/charts/portal-web/Chart.lock
+++ b/charts/platform/charts/portal-web/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.39.0
+  version: 2.40.0
 - name: seqera-common
   repository: file://../../../seqera-common
   version: 2.1.2
-digest: sha256:b66829bad11b646116b1ac6fc712849c4231dfbb6641380100f3282e06ab9a39
-generated: "2026-05-05T14:18:41.428348035+02:00"
+digest: sha256:6ba9920dedbfbf65d95efe62ede376e3bb4f28872727d78a2d1920918ebae991
+generated: "2026-06-01T11:42:11.253685964+02:00"

--- a/charts/platform/charts/portal-web/Chart.yaml
+++ b/charts/platform/charts/portal-web/Chart.yaml
@@ -19,7 +19,7 @@ apiVersion: v2
 name: portal-web
 description: Portal web frontend for Seqera Platform
 type: application
-version: 0.3.3
+version: 0.3.4
 appVersion: "1.6.0"
 maintainers:
   - name: Seqera Labs

--- a/charts/platform/charts/portal-web/README.md
+++ b/charts/platform/charts/portal-web/README.md
@@ -2,7 +2,7 @@
 
 Portal web frontend for Seqera Platform
 
-![Version: 0.3.3](https://img.shields.io/badge/Version-0.3.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.6.0](https://img.shields.io/badge/AppVersion-1.6.0-informational?style=flat-square)
+![Version: 0.3.4](https://img.shields.io/badge/Version-0.3.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.6.0](https://img.shields.io/badge/AppVersion-1.6.0-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -34,7 +34,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/portal-web \
-  --version 0.3.3 \
+  --version 0.3.4 \
   --namespace my-namespace \
   --create-namespace
 ```

--- a/charts/platform/charts/studios/CHANGELOG.md
+++ b/charts/platform/charts/studios/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.2] - 2026-06-01
+
+### Changed
+
+- Bump bitnami/common dependency to 2.40.0.
+
 ## [1.4.1] - 2026-05-13
 
 ### Changed

--- a/charts/platform/charts/studios/Chart.lock
+++ b/charts/platform/charts/studios/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.39.0
+  version: 2.40.0
 - name: seqera-common
   repository: file://../../../seqera-common
   version: 2.1.2
-digest: sha256:3eac4511073f329f614981ce9b91e6cdda035aa007a3aeecd7069958c9ede539
-generated: "2026-05-05T14:19:18.00542025+02:00"
+digest: sha256:c32497a216446a0420343b4dc90d289f834f54aba4dcaa8030b4b1ff81ed41ef
+generated: "2026-06-01T11:42:37.552899144+02:00"

--- a/charts/platform/charts/studios/Chart.yaml
+++ b/charts/platform/charts/studios/Chart.yaml
@@ -21,7 +21,7 @@ name: studios
 description: Studios is a unified platform for interactive analysis
 sources:
   - https://github.com/seqeralabs/helm-charts/tree/main/seqera/charts/studios
-version: 1.4.1
+version: 1.4.2
 appVersion: "0.11.1"
 maintainers:
   - name: Seqera Labs

--- a/charts/platform/charts/studios/README.md
+++ b/charts/platform/charts/studios/README.md
@@ -2,7 +2,7 @@
 
 Studios is a unified platform for interactive analysis
 
-![Version: 1.4.1](https://img.shields.io/badge/Version-1.4.1-informational?style=flat-square) ![AppVersion: 0.11.1](https://img.shields.io/badge/AppVersion-0.11.1-informational?style=flat-square)
+![Version: 1.4.2](https://img.shields.io/badge/Version-1.4.2-informational?style=flat-square) ![AppVersion: 0.11.1](https://img.shields.io/badge/AppVersion-0.11.1-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -41,7 +41,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/studios \
-  --version 1.4.1 \
+  --version 1.4.2 \
   --namespace my-namespace \
   --create-namespace
 ```

--- a/charts/platform/charts/wave/CHANGELOG.md
+++ b/charts/platform/charts/wave/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.4] - 2026-06-01
+
+### Changed
+
+- Bump bitnami/common dependency to 2.40.0.
+
 ## [0.2.3] - 2026-05-15
 
 ### Changed

--- a/charts/platform/charts/wave/Chart.lock
+++ b/charts/platform/charts/wave/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.39.0
+  version: 2.40.0
 - name: seqera-common
   repository: file://../../../seqera-common
   version: 2.1.2
-digest: sha256:3eac4511073f329f614981ce9b91e6cdda035aa007a3aeecd7069958c9ede539
-generated: "2026-05-05T14:19:45.779728648+02:00"
+digest: sha256:c32497a216446a0420343b4dc90d289f834f54aba4dcaa8030b4b1ff81ed41ef
+generated: "2026-06-01T11:43:04.315892541+02:00"

--- a/charts/platform/charts/wave/Chart.yaml
+++ b/charts/platform/charts/wave/Chart.yaml
@@ -19,7 +19,7 @@ apiVersion: v2
 name: wave
 description: Wave
 type: application
-version: 0.2.3
+version: 0.2.4
 appVersion: "v1.32.4"
 maintainers:
   - name: Seqera Labs

--- a/charts/platform/charts/wave/README.md
+++ b/charts/platform/charts/wave/README.md
@@ -2,7 +2,7 @@
 
 Wave
 
-![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.32.4](https://img.shields.io/badge/AppVersion-v1.32.4-informational?style=flat-square)
+![Version: 0.2.4](https://img.shields.io/badge/Version-0.2.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.32.4](https://img.shields.io/badge/AppVersion-v1.32.4-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -35,7 +35,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/wave \
-  --version 0.2.3 \
+  --version 0.2.4 \
   --namespace my-namespace \
   --create-namespace
 ```

--- a/charts/seqera-common/CHANGELOG.md
+++ b/charts/seqera-common/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.3] - 2026-06-01
+
+### Changed
+
+- Bump bitnami/common dependency to 2.40.0.
+
 ## [2.1.2] - 2026-04-30
 
 ### Security

--- a/charts/seqera-common/Chart.yaml
+++ b/charts/seqera-common/Chart.yaml
@@ -19,7 +19,7 @@ apiVersion: v2
 type: library
 name: seqera-common
 appVersion: 1.0.0
-version: 2.1.2
+version: 2.1.3
 description: A Library Helm Chart for grouping common logic between Seqera charts.
   This chart is not deployable by itself.
 home: https://github.com/seqeralabs/helm-charts

--- a/charts/seqera-common/README.md
+++ b/charts/seqera-common/README.md
@@ -1,6 +1,6 @@
 # seqera-common
 
-![Version: 2.1.2](https://img.shields.io/badge/Version-2.1.2-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 2.1.3](https://img.shields.io/badge/Version-2.1.3-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 A Library Helm Chart for grouping common logic between Seqera charts. This chart is not deployable by itself.
 


### PR DESCRIPTION
The ANTHROPIC_API_KEY entry was always written into the chart's Secret even when neither `anthropic.apiKey` nor `anthropic.existingSecretName` was set, autogenerating a random value which could be misleading. Add a guard on `.Values.anthropic.apiKey` so the key is only emitted when a value is actually provided. A new unit test covers the empty-key case. Bumps agent-backend chart to 1.0.4.