### PR TITLE
fix: Pass CR username and password to cosign call

### DIFF
--- a/.github/workflows/build-helm-charts.yaml
+++ b/.github/workflows/build-helm-charts.yaml
@@ -123,7 +123,7 @@ jobs:
             echo "Pushed chart ${chart_name} in $(($(date +%s) - push_start))s"
 
             echo "Signing ${REPO_HOSTNAME}/${REPO_PROJECT}/${chart_name}@${digest}.."
-            cosign sign --yes "${REPO_HOSTNAME}/${REPO_PROJECT}/${chart_name}@${digest}" || {
+            cosign sign --registry-username "${REPO_USERNAME}" --registry-password "${REPO_PASSWORD}" --yes "${REPO_HOSTNAME}/${REPO_PROJECT}/${chart_name}@${digest}" || {
               rollback
               exit 1
             }

--- a/charts/platform/CHANGELOG.md
+++ b/charts/platform/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Include Helm values schema.
+- Include Helm values JSON schema.
 - Bump agent-backend to 1.0.7, mcp to 0.4.3, pipeline-optimization to 2.0.10, portal-web to 0.3.5, studios to 1.4.3, wave to 0.2.5, seqera-common to 2.1.4 to include new schemas.
 
 ## [0.34.0] - 2026-05-26

--- a/charts/platform/charts/agent-backend/CHANGELOG.md
+++ b/charts/platform/charts/agent-backend/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Include Helm values schema.
+- Include Helm values JSON schema.
 
 ## [1.0.6] - 2026-06-02
 

--- a/charts/platform/charts/mcp/CHANGELOG.md
+++ b/charts/platform/charts/mcp/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Include Helm values schema.
+- Include Helm values JSON schema.
 
 ## [0.4.2] - 2026-06-01
 

--- a/charts/platform/charts/pipeline-optimization/CHANGELOG.md
+++ b/charts/platform/charts/pipeline-optimization/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Include Helm values schema.
+- Include Helm values JSON schema.
 
 ## [2.0.9] - 2026-06-01
 

--- a/charts/platform/charts/portal-web/CHANGELOG.md
+++ b/charts/platform/charts/portal-web/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- Include Helm values schema.
+- Include Helm values JSON schema.
 
 ## [0.3.4] - 2026-06-01
 

--- a/charts/platform/charts/studios/CHANGELOG.md
+++ b/charts/platform/charts/studios/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Include Helm values schema.
+- Include Helm values JSON schema.
 
 ## [1.4.2] - 2026-06-01
 

--- a/charts/platform/charts/wave/CHANGELOG.md
+++ b/charts/platform/charts/wave/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Include Helm values schema.
+- Include Helm values JSON schema.
 
 ## [0.2.4] - 2026-06-01
 

--- a/charts/seqera-common/CHANGELOG.md
+++ b/charts/seqera-common/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Include Helm values schema.
+- Include Helm values JSON schema.
 
 ## [2.1.3] - 2026-06-01
 


### PR DESCRIPTION
#166 added a cosign package signing step, but I forgot to provide cosign the username and password to push the packages, which caused the previous package push to [fail and rollback](https://github.com/seqeralabs/helm-charts/actions/runs/27270694041/job/80539100636) the already pushed platform package.
I updated the Changelog files to retrigger a package build without updating the chart versions, since the previous versions were never pushed. No GH releases were ever created, as that step comes after the chart push phase.