### PR TITLE
feat: Add annotations to Chart.yaml files to point ArtifactHub at keybase pubkey

### DIFF
--- a/.github/scripts/test_inject_artifacthub_changes.py
+++ b/.github/scripts/test_inject_artifacthub_changes.py
@@ -260,6 +260,47 @@ def test_main_skips_missing_changelog():
         shutil.rmtree(tmpdir)
 
 
+def test_main_preserves_existing_annotations():
+    """Inject must add artifacthub.io/changes without overwriting other annotations."""
+    tmpdir = tempfile.mkdtemp()
+    try:
+        with open(os.path.join(tmpdir, "Chart.yaml"), "w") as f:
+            f.write(
+                "apiVersion: v2\n"
+                "name: test-chart\n"
+                "version: 2.0.0\n"
+                "annotations:\n"
+                "  artifacthub.io/signKey: |\n"
+                "    fingerprint: F69F12932C6F3E0EED47964BCE031B0C243F50E0\n"
+                "    url: https://keybase.io/seqeradevops/pgp_keys.asc\n"
+            )
+
+        with open(os.path.join(tmpdir, "CHANGELOG.md"), "w") as f:
+            f.write("## [2.0.0] - 2026-06-24\n\n### Fixed\n\n- Fix something.\n")
+
+        with unittest.mock.patch.dict(os.environ, {"charts_to_package": tmpdir}):
+            result = inject_main()
+            assert result == 0, "main() should return 0"
+
+            # artifacthub.io/changes was injected
+            proc = subprocess.run(
+                ["yq", "-r", '.annotations["artifacthub.io/changes"]', os.path.join(tmpdir, "Chart.yaml")],
+                capture_output=True, text=True, check=True,
+            )
+            assert "fixed" in proc.stdout
+            assert "Fix something" in proc.stdout
+
+            # Pre-existing signKey annotation was NOT clobbered
+            proc2 = subprocess.run(
+                ["yq", "-r", '.annotations["artifacthub.io/signKey"]', os.path.join(tmpdir, "Chart.yaml")],
+                capture_output=True, text=True, check=True,
+            )
+            assert "F69F12932C6F3E0EED47964BCE031B0C243F50E0" in proc2.stdout
+            assert "keybase.io/seqeradevops" in proc2.stdout
+    finally:
+        shutil.rmtree(tmpdir)
+
+
 if __name__ == "__main__":
     tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
     passed = 0

--- a/charts/platform/CHANGELOG.md
+++ b/charts/platform/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.34.3] - 2026-06-24
+
+### Added
+
+- Add ArtifactHub annotations: license, links, and sign key to all charts.
+- Bump agent-backend to 1.0.9, mcp to 0.4.5, pipeline-optimization to 2.0.12, portal-web to 0.3.7, studios to 1.4.5, wave to 0.2.7, seqera-common to 2.1.6.
+
 ## [0.34.2] - 2026-06-11
 
 ### Added

--- a/charts/platform/Chart.lock
+++ b/charts/platform/Chart.lock
@@ -4,24 +4,24 @@ dependencies:
   version: 2.40.0
 - name: seqera-common
   repository: file://../seqera-common
-  version: 2.1.5
+  version: 2.1.6
 - name: pipeline-optimization
   repository: file://charts/pipeline-optimization
-  version: 2.0.11
+  version: 2.0.12
 - name: studios
   repository: file://charts/studios
-  version: 1.4.4
+  version: 1.4.5
 - name: wave
   repository: file://charts/wave
-  version: 0.2.6
+  version: 0.2.7
 - name: mcp
   repository: file://charts/mcp
-  version: 0.4.4
+  version: 0.4.5
 - name: agent-backend
   repository: file://charts/agent-backend
-  version: 1.0.8
+  version: 1.0.9
 - name: portal-web
   repository: file://charts/portal-web
-  version: 0.3.6
-digest: sha256:56bf44fffc631cba8dbe71bc6f7e385b776267fe47d762be4b9adb5f7fbd0659
-generated: "2026-06-11T13:15:27.687966089+02:00"
+  version: 0.3.7
+digest: sha256:f75a5af6b10df58bf1c4a47c835aa0ce0b264562250da8a5d54265d7607f230b
+generated: "2026-06-24T11:03:21.815487827+02:00"

--- a/charts/platform/Chart.yaml
+++ b/charts/platform/Chart.yaml
@@ -38,13 +38,24 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.34.2
+version: 0.34.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 appVersion: "v26.1.0"
+
+annotations:
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/links: |
+    - name: Seqera Docs
+      url: https://docs.seqera.io
+    - name: Helm charts repository
+      url: https://github.com/seqeralabs/helm-charts/
+  artifacthub.io/signKey: |
+    fingerprint: F69F12932C6F3E0EED47964BCE031B0C243F50E0
+    url: https://keybase.io/seqeradevops/pgp_keys.asc
 
 dependencies:
   - name: common

--- a/charts/platform/README.md
+++ b/charts/platform/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart to deploy Seqera Platform (also referred to as Tower) on Kubernetes.
 
-![Version: 0.34.2](https://img.shields.io/badge/Version-0.34.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v26.1.0](https://img.shields.io/badge/AppVersion-v26.1.0-informational?style=flat-square)
+![Version: 0.34.3](https://img.shields.io/badge/Version-0.34.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v26.1.0](https://img.shields.io/badge/AppVersion-v26.1.0-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -41,7 +41,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/platform \
-  --version 0.34.2 \
+  --version 0.34.3 \
   --namespace my-namespace \
   --create-namespace
 ```

--- a/charts/platform/charts/agent-backend/CHANGELOG.md
+++ b/charts/platform/charts/agent-backend/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.9] - 2026-06-24
+
+### Added
+
+- Add ArtifactHub annotations: license, links, and sign key.
+
 ## [1.0.8] - 2026-06-11
 
 ### Added

--- a/charts/platform/charts/agent-backend/Chart.lock
+++ b/charts/platform/charts/agent-backend/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 2.40.0
 - name: seqera-common
   repository: file://../../../seqera-common
-  version: 2.1.4
-digest: sha256:472269afe625b0c68a2ce5337c4d4ef4f169c61990a0132afe211dbdebbb2b4a
-generated: "2026-06-10T11:23:30.522228829+02:00"
+  version: 2.1.6
+digest: sha256:a9aadb65b5f908c78973dc5dd1c9f88636b7af59fcb83b63fe78aa80575d0cd8
+generated: "2026-06-24T11:03:36.692112472+02:00"

--- a/charts/platform/charts/agent-backend/Chart.yaml
+++ b/charts/platform/charts/agent-backend/Chart.yaml
@@ -19,13 +19,23 @@ apiVersion: v2
 name: agent-backend
 description: Backend service for Seqera CLI AI capabilities
 type: application
-version: 1.0.8
+version: 1.0.9
 appVersion: "1.11.0"
 icon: https://raw.githubusercontent.com/seqeralabs/helm-charts/master/media/seqera-icon-light.svg
 maintainers:
   - name: Seqera Labs
     email: devops@seqera.io
     url: https://seqera.io
+annotations:
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/links: |
+    - name: Seqera Docs
+      url: https://docs.seqera.io
+    - name: Helm charts repository
+      url: https://github.com/seqeralabs/helm-charts/
+  artifacthub.io/signKey: |
+    fingerprint: F69F12932C6F3E0EED47964BCE031B0C243F50E0
+    url: https://keybase.io/seqeradevops/pgp_keys.asc
 dependencies:
   - name: common
     repository: oci://registry-1.docker.io/bitnamicharts

--- a/charts/platform/charts/agent-backend/README.md
+++ b/charts/platform/charts/agent-backend/README.md
@@ -2,7 +2,7 @@
 
 Backend service for Seqera CLI AI capabilities
 
-![Version: 1.0.8](https://img.shields.io/badge/Version-1.0.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.11.0](https://img.shields.io/badge/AppVersion-1.11.0-informational?style=flat-square)
+![Version: 1.0.9](https://img.shields.io/badge/Version-1.0.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.11.0](https://img.shields.io/badge/AppVersion-1.11.0-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -45,7 +45,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/agent-backend \
-  --version 1.0.8 \
+  --version 1.0.9 \
   --namespace my-namespace \
   --create-namespace
 ```

--- a/charts/platform/charts/mcp/CHANGELOG.md
+++ b/charts/platform/charts/mcp/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.5] - 2026-06-24
+
+### Added
+
+- Add ArtifactHub annotations: license, links, and sign key.
+
 ## [0.4.4] - 2026-06-11
 
 ### Added

--- a/charts/platform/charts/mcp/Chart.lock
+++ b/charts/platform/charts/mcp/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 2.40.0
 - name: seqera-common
   repository: file://../../../seqera-common
-  version: 2.1.4
-digest: sha256:621bb2f834e644024ea9d0df265136567e153761551a208c0d2921b6e339247b
-generated: "2026-06-10T11:23:41.246943085+02:00"
+  version: 2.1.6
+digest: sha256:229187490963d6cc0470c5336122272420bd5dee423b0c07562046d97aea643e
+generated: "2026-06-24T11:03:52.270940455+02:00"

--- a/charts/platform/charts/mcp/Chart.yaml
+++ b/charts/platform/charts/mcp/Chart.yaml
@@ -22,13 +22,23 @@ description: |
   Wave container provisioning, bioinformatics data, and nf-core modules through intelligent
   RAG-based natural language interactions.
 type: application
-version: 0.4.4
+version: 0.4.5
 appVersion: "1.3.0"
 icon: https://raw.githubusercontent.com/seqeralabs/helm-charts/master/media/seqera-icon-light.svg
 maintainers:
   - name: Seqera Labs
     email: devops@seqera.io
     url: https://seqera.io
+annotations:
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/links: |
+    - name: Seqera Docs
+      url: https://docs.seqera.io
+    - name: Helm charts repository
+      url: https://github.com/seqeralabs/helm-charts/
+  artifacthub.io/signKey: |
+    fingerprint: F69F12932C6F3E0EED47964BCE031B0C243F50E0
+    url: https://keybase.io/seqeradevops/pgp_keys.asc
 dependencies:
   - name: common
     repository: oci://registry-1.docker.io/bitnamicharts

--- a/charts/platform/charts/mcp/README.md
+++ b/charts/platform/charts/mcp/README.md
@@ -4,7 +4,7 @@ A Model Context Protocol (MCP) server that provides comprehensive access to the 
 Wave container provisioning, bioinformatics data, and nf-core modules through intelligent
 RAG-based natural language interactions.
 
-![Version: 0.4.4](https://img.shields.io/badge/Version-0.4.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.0](https://img.shields.io/badge/AppVersion-1.3.0-informational?style=flat-square)
+![Version: 0.4.5](https://img.shields.io/badge/Version-0.4.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.0](https://img.shields.io/badge/AppVersion-1.3.0-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -40,7 +40,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/mcp \
-  --version 0.4.4 \
+  --version 0.4.5 \
   --namespace my-namespace \
   --create-namespace
 ```

--- a/charts/platform/charts/pipeline-optimization/CHANGELOG.md
+++ b/charts/platform/charts/pipeline-optimization/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.12] - 2026-06-24
+
+### Added
+
+- Add ArtifactHub annotations: license, links, and sign key.
+
 ## [2.0.11] - 2026-06-11
 
 ### Added

--- a/charts/platform/charts/pipeline-optimization/Chart.lock
+++ b/charts/platform/charts/pipeline-optimization/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 2.40.0
 - name: seqera-common
   repository: file://../../../seqera-common
-  version: 2.1.4
-digest: sha256:472269afe625b0c68a2ce5337c4d4ef4f169c61990a0132afe211dbdebbb2b4a
-generated: "2026-06-10T11:23:51.924599303+02:00"
+  version: 2.1.6
+digest: sha256:a9aadb65b5f908c78973dc5dd1c9f88636b7af59fcb83b63fe78aa80575d0cd8
+generated: "2026-06-24T11:04:08.474619217+02:00"

--- a/charts/platform/charts/pipeline-optimization/Chart.yaml
+++ b/charts/platform/charts/pipeline-optimization/Chart.yaml
@@ -23,9 +23,19 @@ maintainers:
     email: devops@seqera.io
     url: https://seqera.io
 type: application
-version: 2.0.11
+version: 2.0.12
 appVersion: "0.4.13"
 icon: https://raw.githubusercontent.com/seqeralabs/helm-charts/master/media/seqera-icon-light.svg
+annotations:
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/links: |
+    - name: Seqera Docs
+      url: https://docs.seqera.io
+    - name: Helm charts repository
+      url: https://github.com/seqeralabs/helm-charts/
+  artifacthub.io/signKey: |
+    fingerprint: F69F12932C6F3E0EED47964BCE031B0C243F50E0
+    url: https://keybase.io/seqeradevops/pgp_keys.asc
 dependencies:
   - name: common
     version: "2.x.x"

--- a/charts/platform/charts/pipeline-optimization/README.md
+++ b/charts/platform/charts/pipeline-optimization/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart to deploy the Seqera Pipeline Optimization service (referred to as Groundswell in Platform configuration files).
 
-![Version: 2.0.11](https://img.shields.io/badge/Version-2.0.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.13](https://img.shields.io/badge/AppVersion-0.4.13-informational?style=flat-square)
+![Version: 2.0.12](https://img.shields.io/badge/Version-2.0.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.13](https://img.shields.io/badge/AppVersion-0.4.13-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -37,7 +37,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/pipeline-optimization \
-  --version 2.0.11 \
+  --version 2.0.12 \
   --namespace my-namespace \
   --create-namespace
 ```

--- a/charts/platform/charts/portal-web/CHANGELOG.md
+++ b/charts/platform/charts/portal-web/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this chart will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.3.7] - 2026-06-24
+
+### Added
+
+- Add ArtifactHub annotations: license, links, and sign key.
+
 ## [0.3.6] - 2026-06-11
 
 ### Added

--- a/charts/platform/charts/portal-web/Chart.lock
+++ b/charts/platform/charts/portal-web/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 2.40.0
 - name: seqera-common
   repository: file://../../../seqera-common
-  version: 2.1.4
-digest: sha256:621bb2f834e644024ea9d0df265136567e153761551a208c0d2921b6e339247b
-generated: "2026-06-10T11:24:01.685414765+02:00"
+  version: 2.1.6
+digest: sha256:229187490963d6cc0470c5336122272420bd5dee423b0c07562046d97aea643e
+generated: "2026-06-24T11:04:23.620494231+02:00"

--- a/charts/platform/charts/portal-web/Chart.yaml
+++ b/charts/platform/charts/portal-web/Chart.yaml
@@ -19,13 +19,23 @@ apiVersion: v2
 name: portal-web
 description: Portal web frontend for Seqera Platform
 type: application
-version: 0.3.6
+version: 0.3.7
 appVersion: "1.6.0"
 icon: https://raw.githubusercontent.com/seqeralabs/helm-charts/master/media/seqera-icon-light.svg
 maintainers:
   - name: Seqera Labs
     email: devops@seqera.io
     url: https://seqera.io
+annotations:
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/links: |
+    - name: Seqera Docs
+      url: https://docs.seqera.io
+    - name: Helm charts repository
+      url: https://github.com/seqeralabs/helm-charts/
+  artifacthub.io/signKey: |
+    fingerprint: F69F12932C6F3E0EED47964BCE031B0C243F50E0
+    url: https://keybase.io/seqeradevops/pgp_keys.asc
 dependencies:
   - name: common
     repository: oci://registry-1.docker.io/bitnamicharts

--- a/charts/platform/charts/portal-web/README.md
+++ b/charts/platform/charts/portal-web/README.md
@@ -2,7 +2,7 @@
 
 Portal web frontend for Seqera Platform
 
-![Version: 0.3.6](https://img.shields.io/badge/Version-0.3.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.6.0](https://img.shields.io/badge/AppVersion-1.6.0-informational?style=flat-square)
+![Version: 0.3.7](https://img.shields.io/badge/Version-0.3.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.6.0](https://img.shields.io/badge/AppVersion-1.6.0-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -34,7 +34,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/portal-web \
-  --version 0.3.6 \
+  --version 0.3.7 \
   --namespace my-namespace \
   --create-namespace
 ```

--- a/charts/platform/charts/studios/CHANGELOG.md
+++ b/charts/platform/charts/studios/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.5] - 2026-06-24
+
+### Added
+
+- Add ArtifactHub annotations: license, links, and sign key.
+
 ## [1.4.4] - 2026-06-11
 
 ### Added

--- a/charts/platform/charts/studios/Chart.lock
+++ b/charts/platform/charts/studios/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 2.40.0
 - name: seqera-common
   repository: file://../../../seqera-common
-  version: 2.1.4
-digest: sha256:472269afe625b0c68a2ce5337c4d4ef4f169c61990a0132afe211dbdebbb2b4a
-generated: "2026-06-10T11:24:11.087010823+02:00"
+  version: 2.1.6
+digest: sha256:a9aadb65b5f908c78973dc5dd1c9f88636b7af59fcb83b63fe78aa80575d0cd8
+generated: "2026-06-24T11:04:38.304982315+02:00"

--- a/charts/platform/charts/studios/Chart.yaml
+++ b/charts/platform/charts/studios/Chart.yaml
@@ -21,13 +21,23 @@ name: studios
 description: Studios is a unified platform for interactive analysis
 sources:
   - https://github.com/seqeralabs/helm-charts/tree/main/seqera/charts/studios
-version: 1.4.4
+version: 1.4.5
 appVersion: "0.11.1"
 icon: https://raw.githubusercontent.com/seqeralabs/helm-charts/master/media/seqera-icon-light.svg
 maintainers:
   - name: Seqera Labs
     email: devops@seqera.io
     url: https://seqera.io
+annotations:
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/links: |
+    - name: Seqera Docs
+      url: https://docs.seqera.io
+    - name: Helm charts repository
+      url: https://github.com/seqeralabs/helm-charts/
+  artifacthub.io/signKey: |
+    fingerprint: F69F12932C6F3E0EED47964BCE031B0C243F50E0
+    url: https://keybase.io/seqeradevops/pgp_keys.asc
 dependencies:
   - name: common
     version: "2.x.x"

--- a/charts/platform/charts/studios/README.md
+++ b/charts/platform/charts/studios/README.md
@@ -2,7 +2,7 @@
 
 Studios is a unified platform for interactive analysis
 
-![Version: 1.4.4](https://img.shields.io/badge/Version-1.4.4-informational?style=flat-square) ![AppVersion: 0.11.1](https://img.shields.io/badge/AppVersion-0.11.1-informational?style=flat-square)
+![Version: 1.4.5](https://img.shields.io/badge/Version-1.4.5-informational?style=flat-square) ![AppVersion: 0.11.1](https://img.shields.io/badge/AppVersion-0.11.1-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -41,7 +41,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/studios \
-  --version 1.4.4 \
+  --version 1.4.5 \
   --namespace my-namespace \
   --create-namespace
 ```

--- a/charts/platform/charts/wave/CHANGELOG.md
+++ b/charts/platform/charts/wave/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.7] - 2026-06-24
+
+### Added
+
+- Add ArtifactHub annotations: license, links, and sign key.
+
 ## [0.2.6] - 2026-06-11
 
 ### Added

--- a/charts/platform/charts/wave/Chart.lock
+++ b/charts/platform/charts/wave/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 2.40.0
 - name: seqera-common
   repository: file://../../../seqera-common
-  version: 2.1.4
-digest: sha256:472269afe625b0c68a2ce5337c4d4ef4f169c61990a0132afe211dbdebbb2b4a
-generated: "2026-06-10T11:24:22.020830272+02:00"
+  version: 2.1.6
+digest: sha256:a9aadb65b5f908c78973dc5dd1c9f88636b7af59fcb83b63fe78aa80575d0cd8
+generated: "2026-06-24T11:04:53.322859532+02:00"

--- a/charts/platform/charts/wave/Chart.yaml
+++ b/charts/platform/charts/wave/Chart.yaml
@@ -19,13 +19,23 @@ apiVersion: v2
 name: wave
 description: Wave
 type: application
-version: 0.2.6
+version: 0.2.7
 appVersion: "v1.32.4"
 icon: https://raw.githubusercontent.com/seqeralabs/helm-charts/master/media/seqera-icon-light.svg
 maintainers:
   - name: Seqera Labs
     email: devops@seqera.io
     url: https://seqera.io
+annotations:
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/links: |
+    - name: Seqera Docs
+      url: https://docs.seqera.io
+    - name: Helm charts repository
+      url: https://github.com/seqeralabs/helm-charts/
+  artifacthub.io/signKey: |
+    fingerprint: F69F12932C6F3E0EED47964BCE031B0C243F50E0
+    url: https://keybase.io/seqeradevops/pgp_keys.asc
 dependencies:
   - name: common
     repository: oci://registry-1.docker.io/bitnamicharts

--- a/charts/platform/charts/wave/README.md
+++ b/charts/platform/charts/wave/README.md
@@ -2,7 +2,7 @@
 
 Wave
 
-![Version: 0.2.6](https://img.shields.io/badge/Version-0.2.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.32.4](https://img.shields.io/badge/AppVersion-v1.32.4-informational?style=flat-square)
+![Version: 0.2.7](https://img.shields.io/badge/Version-0.2.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.32.4](https://img.shields.io/badge/AppVersion-v1.32.4-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -35,7 +35,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/wave \
-  --version 0.2.6 \
+  --version 0.2.7 \
   --namespace my-namespace \
   --create-namespace
 ```

--- a/charts/seqera-common/CHANGELOG.md
+++ b/charts/seqera-common/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.6] - 2026-06-24
+
+### Added
+
+- Add ArtifactHub annotations: license, links, and sign key.
+
 ## [2.1.5] - 2026-06-11
 
 ### Added

--- a/charts/seqera-common/Chart.yaml
+++ b/charts/seqera-common/Chart.yaml
@@ -19,7 +19,7 @@ apiVersion: v2
 type: library
 name: seqera-common
 appVersion: 1.0.0
-version: 2.1.5
+version: 2.1.6
 icon: https://raw.githubusercontent.com/seqeralabs/helm-charts/master/media/seqera-icon-light.svg
 description: A Library Helm Chart for grouping common logic between Seqera charts.
   This chart is not deployable by itself.
@@ -34,3 +34,13 @@ maintainers:
     url: https://github.com/seqeralabs/helm-charts
 sources:
   - https://github.com/seqeralabs/helm-charts/tree/main/seqera-common
+annotations:
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/links: |
+    - name: Seqera Docs
+      url: https://docs.seqera.io
+    - name: Helm charts repository
+      url: https://github.com/seqeralabs/helm-charts/
+  artifacthub.io/signKey: |
+    fingerprint: F69F12932C6F3E0EED47964BCE031B0C243F50E0
+    url: https://keybase.io/seqeradevops/pgp_keys.asc

--- a/charts/seqera-common/README.md
+++ b/charts/seqera-common/README.md
@@ -1,6 +1,6 @@
 # seqera-common
 
-![Version: 2.1.5](https://img.shields.io/badge/Version-2.1.5-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 2.1.6](https://img.shields.io/badge/Version-2.1.6-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 A Library Helm Chart for grouping common logic between Seqera charts. This chart is not deployable by itself.
 


### PR DESCRIPTION
Follow up of #169, the packages were already signed but we were missing to instruct ArtifactHub where to find the pubkey to validate signatures.