### PR TITLE
feat: Bump chart's app versions

### DIFF
--- a/charts/platform/CHANGELOG.md
+++ b/charts/platform/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.35.0] - 2026-07-07
 
+### Changed
+
+- Bumped Platform `appVersion` to `v26.1.3`.
+
 ### Removed
 
 - **BREAKING**: Removed support for overriding container images via `global.azure.images`

--- a/charts/platform/Chart.yaml
+++ b/charts/platform/Chart.yaml
@@ -44,7 +44,7 @@ version: 0.35.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v26.1.0"
+appVersion: "v26.1.3"
 
 annotations:
   artifacthub.io/license: Apache-2.0

--- a/charts/platform/README.md
+++ b/charts/platform/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart to deploy Seqera Platform (also referred to as Tower) on Kubernetes.
 
-![Version: 0.35.0](https://img.shields.io/badge/Version-0.35.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v26.1.0](https://img.shields.io/badge/AppVersion-v26.1.0-informational?style=flat-square)
+![Version: 0.35.0](https://img.shields.io/badge/Version-0.35.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v26.1.3](https://img.shields.io/badge/AppVersion-v26.1.3-informational?style=flat-square)
 
 Some basic familiarity with Helm is assumed. If you are new to Helm, please refer to the [Helm documentation](https://helm.sh/docs/).
 We recommend reading through the `values.yaml` file to understand the configuration options available for the chart. Each entry in the `values.yaml` file is documented with comments describing its purpose and usage.
@@ -29,7 +29,7 @@ The required values to set in order to have a working installation are:
 
 The Helm chart comes with several requirement checks that will validate the provided configuration before proceeding with the installation.
 
-By default the chart selects the Platform application images defined in the `appVersion` field of the `Chart.yaml` file, currently set as `v26.1.0`.
+By default the chart selects the Platform application images defined in the `appVersion` field of the `Chart.yaml` file, currently set as `v26.1.3`.
 
 > [!NOTE]
 > The Platform chart requires the [unprivileged version](https://docs.seqera.io/platform-enterprise/enterprise/kubernetes#seqera-frontend-unprivileged) of the Seqera Platform frontend image (shipped with `-unprivileged` suffix until Platform v25.3, without any suffix starting from v26.1).

--- a/charts/platform/charts/agent-backend/CHANGELOG.md
+++ b/charts/platform/charts/agent-backend/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.1.0] - 2026-07-07
 
+### Changed
+
+- Bumped `appVersion` to `1.13.1`.
+
 ### Removed
 
 - **BREAKING**: Removed `global.azure.images` image overrides for `agentBackend` and the

--- a/charts/platform/charts/agent-backend/Chart.yaml
+++ b/charts/platform/charts/agent-backend/Chart.yaml
@@ -20,7 +20,7 @@ name: agent-backend
 description: Backend service for Seqera CLI AI capabilities
 type: application
 version: 1.1.0
-appVersion: "1.11.0"
+appVersion: "1.13.1"
 icon: https://raw.githubusercontent.com/seqeralabs/helm-charts/master/media/seqera-icon-light.svg
 maintainers:
   - name: Seqera Labs

--- a/charts/platform/charts/agent-backend/README.md
+++ b/charts/platform/charts/agent-backend/README.md
@@ -2,7 +2,7 @@
 
 Backend service for Seqera CLI AI capabilities
 
-![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.11.0](https://img.shields.io/badge/AppVersion-1.11.0-informational?style=flat-square)
+![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.13.1](https://img.shields.io/badge/AppVersion-1.13.1-informational?style=flat-square)
 
 Some basic familiarity with Helm is assumed. If you are new to Helm, please refer to the [Helm documentation](https://helm.sh/docs/).
 We recommend reading through the `values.yaml` file to understand the configuration options available for the chart. Each entry in the `values.yaml` file is documented with comments describing its purpose and usage.
@@ -36,7 +36,7 @@ The following capabilities are **optional** and disabled when their provider is 
 
 The Helm chart comes with several requirement checks that will validate the provided configuration before proceeding with the installation.
 
-By default the chart selects the application images defined in the `appVersion` field of the `Chart.yaml` file, currently set as `1.11.0`.
+By default the chart selects the application images defined in the `appVersion` field of the `Chart.yaml` file, currently set as `1.13.1`.
 
 When a sensitive value is required (e.g. the database password, the Seqera license key), you can either provide it directly in the values file or reference an existing Kubernetes Secret containing the value. The key names to use in the provided Secret are specified in the values file comments.
 Sensitive values provided as plain text by the user are always stored in a Kubernetes Secret created by the chart. When an external Secret is used instead, the chart instructs the components to read the sensitive value from the external Secret directly, without further storing copies of the sensitive value in the chart-created Secret.

--- a/charts/platform/charts/mcp/CHANGELOG.md
+++ b/charts/platform/charts/mcp/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Bumped `appVersion` to `1.4.2`.
 - Bumped `seqera-common` dependency to `3.x.x`. The `waitForPlatform` init container no longer
   accepts a `cloudProviderImageKey` — `global.azure.images` overrides are no longer honored.
 

--- a/charts/platform/charts/mcp/Chart.yaml
+++ b/charts/platform/charts/mcp/Chart.yaml
@@ -23,7 +23,7 @@ description: |
   RAG-based natural language interactions.
 type: application
 version: 0.5.0
-appVersion: "1.3.0"
+appVersion: "1.4.2"
 icon: https://raw.githubusercontent.com/seqeralabs/helm-charts/master/media/seqera-icon-light.svg
 maintainers:
   - name: Seqera Labs

--- a/charts/platform/charts/mcp/README.md
+++ b/charts/platform/charts/mcp/README.md
@@ -4,7 +4,7 @@ A Model Context Protocol (MCP) server that provides comprehensive access to the 
 Wave container provisioning, bioinformatics data, and nf-core modules through intelligent
 RAG-based natural language interactions.
 
-![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.0](https://img.shields.io/badge/AppVersion-1.3.0-informational?style=flat-square)
+![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.4.2](https://img.shields.io/badge/AppVersion-1.4.2-informational?style=flat-square)
 
 Some basic familiarity with Helm is assumed. If you are new to Helm, please refer to the [Helm documentation](https://helm.sh/docs/).
 We recommend reading through the `values.yaml` file to understand the configuration options available for the chart. Each entry in the `values.yaml` file is documented with comments describing its purpose and usage.
@@ -30,7 +30,7 @@ The required values to set in order to have a working installation are:
 
 The Helm chart comes with several requirement checks that will validate the provided configuration before proceeding with the installation.
 
-By default the chart selects the application images defined in the `appVersion` field of the `Chart.yaml` file, currently set as `1.3.0`.
+By default the chart selects the application images defined in the `appVersion` field of the `Chart.yaml` file, currently set as `1.4.2`.
 
 When a sensitive value is required (e.g. the database password, the Seqera license key), you can either provide it directly in the values file or reference an existing Kubernetes Secret containing the value. The key names to use in the provided Secret are specified in the values file comments.
 Sensitive values provided as plain text by the user are always stored in a Kubernetes Secret created by the chart. When an external Secret is used instead, the chart instructs the components to read the sensitive value from the external Secret directly, without further storing copies of the sensitive value in the chart-created Secret.

--- a/charts/platform/charts/pipeline-optimization/CHANGELOG.md
+++ b/charts/platform/charts/pipeline-optimization/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.1.0] - 2026-07-07
 
+### Changed
+
+- Bumped `appVersion` to `0.4.15`.
+
 ### Removed
 
 - **BREAKING**: Removed `global.azure.images` image overrides for `pipelineOptimization`,

--- a/charts/platform/charts/pipeline-optimization/Chart.yaml
+++ b/charts/platform/charts/pipeline-optimization/Chart.yaml
@@ -24,7 +24,7 @@ maintainers:
     url: https://seqera.io
 type: application
 version: 2.1.0
-appVersion: "0.4.13"
+appVersion: "0.4.15"
 icon: https://raw.githubusercontent.com/seqeralabs/helm-charts/master/media/seqera-icon-light.svg
 annotations:
   artifacthub.io/license: Apache-2.0

--- a/charts/platform/charts/pipeline-optimization/README.md
+++ b/charts/platform/charts/pipeline-optimization/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart to deploy the Seqera Pipeline Optimization service (referred to as Groundswell in Platform configuration files).
 
-![Version: 2.1.0](https://img.shields.io/badge/Version-2.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.13](https://img.shields.io/badge/AppVersion-0.4.13-informational?style=flat-square)
+![Version: 2.1.0](https://img.shields.io/badge/Version-2.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.15](https://img.shields.io/badge/AppVersion-0.4.15-informational?style=flat-square)
 
 Some basic familiarity with Helm is assumed. If you are new to Helm, please refer to the [Helm documentation](https://helm.sh/docs/).
 We recommend reading through the `values.yaml` file to understand the configuration options available for the chart. Each entry in the `values.yaml` file is documented with comments describing its purpose and usage.
@@ -26,7 +26,7 @@ The required values to set in order to have a working installation are:
 
 The Helm chart comes with several requirement checks that will validate the provided configuration before proceeding with the installation.
 
-By default the chart selects the Platform application images defined in the `appVersion` field of the `Chart.yaml` file, currently set as `0.4.13`.
+By default the chart selects the Platform application images defined in the `appVersion` field of the `Chart.yaml` file, currently set as `0.4.15`.
 
 When a sensitive value is required (e.g. the database password, the Seqera license key), you can either provide it directly in the values file or reference an existing Kubernetes Secret containing the value. The key names to use in the provided Secret are specified in the values file comments.
 Sensitive values provided as plain text by the user are always stored in a Kubernetes Secret created by the chart. When an external Secret is used instead, the chart instructs the components to read the sensitive value from the external Secret directly, without further storing copies of the sensitive value in the chart-created Secret.

--- a/charts/platform/charts/portal-web/CHANGELOG.md
+++ b/charts/platform/charts/portal-web/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Bumped `appVersion` to `1.7.2`.
 - Bumped `seqera-common` dependency to `3.x.x` (the library no longer exposes
   `seqera.images.image` nor honors `global.azure.images` overrides).
 

--- a/charts/platform/charts/portal-web/Chart.yaml
+++ b/charts/platform/charts/portal-web/Chart.yaml
@@ -20,7 +20,7 @@ name: portal-web
 description: Portal web frontend for Seqera Platform
 type: application
 version: 0.4.0
-appVersion: "1.6.0"
+appVersion: "1.7.2"
 icon: https://raw.githubusercontent.com/seqeralabs/helm-charts/master/media/seqera-icon-light.svg
 maintainers:
   - name: Seqera Labs

--- a/charts/platform/charts/portal-web/README.md
+++ b/charts/platform/charts/portal-web/README.md
@@ -2,7 +2,7 @@
 
 Portal web frontend for Seqera Platform
 
-![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.6.0](https://img.shields.io/badge/AppVersion-1.6.0-informational?style=flat-square)
+![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.7.2](https://img.shields.io/badge/AppVersion-1.7.2-informational?style=flat-square)
 
 Some basic familiarity with Helm is assumed. If you are new to Helm, please refer to the [Helm documentation](https://helm.sh/docs/).
 We recommend reading through the `values.yaml` file to understand the configuration options available for the chart. Each entry in the `values.yaml` file is documented with comments describing its purpose and usage.
@@ -27,7 +27,7 @@ The required values to set in order to have a working installation are:
 
 The Helm chart comes with several requirement checks that will validate the provided configuration before proceeding with the installation.
 
-By default the chart selects the application images defined in the `appVersion` field of the `Chart.yaml` file, currently set as `1.6.0`.
+By default the chart selects the application images defined in the `appVersion` field of the `Chart.yaml` file, currently set as `1.7.2`.
 
 ## Installing the chart
 

--- a/charts/platform/charts/wave/CHANGELOG.md
+++ b/charts/platform/charts/wave/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.3.0] - 2026-07-07
 
+### Changed
+
+- Bumped `appVersion` to `v1.35.0`.
+
 ### Removed
 
 - **BREAKING**: Removed `global.azure.images` image overrides for the `wave` container, its

--- a/charts/platform/charts/wave/Chart.yaml
+++ b/charts/platform/charts/wave/Chart.yaml
@@ -20,7 +20,7 @@ name: wave
 description: Wave
 type: application
 version: 0.3.0
-appVersion: "v1.32.4"
+appVersion: "v1.35.0"
 icon: https://raw.githubusercontent.com/seqeralabs/helm-charts/master/media/seqera-icon-light.svg
 maintainers:
   - name: Seqera Labs

--- a/charts/platform/charts/wave/README.md
+++ b/charts/platform/charts/wave/README.md
@@ -2,7 +2,7 @@
 
 Wave
 
-![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.32.4](https://img.shields.io/badge/AppVersion-v1.32.4-informational?style=flat-square)
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.35.0](https://img.shields.io/badge/AppVersion-v1.35.0-informational?style=flat-square)
 
 Some basic familiarity with Helm is assumed. If you are new to Helm, please refer to the [Helm documentation](https://helm.sh/docs/).
 We recommend reading through the `values.yaml` file to understand the configuration options available for the chart. Each entry in the `values.yaml` file is documented with comments describing its purpose and usage.
@@ -24,7 +24,7 @@ The required values to set in order to have a working installation are:
 
 The Helm chart comes with several requirement checks that will validate the provided configuration before proceeding with the installation.
 
-By default the chart selects the application images defined in the `appVersion` field of the `Chart.yaml` file, currently set as `v1.32.4`.
+By default the chart selects the application images defined in the `appVersion` field of the `Chart.yaml` file, currently set as `v1.35.0`.
 
 When a sensitive value is required (e.g. the database password, the Seqera license key), you can either provide it directly in the values file or reference an existing Kubernetes Secret containing the value. The key names to use in the provided Secret are specified in the values file comments.
 Sensitive values provided as plain text by the user are always stored in a Kubernetes Secret created by the chart. When an external Secret is used instead, the chart instructs the components to read the sensitive value from the external Secret directly, without further storing copies of the sensitive value in the chart-created Secret.


### PR DESCRIPTION
Update several app versions (all but studios, I asked the team to confirm no updates were released):
- platform v26.1.0 → v26.1.3
- agent-backend 1.11.0 → 1.13.1
- mcp 1.3.0 → 1.4.2
- pipeline-optimization 0.4.13 → 0.4.15
- portal-web 1.6.0 → 1.7.2
- wave v1.32.4 → v1.35.0
