### PR TITLE
fix: align backend Secret refs with `common.names.fullname` collapse rule

### DIFF
--- a/charts/platform/CHANGELOG.md
+++ b/charts/platform/CHANGELOG.md
@@ -11,6 +11,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bumped Platform `appVersion` to `v26.1.3`.
 
+### Fixed
+
+- Align the default `.global.platformServiceAddress`, `.studios.proxy.oidcClientRegistrationTokenSecretName`,
+  and `.mcp.oidcToken.existingSecretName` templates with the naming rule used by the backend
+  Deployment and Secret (`common.names.fullname` + `-backend`). Previously these defaults were
+  hard-coded to `{{ .Release.Name }}-platform-backend`, which produced a name like
+  `seqera-platform-platform-backend` for releases whose name already contained `platform` — a
+  resource that never exists in-cluster, because `common.names.fullname` collapses the repeated
+  chart name. The subchart references now use `common.names.dependency.fullname` with an explicit
+  `chartName: platform` so the correct parent name is produced from the subchart's render context.
+  Resolved names are unchanged for releases whose name does not contain `platform`.
+
 ### Removed
 
 - **BREAKING**: Removed support for overriding container images via `global.azure.images`

--- a/charts/platform/README.md
+++ b/charts/platform/README.md
@@ -80,7 +80,7 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 |-----|------|---------|-------------|
 | global.platformExternalDomain | string | `"example.com"` | Domain where Seqera Platform listens |
 | global.contentDomain | string | `"{{ printf \"user-data.%s\" .Values.global.platformExternalDomain }}"` | Domain where user-created Platform reports are exposed, to avoid Cross-Site Scripting (XSS) attacks. If unset, data is served through the main domain `.global.platformExternalDomain`. Evaluated as a template |
-| global.platformServiceAddress | string | `"{{ printf \"%s-platform-backend\" .Release.Name | lower }}"` | Seqera Platform Service name: can be the internal Kubernetes hostname or an external ingress hostname. Evaluated as a template |
+| global.platformServiceAddress | string | `"{{ printf \"%s-backend\" (include \"common.names.fullname\" .) | lower }}"` | Seqera Platform Service name: can be the internal Kubernetes hostname or an external ingress hostname. Evaluated as a template. Routed through `common.names.fullname` so it stays aligned with the backend Deployment/Secret naming and collapses correctly when the release name already contains `platform` (e.g. `seqera-platform` → `seqera-platform-backend` rather than `seqera-platform-platform-backend`) |
 | global.platformServicePort | int | `8080` | Seqera Platform Service port |
 | global.studiosDomain | string | `"{{ printf \"studios.%s\" .Values.global.platformExternalDomain }}"` | Domain where the Studios service listens. Make sure the TLS certificate covers this and its wildcard subdomains. Evaluated as a template |
 | global.studiosConnectionUrl | string | `"{{ printf \"https://connect.%s\" (tpl .Values.global.studiosDomain $) }}"` | Base URL for Studios connections: can be any value, since each session will use a unique subdomain under `.global.studiosDomain` anyway to connect. Evaluated as a template |
@@ -401,11 +401,11 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | commonAnnotations | object | `{}` | Annotations to add to all deployed objects |
 | commonLabels | object | `{}` | Labels to add to all deployed objects |
 | studios.enabled | bool | `true` | Enable Studios feature. Refer to the subchart README for more details and the full list of configuration options |
-| studios.proxy.oidcClientRegistrationTokenSecretName | string | `"{{ printf \"%s-platform-backend\" .Release.Name }}"` |  |
+| studios.proxy.oidcClientRegistrationTokenSecretName | string | `"{{ printf \"%s-backend\" (include \"common.names.dependency.fullname\" (dict \"chartName\" \"platform\" \"chartValues\" .Values \"context\" .)) }}"` |  |
 | studios.proxy.oidcClientRegistrationTokenSecretKey | string | `"OIDC_CLIENT_REGISTRATION_TOKEN"` |  |
 | pipeline-optimization.enabled | bool | `true` | Enable pipeline optimization feature. Refer to the subchart README for more details and the full list of configuration options |
 | mcp.enabled | bool | `true` | Enable the Seqera Model Context Protocol (MCP) service. Refer to the subchart README for more details and the full list of configuration options |
-| mcp.oidcToken.existingSecretName | string | `"{{ printf \"%s-platform-backend\" .Release.Name }}"` |  |
+| mcp.oidcToken.existingSecretName | string | `"{{ printf \"%s-backend\" (include \"common.names.dependency.fullname\" (dict \"chartName\" \"platform\" \"chartValues\" .Values \"context\" .)) }}"` |  |
 | mcp.oidcToken.existingSecretKey | string | `"OIDC_CLIENT_REGISTRATION_TOKEN"` |  |
 | agent-backend.enabled | bool | `true` | Enable agent backend feature used by seqera cli ai command. Refer to the subchart README for more details and the full list of configuration options |
 | portal-web.enabled | bool | `true` | Enable portal web frontend. Refer to the subchart README for more details and the full list of configuration options |

--- a/charts/platform/tests/oidc_token_secret_reference_test.yaml
+++ b/charts/platform/tests/oidc_token_secret_reference_test.yaml
@@ -1,0 +1,112 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+#
+# Copyright (c) 2025 - 2026 Seqera Labs
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Regression tests for the default Studios/MCP references to the platform
+# backend Secret. The parent chart defaults (charts/platform/values.yaml) wire
+# both subcharts to the platform backend Secret via
+#   '{{ printf "%s-platform-backend" .Release.Name }}'
+# but the platform backend Secret's own name is
+#   '{{ include "common.names.fullname" . }}-backend'
+# and common.names.fullname collapses '<name>-platform' releases down to
+# '<name>-platform' (no doubling). If the release name already contains
+# 'platform' the two names diverge and the subchart pods reference a Secret
+# that does not exist.
+suite: test OIDC token Secret reference alignment (parent defaults)
+templates:
+- charts/studios/templates/deployment-proxy.yaml
+- charts/studios/templates/secret.yaml
+- charts/mcp/templates/deployment.yaml
+- charts/mcp/templates/secret.yaml
+- charts/mcp/templates/configmap.yaml
+- secret.yaml
+chart:
+  version: 9.8.7
+  appVersion: 1.2.3-asdf
+# Avoid expensive RSA key generation.
+set:
+  platform:
+    oidcPrivateKeyBase64: "LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlCb3dJQkFBS0JBUUVBMQ=="
+tests:
+# --- Sanity: release name does NOT contain the chart name --------------------
+# common.names.fullname returns '<release>-<chart>' when the release does not
+# contain the chart name, so both the platform backend Secret and the
+# subcharts' default reference resolve to 'myrelease-platform-backend'.
+- it: platform backend Secret is named '<release>-platform-backend' when the release does not contain 'platform'
+  release:
+    name: myrelease
+  template: secret.yaml
+  documentSelector:
+    path: kind
+    value: Secret
+  asserts:
+  - equal:
+      path: metadata.name
+      value: myrelease-platform-backend
+- it: Studios proxy references '<release>-platform-backend' when the release does not contain 'platform'
+  release:
+    name: myrelease
+  template: charts/studios/templates/deployment-proxy.yaml
+  asserts:
+  - equal:
+      path: spec.template.spec.containers[0].env[?(@.name=="CONNECT_OIDC_CLIENT_REGISTRATION_TOKEN")].valueFrom.secretKeyRef.name
+      value: myrelease-platform-backend
+- it: MCP references '<release>-platform-backend' when the release does not contain 'platform'
+  release:
+    name: myrelease
+  template: charts/mcp/templates/deployment.yaml
+  asserts:
+  - equal:
+      path: spec.template.spec.containers[0].env[?(@.name=="MCP_OAUTH_INITIAL_ACCESS_TOKEN")].valueFrom.secretKeyRef.name
+      value: myrelease-platform-backend
+
+# --- Regression: release name already contains 'platform' --------------------
+# With release 'seqera-platform', common.names.fullname collapses the repeated
+# 'platform' so the platform Secret is 'seqera-platform-backend'. The default
+# '{{ .Release.Name }}-platform-backend' template used by both subcharts does
+# NOT collapse, so it resolves to 'seqera-platform-platform-backend' — a
+# Secret that does not exist. The last two tests below therefore fail today
+# and will only pass once the defaults are switched to
+# '{{ include "common.names.fullname" . }}-backend' (or equivalent).
+- it: platform backend Secret collapses the doubled 'platform' when release name already contains it
+  release:
+    name: seqera-platform
+  template: secret.yaml
+  documentSelector:
+    path: kind
+    value: Secret
+  asserts:
+  - equal:
+      path: metadata.name
+      value: seqera-platform-backend
+- it: Studios proxy points at the same collapsed name as the platform backend Secret
+  release:
+    name: seqera-platform
+  template: charts/studios/templates/deployment-proxy.yaml
+  asserts:
+  - equal:
+      path: spec.template.spec.containers[0].env[?(@.name=="CONNECT_OIDC_CLIENT_REGISTRATION_TOKEN")].valueFrom.secretKeyRef.name
+      value: seqera-platform-backend
+- it: MCP points at the same collapsed name as the platform backend Secret
+  release:
+    name: seqera-platform
+  template: charts/mcp/templates/deployment.yaml
+  asserts:
+  - equal:
+      path: spec.template.spec.containers[0].env[?(@.name=="MCP_OAUTH_INITIAL_ACCESS_TOKEN")].valueFrom.secretKeyRef.name
+      value: seqera-platform-backend

--- a/charts/platform/values.schema.json
+++ b/charts/platform/values.schema.json
@@ -3538,8 +3538,8 @@
           "type": "string"
         },
         "platformServiceAddress": {
-          "default": "{{ printf \"%s-platform-backend\" .Release.Name | lower }}",
-          "description": "Seqera Platform Service name: can be the internal Kubernetes hostname or an external ingress\nhostname. Evaluated as a template",
+          "default": "{{ printf \"%s-backend\" (include \"common.names.fullname\" .) | lower }}",
+          "description": "Seqera Platform Service name: can be the internal Kubernetes hostname or an external ingress\nhostname. Evaluated as a template. Routed through `common.names.fullname` so it stays aligned\nwith the backend Deployment/Secret naming and collapses correctly when the release name\nalready contains `platform` (e.g. `seqera-platform` → `seqera-platform-backend` rather than\n`seqera-platform-platform-backend`)",
           "title": "platformServiceAddress",
           "type": "string"
         },

--- a/charts/platform/values.yaml
+++ b/charts/platform/values.yaml
@@ -41,8 +41,11 @@ global:
   contentDomain: '{{ printf "user-data.%s" .Values.global.platformExternalDomain }}'
 
   # -- Seqera Platform Service name: can be the internal Kubernetes hostname or an external ingress
-  # hostname. Evaluated as a template
-  platformServiceAddress: '{{ printf "%s-platform-backend" .Release.Name | lower }}'
+  # hostname. Evaluated as a template. Routed through `common.names.fullname` so it stays aligned
+  # with the backend Deployment/Secret naming and collapses correctly when the release name
+  # already contains `platform` (e.g. `seqera-platform` → `seqera-platform-backend` rather than
+  # `seqera-platform-platform-backend`)
+  platformServiceAddress: '{{ printf "%s-backend" (include "common.names.fullname" .) | lower }}'
   # @schema
   # type: [integer, string, null]
   # @schema
@@ -1314,7 +1317,10 @@ studios:
   proxy:
     # Wire the OIDC registration token to the platform backend secret so all consumers share the
     # same token. Override these values only if you want studios to use a different secret.
-    oidcClientRegistrationTokenSecretName: '{{ printf "%s-platform-backend" .Release.Name }}'
+    # `common.names.dependency.fullname` is used (rather than `common.names.fullname`) because this
+    # value is `tpl`-evaluated inside the studios subchart context where `.Chart.Name` is `studios`,
+    # not `platform`; passing `chartName: platform` explicitly reproduces the parent's fullname
+    oidcClientRegistrationTokenSecretName: '{{ printf "%s-backend" (include "common.names.dependency.fullname" (dict "chartName" "platform" "chartValues" .Values "context" .)) }}'
     oidcClientRegistrationTokenSecretKey: "OIDC_CLIENT_REGISTRATION_TOKEN"
 
 pipeline-optimization:
@@ -1329,7 +1335,10 @@ mcp:
   oidcToken:
     # Wire the OIDC registration token to the platform backend secret so all consumers share the
     # same token. Override these values only if you want mcp to use a different secret.
-    existingSecretName: '{{ printf "%s-platform-backend" .Release.Name }}'
+    # `common.names.dependency.fullname` is used (rather than `common.names.fullname`) because this
+    # value is `tpl`-evaluated inside the mcp subchart context where `.Chart.Name` is `mcp`, not
+    # `platform`; passing `chartName: platform` explicitly reproduces the parent's fullname
+    existingSecretName: '{{ printf "%s-backend" (include "common.names.dependency.fullname" (dict "chartName" "platform" "chartValues" .Values "context" .)) }}'
     existingSecretKey: "OIDC_CLIENT_REGISTRATION_TOKEN"
 
 agent-backend:


### PR DESCRIPTION
The default `.global.platformServiceAddress`, `.studios.proxy.oidcClient RegistrationTokenSecretName`, and `.mcp.oidcToken.existingSecretName` values were hard-coded to `{{ .Release.Name }}-platform-backend`. For releases whose name already contains `platform` (e.g. `seqera-platform`) that produced `seqera-platform-platform-backend` — a Secret/Service that never exists in-cluster, because the parent's `common.names.fullname` collapses the repeated chart name to `seqera-platform`.

Switch to `common.names.fullname` in the parent context, and to `common.names.dependency.fullname` with `chartName: platform` in the subchart-context values so the subchart's `.Chart.Name` (`studios` / `mcp`) doesn't leak into the resolved name. Resolved names are unchanged for releases that don't contain `platform`, so no snapshots churn.

Adds a regression suite that renders the parent Secret alongside the Studios proxy and MCP deployments for both a normal release and the `seqera-platform` edge case, and asserts all three names align.

Thanks to @gwright99 for reporting the bug.