### PR TITLE
fix: Resolve platformServiceAddress via dependency.fullname so subcharts see the correct backend name

### DIFF
--- a/charts/platform/CHANGELOG.md
+++ b/charts/platform/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.35.1] - 2026-07-13
 
+### Changed
+
+- Move `TOWER_SMTP_HOST`, `TOWER_SMTP_PORT` and `TOWER_SMTP_USER` from the
+  `<release>-platform-shared-backend-cron` ConfigMap into the `<release>-platform-cron` ConfigMap,
+  so SMTP configuration is only injected into the cron Deployment (which sends scheduled emails)
+  and no longer leaks into the backend Deployment's environment.
+
 ### Fixed
 
 - Fix the default `global.platformServiceAddress` template so it resolves to the parent chart's

--- a/charts/platform/CHANGELOG.md
+++ b/charts/platform/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.35.1] - 2026-07-13
+
+### Fixed
+
+- Fix the default `global.platformServiceAddress` template so it resolves to the parent chart's
+  fullname when `tpl`-evaluated inside a subchart context. Previously it used
+  `common.names.fullname .`, which reads `.Chart.Name` from the current rendering context — when
+  the value was consumed from subchart templates (e.g. the MCP `wait-for-platform` init container
+  or the MCP ConfigMap's `TOWER_API_ENDPOINT`), it resolved to `<release>-<subchart>-backend`
+  (e.g. `enterprise-mcp-backend`) rather than the actual backend Service name
+  (`enterprise-platform-backend`), causing MCP pods to hang forever in init waiting on a host that
+  never exists. Switched to `common.names.dependency.fullname` with an explicit
+  `chartName: platform`, matching the pattern already used for
+  `mcp.oidcToken.existingSecretName` and `studios.proxy.oidcClientRegistrationTokenSecretName`.
+
 ## [0.35.0] - 2026-07-07
 
 ### Added

--- a/charts/platform/Chart.yaml
+++ b/charts/platform/Chart.yaml
@@ -38,7 +38,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.35.0
+version: 0.35.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/platform/examples/kustomize/kustomization.yaml
+++ b/charts/platform/examples/kustomize/kustomization.yaml
@@ -7,7 +7,7 @@ namespace: albertoc-platform
 helmCharts:
 - name: platform
   repo: oci://public.cr.seqera.io/charts
-  version: 0.33.8
+  version: 0.35.1 # Update this to the newest version when available
   releaseName: seqera-platform
   # Basic values to provide to the Helm chart
   valuesFile: values.yaml

--- a/charts/platform/templates/configmap.yaml
+++ b/charts/platform/templates/configmap.yaml
@@ -56,6 +56,11 @@ metadata:
 data:
   MICRONAUT_ENVIRONMENTS: {{ include "platform.cron.micronautEnvs" . }}
   TOWER_CRON_SERVER_PORT: {{ .Values.cron.service.http.targetPort | int | quote }}
+{{- if .Values.platform.smtp.host }}
+  TOWER_SMTP_HOST: {{ .Values.platform.smtp.host | quote }}
+  TOWER_SMTP_PORT: {{ .Values.platform.smtp.port | quote }}
+  TOWER_SMTP_USER: {{ .Values.platform.smtp.user | quote }}
+{{- end }}
 ---
 kind: ConfigMap
 apiVersion: v1
@@ -84,12 +89,6 @@ data:
   TOWER_DB_MIN_POOL_SIZE: {{ .Values.platformDatabase.minPoolSize | toString | quote }}
 
   TOWER_OIDC_PEM_PATH: /data/certs/oidc.pem
-
-{{- if .Values.platform.smtp.host }}
-  TOWER_SMTP_HOST: {{ .Values.platform.smtp.host | quote }}
-  TOWER_SMTP_PORT: {{ .Values.platform.smtp.port | quote }}
-  TOWER_SMTP_USER: {{ .Values.platform.smtp.user | quote }}
-{{- end }}
 ---
 kind: ConfigMap
 apiVersion: v1

--- a/charts/platform/values.schema.json
+++ b/charts/platform/values.schema.json
@@ -3544,8 +3544,8 @@
           "type": "string"
         },
         "platformServiceAddress": {
-          "default": "{{ printf \"%s-backend\" (include \"common.names.fullname\" .) | lower }}",
-          "description": "Seqera Platform Service name: can be the internal Kubernetes hostname or an external ingress\nhostname. Evaluated as a template. Routed through `common.names.fullname` so it stays aligned\nwith the backend Deployment/Secret naming and collapses correctly when the release name\nalready contains `platform` (e.g. `seqera-platform` → `seqera-platform-backend` rather than\n`seqera-platform-platform-backend`)",
+          "default": "{{ printf \"%s-backend\" (include \"common.names.dependency.fullname\" (dict \"chartName\" \"platform\" \"chartValues\" .Values \"context\" .)) | lower }}",
+          "description": "Seqera Platform Service name: can be the internal Kubernetes hostname or an external ingress\nhostname. Evaluated as a template. Routed through `common.names.dependency.fullname` (with an\nexplicit `chartName: platform`) so it stays aligned with the backend Deployment/Secret naming\nand collapses correctly when the release name already contains `platform` (e.g.\n`seqera-platform` → `seqera-platform-backend` rather than `seqera-platform-platform-backend`).\n`common.names.dependency.fullname` is used (rather than `common.names.fullname`) because this\nvalue is `tpl`-evaluated inside subchart contexts (e.g. mcp, studios) where `.Chart.Name` is\nthe subchart's name, not `platform`; passing `chartName: platform` explicitly reproduces the\nparent's fullname regardless of the rendering context",
           "title": "platformServiceAddress",
           "type": "string"
         },

--- a/charts/platform/values.yaml
+++ b/charts/platform/values.yaml
@@ -43,12 +43,16 @@ global:
   contentDomain: '{{ printf "user-data.%s" .Values.global.platformExternalDomain }}'
 
   # -- Seqera Platform Service name: can be the internal Kubernetes hostname or an external ingress
-  # hostname. Evaluated as a template. Routed through `common.names.fullname` so it stays aligned
-  # with the backend Deployment/Secret naming and collapses correctly when the release name
-  # already contains `platform` (e.g. `seqera-platform` → `seqera-platform-backend` rather than
-  # `seqera-platform-platform-backend`)
+  # hostname. Evaluated as a template. Routed through `common.names.dependency.fullname` (with an
+  # explicit `chartName: platform`) so it stays aligned with the backend Deployment/Secret naming
+  # and collapses correctly when the release name already contains `platform` (e.g.
+  # `seqera-platform` → `seqera-platform-backend` rather than `seqera-platform-platform-backend`).
+  # `common.names.dependency.fullname` is used (rather than `common.names.fullname`) because this
+  # value is `tpl`-evaluated inside subchart contexts (e.g. mcp, studios) where `.Chart.Name` is
+  # the subchart's name, not `platform`; passing `chartName: platform` explicitly reproduces the
+  # parent's fullname regardless of the rendering context
   # @section -- Global
-  platformServiceAddress: '{{ printf "%s-backend" (include "common.names.fullname" .) | lower }}'
+  platformServiceAddress: '{{ printf "%s-backend" (include "common.names.dependency.fullname" (dict "chartName" "platform" "chartValues" .Values "context" .)) | lower }}'
   # @schema
   # type: [integer, string, null]
   # @schema

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "ignorePaths": [
+    "charts/platform/examples/kustomize/kustomization.yaml"
+  ]
+}


### PR DESCRIPTION
The default `global.platformServiceAddress` used `common.names.fullname .`, which reads `.Chart.Name` from the current rendering context. When `tpl`-evaluated inside the MCP subchart (wait-for-platform init container, TOWER_API_ENDPOINT in the ConfigMap), it resolved to `<release>-mcp-backend` instead of the actual backend Service `<release>-platform-backend`, so MCP pods hung forever in init.

Switched to `common.names.dependency.fullname` with an explicit `chartName: platform`, matching the pattern already used for `mcp.oidcToken.existingSecretName` and
`studios.proxy.oidcClientRegistrationTokenSecretName`.