### PR TITLE
feat: Push chart package signature to GH releases as well

### DIFF
--- a/.github/workflows/build-helm-charts.yaml
+++ b/.github/workflows/build-helm-charts.yaml
@@ -159,13 +159,16 @@ jobs:
           EOF
 
             # Create the release with auto-generated notes and attach the
-            # packaged chart as a release asset.
+            # packaged chart and its GPG provenance file as release assets.
+            # The .prov file is required by ArtifactHub and `helm verify` to
+            # confirm the package signature.
             gh release create "${release_tag}" \
               --repo ${{ github.repository }} \
               --title "${chart_name} ${chart_version}" \
               --generate-notes \
               --notes-file ${temp_file} \
-              "${chart_name}-${chart_version}.tgz"
+              "${chart_name}-${chart_version}.tgz" \
+              "${chart_name}-${chart_version}.tgz.prov"
 
             echo "Created release ${release_tag}"
           done
@@ -195,6 +198,7 @@ jobs:
             chart_name=$(yq -r '.name' ${chart}/Chart.yaml)
             chart_version=$(yq -r '.version' ${chart}/Chart.yaml)
             mv "${chart_name}-${chart_version}.tgz" .cr-release-packages/
+            mv "${chart_name}-${chart_version}.tgz.prov" .cr-release-packages/
           done
 
           owner="${GITHUB_REPOSITORY%%/*}"

--- a/charts/platform/CHANGELOG.md
+++ b/charts/platform/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.34.4] - 2026-06-24
+
+### Added
+
+- Add GPG provenance file to GitHub releases to enable ArtifactHub signature verification.
+
 ## [0.34.3] - 2026-06-24
 
 ### Added

--- a/charts/platform/Chart.yaml
+++ b/charts/platform/Chart.yaml
@@ -38,7 +38,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.34.3
+version: 0.34.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/platform/README.md
+++ b/charts/platform/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart to deploy Seqera Platform (also referred to as Tower) on Kubernetes.
 
-![Version: 0.34.3](https://img.shields.io/badge/Version-0.34.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v26.1.0](https://img.shields.io/badge/AppVersion-v26.1.0-informational?style=flat-square)
+![Version: 0.34.4](https://img.shields.io/badge/Version-0.34.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v26.1.0](https://img.shields.io/badge/AppVersion-v26.1.0-informational?style=flat-square)
 
 > [!WARNING]
 > This chart is currently still in development and breaking changes are expected.
@@ -41,7 +41,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm install my-release oci://public.cr.seqera.io/charts/platform \
-  --version 0.34.3 \
+  --version 0.34.4 \
   --namespace my-namespace \
   --create-namespace
 ```


### PR DESCRIPTION
Follow up of #171. I configured the ArtifactHub repo as HTTP on https://seqeralabs.github.io/helm-charts/, but we weren't uploading the helm chart signatures in the releases. Bump platform chart only to test signature verification.