### PR TITLE
fix: make ingress.contentPath default to ingress.path or global.ingress.path

### DIFF
--- a/charts/platform/CHANGELOG.md
+++ b/charts/platform/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   chart name. The subchart references now use `common.names.dependency.fullname` with an explicit
   `chartName: platform` so the correct parent name is produced from the subchart's render context.
   Resolved names are unchanged for releases whose name does not contain `platform`.
+- `ingress.contentPath` now falls back to `ingress.path` (and then `global.ingress.path`) when left empty, consistent with how other path values are resolved.
 
 ### Removed
 

--- a/charts/platform/README.md
+++ b/charts/platform/README.md
@@ -389,7 +389,7 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | serviceAccount.automountServiceAccountToken | bool | `false` | Automount service account token when the service account is generated |
 | ingress.enabled | bool | `false` | Enable ingress for Platform |
 | ingress.path | string | `""` | Path for the main ingress rule. When empty, falls back to `global.ingress.path` |
-| ingress.contentPath | string | `"/"` | Path for the content domain ingress rule |
+| ingress.contentPath | string | `""` | Path for the content domain ingress rule. When empty, falls back to `ingress.path` |
 | ingress.defaultPathType | string | `""` | Default path type for the Ingress. When empty, falls back to `global.ingress.defaultPathType` |
 | ingress.defaultBackend | object | `{}` | Configure the default service for the ingress (evaluated as template) Important: make sure only one defaultBackend is defined across the k8s cluster: if the ingress doesn't reconcile successfully, 'describe ingress <name>' will report problems |
 | ingress.extraHosts | list | `[]` | Additional hosts you want to include. Evaluated as a template |

--- a/charts/platform/charts/agent-backend/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/platform/charts/agent-backend/tests/__snapshot__/deployment_test.yaml.snap
@@ -129,7 +129,7 @@ should render a Deployment with default values:
                 - sh
                 - -c
                 - |
-                  echo "$(date): starting check redis '$REDIS_URI' (auth ${REDISCLI_AUTH:+set})"
+                  if [ -n "$REDISCLI_AUTH" ]; then echo "$(date): starting check redis '$REDIS_URI' (auth set)"; else echo "$(date): starting check redis '$REDIS_URI' (auth not set)"; fi
                   until redis-cli -u "$REDIS_URI" get hello; do
                     echo "$(date): see you in $SLEEP_PERIOD_SECONDS seconds"
                     sleep $SLEEP_PERIOD_SECONDS

--- a/charts/platform/charts/wave/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/platform/charts/wave/tests/__snapshot__/deployment_test.yaml.snap
@@ -130,7 +130,7 @@ should render a Deployment with default values:
                 - sh
                 - -c
                 - |
-                  echo "$(date): starting check redis '$REDIS_URI' (auth ${REDISCLI_AUTH:+set})"
+                  if [ -n "$REDISCLI_AUTH" ]; then echo "$(date): starting check redis '$REDIS_URI' (auth set)"; else echo "$(date): starting check redis '$REDIS_URI' (auth not set)"; fi
                   until redis-cli -u "$REDIS_URI" get hello; do
                     echo "$(date): see you in $SLEEP_PERIOD_SECONDS seconds"
                     sleep $SLEEP_PERIOD_SECONDS

--- a/charts/platform/examples/ingress-configurations/aws-alb.yaml
+++ b/charts/platform/examples/ingress-configurations/aws-alb.yaml
@@ -49,7 +49,7 @@ ingress:
 
   # ALB requires path "/*" instead of "/"
   path: "/*"
-  contentPath: "/*"
+  # contentPath: "/*"  # defaults to ingress.path if empty
 
   annotations:
     # ALB configuration

--- a/charts/platform/templates/ingress.yaml
+++ b/charts/platform/templates/ingress.yaml
@@ -25,6 +25,7 @@
   {{- $annotations := include "common.tplvalues.render" (dict "value" $mergedAnnotations "context" $) -}}
   {{- $defaultPathType := default .Values.global.ingress.defaultPathType .Values.ingress.defaultPathType -}}
   {{- $path := default .Values.global.ingress.path .Values.ingress.path -}}
+  {{- $contentPath := default $path .Values.ingress.contentPath -}}
   {{- $ingressClassName := default .Values.global.ingress.ingressClassName .Values.ingress.ingressClassName -}}
   {{- $tls := concat (default (list) .Values.ingress.tls) (default (list) .Values.global.ingress.tls) -}}
 
@@ -66,7 +67,7 @@ spec:
     - host: {{ tpl .Values.global.contentDomain $ | quote }}
       http:
         paths:
-          - path: {{ .Values.ingress.contentPath | quote }}
+          - path: {{ $contentPath | quote }}
             pathType: {{ $defaultPathType }}
             backend:
               service:

--- a/charts/platform/tests/__snapshot__/deployment-backend_test.yaml.snap
+++ b/charts/platform/tests/__snapshot__/deployment-backend_test.yaml.snap
@@ -123,7 +123,7 @@ should produce a Deployment resource with minimal values:
           - sh
           - -c
           - |
-            echo "$(date): starting check redis '$REDIS_URI' (auth ${REDISCLI_AUTH:+set})"
+            if [ -n "$REDISCLI_AUTH" ]; then echo "$(date): starting check redis '$REDIS_URI' (auth set)"; else echo "$(date): starting check redis '$REDIS_URI' (auth not set)"; fi
             until redis-cli -u "$REDIS_URI" get hello; do
               echo "$(date): see you in $SLEEP_PERIOD_SECONDS seconds"
               sleep $SLEEP_PERIOD_SECONDS
@@ -364,7 +364,7 @@ should render the backend deployment with the correct checksums, labels and anno
                 - sh
                 - -c
                 - |
-                  echo "$(date): starting check redis '$REDIS_URI' (auth ${REDISCLI_AUTH:+set})"
+                  if [ -n "$REDISCLI_AUTH" ]; then echo "$(date): starting check redis '$REDIS_URI' (auth set)"; else echo "$(date): starting check redis '$REDIS_URI' (auth not set)"; fi
                   until redis-cli -u "$REDIS_URI" get hello; do
                     echo "$(date): see you in $SLEEP_PERIOD_SECONDS seconds"
                     sleep $SLEEP_PERIOD_SECONDS

--- a/charts/platform/tests/__snapshot__/deployment-cron_test.yaml.snap
+++ b/charts/platform/tests/__snapshot__/deployment-cron_test.yaml.snap
@@ -118,7 +118,7 @@ should produce a Deployment resource with minimal values:
           - sh
           - -c
           - |
-            echo "$(date): starting check redis '$REDIS_URI' (auth ${REDISCLI_AUTH:+set})"
+            if [ -n "$REDISCLI_AUTH" ]; then echo "$(date): starting check redis '$REDIS_URI' (auth set)"; else echo "$(date): starting check redis '$REDIS_URI' (auth not set)"; fi
             until redis-cli -u "$REDIS_URI" get hello; do
               echo "$(date): see you in $SLEEP_PERIOD_SECONDS seconds"
               sleep $SLEEP_PERIOD_SECONDS
@@ -355,7 +355,7 @@ should render the cron deployment with the correct checksums, labels and annotat
                 - sh
                 - -c
                 - |
-                  echo "$(date): starting check redis '$REDIS_URI' (auth ${REDISCLI_AUTH:+set})"
+                  if [ -n "$REDISCLI_AUTH" ]; then echo "$(date): starting check redis '$REDIS_URI' (auth set)"; else echo "$(date): starting check redis '$REDIS_URI' (auth not set)"; fi
                   until redis-cli -u "$REDIS_URI" get hello; do
                     echo "$(date): see you in $SLEEP_PERIOD_SECONDS seconds"
                     sleep $SLEEP_PERIOD_SECONDS

--- a/charts/platform/tests/ingress_test.yaml
+++ b/charts/platform/tests/ingress_test.yaml
@@ -188,6 +188,35 @@ tests:
   - equal:
       path: spec.rules[1].http.paths[0].path
       value: /platform/*
+- it: should fall back to ingress.path for content domain when contentPath is empty
+  set:
+    ingress:
+      enabled: true
+      path: /*
+      contentPath: ""
+    global:
+      platformExternalDomain: platform.example.com
+  asserts:
+  - equal:
+      path: spec.rules[1].http.paths[0].path
+      value: /*
+- it: should fall back to global.ingress.path for content domain when both local path and contentPath are empty
+  set:
+    ingress:
+      enabled: true
+      path: ""
+      contentPath: ""
+    global:
+      platformExternalDomain: platform.example.com
+      ingress:
+        path: /global/*
+  asserts:
+  - equal:
+      path: spec.rules[0].http.paths[0].path
+      value: /global/*
+  - equal:
+      path: spec.rules[1].http.paths[0].path
+      value: /global/*
 - it: should configure extra hosts with multiple paths
   set:
     ingress:

--- a/charts/platform/values.schema.json
+++ b/charts/platform/values.schema.json
@@ -3605,8 +3605,8 @@
           "type": "object"
         },
         "contentPath": {
-          "default": "/",
-          "description": "Path for the content domain ingress rule",
+          "default": "",
+          "description": "Path for the content domain ingress rule. When empty, falls back to `ingress.path`",
           "title": "contentPath",
           "type": "string"
         },

--- a/charts/platform/values.yaml
+++ b/charts/platform/values.yaml
@@ -1248,8 +1248,8 @@ ingress:
   # -- Path for the main ingress rule. When empty, falls back to `global.ingress.path`
   path: ""
 
-  # -- Path for the content domain ingress rule
-  contentPath: "/"
+  # -- Path for the content domain ingress rule. When empty, falls back to `ingress.path`
+  contentPath: ""
 
   # -- Default path type for the Ingress. When empty, falls back to `global.ingress.defaultPathType`
   defaultPathType: ""


### PR DESCRIPTION
I noticed that we could make `ingress.contentPath` smarter (paths are required to be set to `/*` when using AWS ALB).