### PR TITLE
refactor: Move TOWER_SMTP_HOST/PORT/USER into the cron ConfigMap 

### DIFF
--- a/charts/platform/CHANGELOG.md
+++ b/charts/platform/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.35.1] - 2026-07-13
 
+### Changed
+
+- Move `TOWER_SMTP_HOST`, `TOWER_SMTP_PORT` and `TOWER_SMTP_USER` from the
+  `<release>-platform-shared-backend-cron` ConfigMap into the `<release>-platform-cron` ConfigMap,
+  so SMTP configuration is only injected into the cron Deployment (which sends scheduled emails)
+  and no longer leaks into the backend Deployment's environment.
+
 ### Fixed
 
 - Fix the default `global.platformServiceAddress` template so it resolves to the parent chart's

--- a/charts/platform/examples/kustomize/kustomization.yaml
+++ b/charts/platform/examples/kustomize/kustomization.yaml
@@ -7,7 +7,7 @@ namespace: albertoc-platform
 helmCharts:
 - name: platform
   repo: oci://public.cr.seqera.io/charts
-  version: 0.33.8
+  version: 0.35.1 # Update this to the newest version when available
   releaseName: seqera-platform
   # Basic values to provide to the Helm chart
   valuesFile: values.yaml

--- a/charts/platform/templates/configmap.yaml
+++ b/charts/platform/templates/configmap.yaml
@@ -56,6 +56,11 @@ metadata:
 data:
   MICRONAUT_ENVIRONMENTS: {{ include "platform.cron.micronautEnvs" . }}
   TOWER_CRON_SERVER_PORT: {{ .Values.cron.service.http.targetPort | int | quote }}
+{{- if .Values.platform.smtp.host }}
+  TOWER_SMTP_HOST: {{ .Values.platform.smtp.host | quote }}
+  TOWER_SMTP_PORT: {{ .Values.platform.smtp.port | quote }}
+  TOWER_SMTP_USER: {{ .Values.platform.smtp.user | quote }}
+{{- end }}
 ---
 kind: ConfigMap
 apiVersion: v1
@@ -84,12 +89,6 @@ data:
   TOWER_DB_MIN_POOL_SIZE: {{ .Values.platformDatabase.minPoolSize | toString | quote }}
 
   TOWER_OIDC_PEM_PATH: /data/certs/oidc.pem
-
-{{- if .Values.platform.smtp.host }}
-  TOWER_SMTP_HOST: {{ .Values.platform.smtp.host | quote }}
-  TOWER_SMTP_PORT: {{ .Values.platform.smtp.port | quote }}
-  TOWER_SMTP_USER: {{ .Values.platform.smtp.user | quote }}
-{{- end }}
 ---
 kind: ConfigMap
 apiVersion: v1

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "ignorePaths": [
+    "charts/platform/examples/kustomize/kustomization.yaml"
+  ]
+}


### PR DESCRIPTION
These env vars were previously in the shared-backend-cron ConfigMap, which is mounted by both the backend and cron Deployments. SMTP is only used by cron (to send scheduled emails), so keeping HOST/PORT/USER in the shared ConfigMap leaked mail-server configuration into the backend's environment for no reason.

Move them into the cron-only ConfigMap so SMTP settings are scoped to the Deployment that actually needs them.