### PR TITLE
chore: Set cron SMTP port default to 587, remove double quotes in Readmes

### DIFF
--- a/charts/platform/README.md
+++ b/charts/platform/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart to deploy Seqera Platform (also referred to as Tower) on Kubernetes.
 
-![Version: 0.35.0](https://img.shields.io/badge/Version-0.35.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v26.1.3](https://img.shields.io/badge/AppVersion-v26.1.3-informational?style=flat-square)
+![Version: 0.35.1](https://img.shields.io/badge/Version-0.35.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v26.1.3](https://img.shields.io/badge/AppVersion-v26.1.3-informational?style=flat-square)
 
 Some basic familiarity with Helm is assumed. If you are new to Helm, please refer to the [Helm documentation](https://helm.sh/docs/).
 We recommend reading through the `values.yaml` file to understand the configuration options available for the chart. Each entry is documented with `# --` comments describing its purpose and usage. Other annotations are used to automatically generate the README files and can be ignored:
@@ -47,13 +47,13 @@ To install the chart:
 
 1. Download the default values file:
    ```console
-   helm show values oci://public.cr.seqera.io/charts/platform --version 0.35.0 > values.yaml
+   helm show values oci://public.cr.seqera.io/charts/platform --version 0.35.1 > values.yaml
    ```
 2. Edit `values.yaml` to match your environment. We recommend removing entries whose defaults you don't need to override — this keeps your configuration file focused and easier to maintain across upgrades.
 3. Install the chart with the release name `my-release`:
    ```console
    helm install my-release oci://public.cr.seqera.io/charts/platform \
-     --version 0.35.0 \
+     --version 0.35.1 \
      --namespace my-namespace \
      --create-namespace \
      -f values.yaml
@@ -69,7 +69,7 @@ Charts are also published to a traditional Helm repository. This can be useful i
 helm repo add seqeralabs https://seqeralabs.github.io/helm-charts
 helm repo update
 helm install my-release seqeralabs/platform \
-  --version 0.35.0 \
+  --version 0.35.1 \
   --namespace my-namespace \
   --create-namespace \
   -f values.yaml
@@ -104,592 +104,592 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| global.platformExternalDomain | string | ``"example.com"`` | Domain where Seqera Platform listens |
-| global.contentDomain | string | ``"{{ printf \"user-data.%s\" .Values.global.platformExternalDomain }}"`` | Domain where user-created Platform reports are exposed, to avoid Cross-Site Scripting (XSS) attacks. If unset, data is served through the main domain `.global.platformExternalDomain`. Evaluated as a template |
-| global.platformServiceAddress | string | ``"{{ printf \"%s-backend\" (include \"common.names.fullname\" .) | lower }}"`` | Seqera Platform Service name: can be the internal Kubernetes hostname or an external ingress hostname. Evaluated as a template. Routed through `common.names.fullname` so it stays aligned with the backend Deployment/Secret naming and collapses correctly when the release name already contains `platform` (e.g. `seqera-platform` → `seqera-platform-backend` rather than `seqera-platform-platform-backend`) |
-| global.platformServicePort | int | ``8080`` | Seqera Platform Service port |
-| global.studiosDomain | string | ``"{{ printf \"studios.%s\" .Values.global.platformExternalDomain }}"`` | Domain where the Studios service listens. Make sure the TLS certificate covers this and its wildcard subdomains. Evaluated as a template |
-| global.studiosConnectionUrl | string | ``"{{ printf \"https://connect.%s\" (tpl .Values.global.studiosDomain $) }}"`` | Base URL for Studios connections: can be any value, since each session will use a unique subdomain under `.global.studiosDomain` anyway to connect. Evaluated as a template |
-| global.waveDomain | string | ``"{{ printf \"wave.%s\" .Values.global.platformExternalDomain }}"`` | Domain where Wave listens. Evaluated as a template |
-| global.mcpDomain | string | ``"{{ printf \"mcp.%s\" .Values.global.platformExternalDomain }}"`` | Domain where Seqera MCP listens. Evaluated as a template |
-| global.agentBackendDomain | string | ``"{{ printf \"ai-api.%s\" .Values.global.platformExternalDomain }}"`` | Domain where the Agent Backend service listens. Evaluated as a template |
-| global.portalWebDomain | string | ``"{{ printf \"ai.%s\" .Values.global.platformExternalDomain }}"`` | Domain where the Portal Web frontend listens. Evaluated as a template |
+| global.platformExternalDomain | string | `"example.com"` | Domain where Seqera Platform listens |
+| global.contentDomain | string | `"{{ printf \"user-data.%s\" .Values.global.platformExternalDomain }}"` | Domain where user-created Platform reports are exposed, to avoid Cross-Site Scripting (XSS) attacks. If unset, data is served through the main domain `.global.platformExternalDomain`. Evaluated as a template |
+| global.platformServiceAddress | string | `"{{ printf \"%s-backend\" (include \"common.names.dependency.fullname\" (dict \"chartName\" \"platform\" \"chartValues\" .Values \"context\" .)) | lower }}"` | Seqera Platform Service name: can be the internal Kubernetes hostname or an external ingress hostname. Evaluated as a template. Routed through `common.names.dependency.fullname` (with an explicit `chartName: platform`) so it stays aligned with the backend Deployment/Secret naming and collapses correctly when the release name already contains `platform` (e.g. `seqera-platform` → `seqera-platform-backend` rather than `seqera-platform-platform-backend`). `common.names.dependency.fullname` is used (rather than `common.names.fullname`) because this value is `tpl`-evaluated inside subchart contexts (e.g. mcp, studios) where `.Chart.Name` is the subchart's name, not `platform`; passing `chartName: platform` explicitly reproduces the parent's fullname regardless of the rendering context |
+| global.platformServicePort | int | `8080` | Seqera Platform Service port |
+| global.studiosDomain | string | `"{{ printf \"studios.%s\" .Values.global.platformExternalDomain }}"` | Domain where the Studios service listens. Make sure the TLS certificate covers this and its wildcard subdomains. Evaluated as a template |
+| global.studiosConnectionUrl | string | `"{{ printf \"https://connect.%s\" (tpl .Values.global.studiosDomain $) }}"` | Base URL for Studios connections: can be any value, since each session will use a unique subdomain under `.global.studiosDomain` anyway to connect. Evaluated as a template |
+| global.waveDomain | string | `"{{ printf \"wave.%s\" .Values.global.platformExternalDomain }}"` | Domain where Wave listens. Evaluated as a template |
+| global.mcpDomain | string | `"{{ printf \"mcp.%s\" .Values.global.platformExternalDomain }}"` | Domain where Seqera MCP listens. Evaluated as a template |
+| global.agentBackendDomain | string | `"{{ printf \"ai-api.%s\" .Values.global.platformExternalDomain }}"` | Domain where the Agent Backend service listens. Evaluated as a template |
+| global.portalWebDomain | string | `"{{ printf \"ai.%s\" .Values.global.platformExternalDomain }}"` | Domain where the Portal Web frontend listens. Evaluated as a template |
 
 ### Global: Ingress
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| global.ingress.enabled | bool | ``false`` | Enable Ingress for the parent chart and every subchart that exposes one. Each chart's local `ingress.enabled` is OR'd with this — set this to `true` to turn on all Ingresses in one switch |
-| global.ingress.path | string | ``"/"`` | Default path applied to ingress rules when a chart's local `ingress.path` is not set. AWS ALB users should override to `/*`. |
-| global.ingress.defaultPathType | string | ``"Prefix"`` | Default path type applied to ingress rules when a chart's local `ingress.defaultPathType` is not set. `Prefix` works for nginx, traefik, AWS ALB, and most modern controllers. Override to `ImplementationSpecific` only if your controller requires it (e.g. older GKE). |
-| global.ingress.ingressClassName | string | ``""`` | Default ingress class name applied to ingress rules when a chart's local `ingress.ingressClassName` is not set. Replaces the deprecated `kubernetes.io/ingress.class` annotation |
-| global.ingress.annotations | object | ``{}`` | Annotations merged into every chart's Ingress (e.g. cert-manager issuer, NGINX `proxy-body-size`, ALB SSL config). Local `ingress.annotations` wins on key collision. Evaluated as a template |
-| global.ingress.extraLabels | object | ``{}`` | Extra labels merged into every chart's Ingress. Local `ingress.extraLabels` wins on key collision. Evaluated as a template |
-| global.ingress.tls | list | ``[]`` | TLS entries concatenated with each chart's local `ingress.tls`. Useful for a single wildcard cert that covers all services. Evaluated as a template |
+| global.ingress.enabled | bool | `false` | Enable Ingress for the parent chart and every subchart that exposes one. Each chart's local `ingress.enabled` is OR'd with this — set this to `true` to turn on all Ingresses in one switch |
+| global.ingress.path | string | `"/"` | Default path applied to ingress rules when a chart's local `ingress.path` is not set. AWS ALB users should override to `/*`. |
+| global.ingress.defaultPathType | string | `"Prefix"` | Default path type applied to ingress rules when a chart's local `ingress.defaultPathType` is not set. `Prefix` works for nginx, traefik, AWS ALB, and most modern controllers. Override to `ImplementationSpecific` only if your controller requires it (e.g. older GKE). |
+| global.ingress.ingressClassName | string | `""` | Default ingress class name applied to ingress rules when a chart's local `ingress.ingressClassName` is not set. Replaces the deprecated `kubernetes.io/ingress.class` annotation |
+| global.ingress.annotations | object | `{}` | Annotations merged into every chart's Ingress (e.g. cert-manager issuer, NGINX `proxy-body-size`, ALB SSL config). Local `ingress.annotations` wins on key collision. Evaluated as a template |
+| global.ingress.extraLabels | object | `{}` | Extra labels merged into every chart's Ingress. Local `ingress.extraLabels` wins on key collision. Evaluated as a template |
+| global.ingress.tls | list | `[]` | TLS entries concatenated with each chart's local `ingress.tls`. Useful for a single wildcard cert that covers all services. Evaluated as a template |
 
 ### Global: Image Credentials
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| global.imageCredentials | list | ``[]`` | Optional credentials to log in and fetch images from a private registry. These credentials are shared with all the subcharts automatically |
-| global.imageCredentialsSecrets | list | ``[]`` | Optional list of existing Secrets containing image pull credentials to use for pulling images from private registries. These Secrets are shared with all the subcharts automatically |
+| global.imageCredentials | list | `[]` | Optional credentials to log in and fetch images from a private registry. These credentials are shared with all the subcharts automatically |
+| global.imageCredentialsSecrets | list | `[]` | Optional list of existing Secrets containing image pull credentials to use for pulling images from private registries. These Secrets are shared with all the subcharts automatically |
 
 ### Platform Database
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| platformDatabase.host | string | ``""`` | Platform MySQL database hostname |
-| platformDatabase.port | int | ``3306`` | Platform MySQL database port |
-| platformDatabase.name | string | ``""`` | Platform MySQL database name |
-| platformDatabase.username | string | ``""`` | Platform MySQL database username |
-| platformDatabase.password | string | ``""`` | Platform MySQL database password |
-| platformDatabase.existingSecretName | string | ``""`` | Name of an existing Secret containing credentials for the Platform MySQL database, as an alternative to the password field. Note: the Secret must already exist in the same namespace at the time of deployment |
-| platformDatabase.existingSecretKey | string | ``"TOWER_DB_PASSWORD"`` | Key in the existing Secret containing the password for the Platform MySQL database |
-| platformDatabase.driver | string | ``"mariadb"`` | Database driver. Possible options: "mariadb" (or its alias "mysql") |
-| platformDatabase.connectionOptions | object | ``{"mariadb":["permitMysqlScheme=true"]}`` | Connection options to compose in the driver URL according to the driver used. The only driver that can be set is 'mariadb' |
-| platformDatabase.connectionOptions.mariadb | list | ``["permitMysqlScheme=true"]`` | Connection options to use with the MariaDB driver. For the full list of supported options see: https://mariadb.com/docs/connectors/mariadb-connector-j/about-mariadb-connector-j |
-| platformDatabase.dialect | string | ``"mysql-8"`` | Hibernate dialect to use, depending on the database version. Possible options: mysql-8 (default), mariadb-10 |
-| platformDatabase.minPoolSize | string | ``"2"`` | Connection pool minimum size |
-| platformDatabase.maxPoolSize | string | ``"10"`` | Connection pool maximum size |
-| platformDatabase.maxLifetime | string | ``"180000"`` | Connection pool maximum lifetime |
+| platformDatabase.host | string | `""` | Platform MySQL database hostname |
+| platformDatabase.port | int | `3306` | Platform MySQL database port |
+| platformDatabase.name | string | `""` | Platform MySQL database name |
+| platformDatabase.username | string | `""` | Platform MySQL database username |
+| platformDatabase.password | string | `""` | Platform MySQL database password |
+| platformDatabase.existingSecretName | string | `""` | Name of an existing Secret containing credentials for the Platform MySQL database, as an alternative to the password field. Note: the Secret must already exist in the same namespace at the time of deployment |
+| platformDatabase.existingSecretKey | string | `"TOWER_DB_PASSWORD"` | Key in the existing Secret containing the password for the Platform MySQL database |
+| platformDatabase.driver | string | `"mariadb"` | Database driver. Possible options: "mariadb" (or its alias "mysql") |
+| platformDatabase.connectionOptions | object | `{"mariadb":["permitMysqlScheme=true"]}` | Connection options to compose in the driver URL according to the driver used. The only driver that can be set is 'mariadb' |
+| platformDatabase.connectionOptions.mariadb | list | `["permitMysqlScheme=true"]` | Connection options to use with the MariaDB driver. For the full list of supported options see: https://mariadb.com/docs/connectors/mariadb-connector-j/about-mariadb-connector-j |
+| platformDatabase.dialect | string | `"mysql-8"` | Hibernate dialect to use, depending on the database version. Possible options: mysql-8 (default), mariadb-10 |
+| platformDatabase.minPoolSize | string | `"2"` | Connection pool minimum size |
+| platformDatabase.maxPoolSize | string | `"10"` | Connection pool maximum size |
+| platformDatabase.maxLifetime | string | `"180000"` | Connection pool maximum lifetime |
 
 ### Platform
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| platform.YAMLConfigFileContent | string | ``""`` | Content to insert into the tower.yml file (you can use `\|-` YAML multilines). See https://docs.seqera.io/platform-enterprise/enterprise/configuration/overview |
-| platform.contactEmail | string | ``"support@example.com"`` | Sender email address for user support |
+| platform.YAMLConfigFileContent | string | `""` | Content to insert into the tower.yml file (you can use `\|-` YAML multilines). See https://docs.seqera.io/platform-enterprise/enterprise/configuration/overview |
+| platform.contactEmail | string | `"support@example.com"` | Sender email address for user support |
 
 ### Platform: JWT Seed
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| platform.jwtSeedString | string | ``""`` | JWT seed, defined as string, used to sign authentication tokens. Define the value as a String or a Secret, not both at the same time. If neither is defined, Helm generates a random 35-character string. WARNING: Always explicitly set this value or use an existing secret when using Kustomize. Auto-generated random values are incompatible with Kustomize. When upgrading releases via Kustomize, Helm cannot query the cluster to check if a secret already exists, causing it to regenerate a new random value on each upgrade |
-| platform.jwtSeedSecretName | string | ``""`` | Name of an existing Secret containing the JWT seed, as an alternative to the string field. Note: the Secret must already exist in the same namespace at the time of deployment |
-| platform.jwtSeedSecretKey | string | ``"TOWER_JWT_SECRET"`` | Key in the existing Secret containing the JWT seed |
+| platform.jwtSeedString | string | `""` | JWT seed, defined as string, used to sign authentication tokens. Define the value as a String or a Secret, not both at the same time. If neither is defined, Helm generates a random 35-character string. WARNING: Always explicitly set this value or use an existing secret when using Kustomize. Auto-generated random values are incompatible with Kustomize. When upgrading releases via Kustomize, Helm cannot query the cluster to check if a secret already exists, causing it to regenerate a new random value on each upgrade |
+| platform.jwtSeedSecretName | string | `""` | Name of an existing Secret containing the JWT seed, as an alternative to the string field. Note: the Secret must already exist in the same namespace at the time of deployment |
+| platform.jwtSeedSecretKey | string | `"TOWER_JWT_SECRET"` | Key in the existing Secret containing the JWT seed |
 
 ### Platform: Crypto Seed
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| platform.cryptoSeedString | string | ``""`` | Crypto seed, defined as string, used to encrypt sensitive data in the database. Note: this needs to be a stable value that doesn't change between deployments, otherwise encrypted data in the database will become inaccessible. Either define the value as a String or a Secret, not both at the same time. If neither is defined, a random 35 characters long string will be generated by Helm WARNING: Always explicitly set this value or use an existing secret when using Kustomize. Auto-generated random values are incompatible with Kustomize. When upgrading releases via Kustomize, Helm cannot query the cluster to check if a secret already exists, causing it to regenerate a new random value on each upgrade |
-| platform.cryptoSeedSecretName | string | ``""`` | Name of an existing Secret containing the crypto seed, as an alternative to the string field. Note: the Secret must already exist in the same namespace at the time of deployment |
-| platform.cryptoSeedSecretKey | string | ``"TOWER_CRYPTO_SECRETKEY"`` | Key in the existing Secret containing the crypto seed |
+| platform.cryptoSeedString | string | `""` | Crypto seed, defined as string, used to encrypt sensitive data in the database. Note: this needs to be a stable value that doesn't change between deployments, otherwise encrypted data in the database will become inaccessible. Either define the value as a String or a Secret, not both at the same time. If neither is defined, a random 35 characters long string will be generated by Helm WARNING: Always explicitly set this value or use an existing secret when using Kustomize. Auto-generated random values are incompatible with Kustomize. When upgrading releases via Kustomize, Helm cannot query the cluster to check if a secret already exists, causing it to regenerate a new random value on each upgrade |
+| platform.cryptoSeedSecretName | string | `""` | Name of an existing Secret containing the crypto seed, as an alternative to the string field. Note: the Secret must already exist in the same namespace at the time of deployment |
+| platform.cryptoSeedSecretKey | string | `"TOWER_CRYPTO_SECRETKEY"` | Key in the existing Secret containing the crypto seed |
 
 ### Platform: Execution Backends
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| platform.executionBackends | list | ``["altair-platform","awsbatch-platform","awscloud-platform","azbatch-platform","azcloud-platform","eks-platform","gke-platform","googlebatch-platform","googlecloud-platform","k8s-platform","lsf-platform","moab-platform","slurm-platform","uge-platform"]`` | List of execution backends to enable. At least one is required. See https://docs.seqera.io/platform-enterprise/enterprise/configuration/overview#compute-environments |
+| platform.executionBackends | list | `["altair-platform","awsbatch-platform","awscloud-platform","azbatch-platform","azcloud-platform","eks-platform","gke-platform","googlebatch-platform","googlecloud-platform","k8s-platform","lsf-platform","moab-platform","slurm-platform","uge-platform"]` | List of execution backends to enable. At least one is required. See https://docs.seqera.io/platform-enterprise/enterprise/configuration/overview#compute-environments |
 
 ### Platform: License
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| platform.licenseString | string | ``""`` | Platform license key. A license key is a long alphanumeric string provided by your Seqera account manager. Define the value as a String or a Secret, not both at the same time |
-| platform.licenseSecretName | string | ``""`` | Name of an existing Secret containing the Platform license key, as an alternative to the string field. Note: the Secret must already exist in the same namespace at the time of deployment |
-| platform.licenseSecretKey | string | ``"TOWER_LICENSE"`` | Key in the existing Secret containing the Platform license key |
+| platform.licenseString | string | `""` | Platform license key. A license key is a long alphanumeric string provided by your Seqera account manager. Define the value as a String or a Secret, not both at the same time |
+| platform.licenseSecretName | string | `""` | Name of an existing Secret containing the Platform license key, as an alternative to the string field. Note: the Secret must already exist in the same namespace at the time of deployment |
+| platform.licenseSecretKey | string | `"TOWER_LICENSE"` | Key in the existing Secret containing the Platform license key |
 
 ### Platform: OIDC
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| platform.oidcPrivateKeyBase64 | string | ``""`` | OIDC private key in PEM format, base64-encoded. Define the value as a String or a Secret, not both at the same time. If neither is defined, Helm generates a random private key. WARNING: Always explicitly set this value or use an existing secret when using Kustomize. Auto-generated random values are incompatible with Kustomize. When upgrading releases via Kustomize, Helm cannot query the cluster to check if a secret already exists, causing it to regenerate a new random value on each upgrade |
-| platform.oidcPrivateKeySecretName | string | ``""`` | Name of an existing Secret containing the OIDC private key in PEM format, as an alternative to the base64-encoded string field. Note: the Secret must already exist in the same namespace at the time of deployment |
-| platform.oidcPrivateKeySecretKey | string | ``"oidc.pem"`` | Key in the existing Secret containing the OIDC private key in PEM format |
-| platform.oidcClientRegistrationToken | string | ``""`` | OIDC client registration token as a string. Used by Studios and MCP to dynamically register OAuth clients with Seqera Platform's OIDC provider. If neither this nor oidcClientRegistrationTokenSecretName is set, a random value is generated. WARNING: Always explicitly set this value or use an existing secret when using Kustomize. Auto-generated random values are incompatible with Kustomize. When upgrading releases via Kustomize, Helm cannot query the cluster to check if a secret already exists, causing it to regenerate a new random value on each upgrade |
-| platform.oidcClientRegistrationTokenSecretName | string | ``""`` | Name of an existing Secret containing the OIDC client registration token, as an alternative to the string field. Note: the Secret must already exist in the same namespace at the time of deployment |
-| platform.oidcClientRegistrationTokenSecretKey | string | ``"OIDC_CLIENT_REGISTRATION_TOKEN"`` | Key in the existing Secret containing the OIDC client registration token |
+| platform.oidcPrivateKeyBase64 | string | `""` | OIDC private key in PEM format, base64-encoded. Define the value as a String or a Secret, not both at the same time. If neither is defined, Helm generates a random private key. WARNING: Always explicitly set this value or use an existing secret when using Kustomize. Auto-generated random values are incompatible with Kustomize. When upgrading releases via Kustomize, Helm cannot query the cluster to check if a secret already exists, causing it to regenerate a new random value on each upgrade |
+| platform.oidcPrivateKeySecretName | string | `""` | Name of an existing Secret containing the OIDC private key in PEM format, as an alternative to the base64-encoded string field. Note: the Secret must already exist in the same namespace at the time of deployment |
+| platform.oidcPrivateKeySecretKey | string | `"oidc.pem"` | Key in the existing Secret containing the OIDC private key in PEM format |
+| platform.oidcClientRegistrationToken | string | `""` | OIDC client registration token as a string. Used by Studios and MCP to dynamically register OAuth clients with Seqera Platform's OIDC provider. If neither this nor oidcClientRegistrationTokenSecretName is set, a random value is generated. WARNING: Always explicitly set this value or use an existing secret when using Kustomize. Auto-generated random values are incompatible with Kustomize. When upgrading releases via Kustomize, Helm cannot query the cluster to check if a secret already exists, causing it to regenerate a new random value on each upgrade |
+| platform.oidcClientRegistrationTokenSecretName | string | `""` | Name of an existing Secret containing the OIDC client registration token, as an alternative to the string field. Note: the Secret must already exist in the same namespace at the time of deployment |
+| platform.oidcClientRegistrationTokenSecretKey | string | `"OIDC_CLIENT_REGISTRATION_TOKEN"` | Key in the existing Secret containing the OIDC client registration token |
 
 ### Platform: SMTP
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| platform.smtp.host | string | ``""`` | SMTP server hostname to let users authenticate through email, and to send email notifications for events |
-| platform.smtp.port | string | ``""`` | SMTP server port |
-| platform.smtp.user | string | ``""`` | SMTP server username |
-| platform.smtp.password | string | ``""`` | SMTP server password |
-| platform.smtp.existingSecretName | string | ``""`` | Name of an existing secret containing the SMTP password |
-| platform.smtp.existingSecretKey | string | ``"TOWER_SMTP_PASSWORD"`` | Key in the existing Secret containing the SMTP password |
+| platform.smtp.host | string | `""` | SMTP server hostname to let users authenticate through email, and to send email notifications for events |
+| platform.smtp.port | int | `587` | SMTP server port |
+| platform.smtp.user | string | `""` | SMTP server username |
+| platform.smtp.password | string | `""` | SMTP server password |
+| platform.smtp.existingSecretName | string | `""` | Name of an existing secret containing the SMTP password |
+| platform.smtp.existingSecretKey | string | `"TOWER_SMTP_PASSWORD"` | Key in the existing Secret containing the SMTP password |
 
 ### Platform: Wave & Data Explorer
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| platform.waveServerUrl | string | ``"https://wave.seqera.io"`` | URL of the Wave service Platform uses. Evaluated as a template. The Wave service provided by Seqera is `https://wave.seqera.io` |
-| platform.dataExplorer.enabled | bool | ``false`` | Enable the Data Explorer feature: https://docs.seqera.io/platform-enterprise/data/data-explorer |
+| platform.waveServerUrl | string | `"https://wave.seqera.io"` | URL of the Wave service Platform uses. Evaluated as a template. The Wave service provided by Seqera is `https://wave.seqera.io` |
+| platform.dataExplorer.enabled | bool | `false` | Enable the Data Explorer feature: https://docs.seqera.io/platform-enterprise/data/data-explorer |
 
 ### Platform: Studios
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| platform.studios.customImageRegistry | string | ``""`` | Image registry where Wave (defined at `.platform.waveServerUrl`) will push custom Studios images built for user sessions. Credentials to the registry/repository must be defined in each Platform Workspace. Example: `myregistry.example.com` |
-| platform.studios.customImageRepository | string | ``""`` | Image repository where Wave (defined at `.platform.waveServerUrl`) will push custom Studios images built for user sessions. Example: `myteam/studios-container-repo` |
-| platform.studios.tools | object | ``{"jupyter":{"deprecated":"public.cr.seqera.io/platform/data-studio-jupyter:4.2.5-0.11","recommended":"public.cr.seqera.io/platform/data-studio-jupyter:4.2.5-0.12","tool":"jupyter"},"ride":{"deprecated":"public.cr.seqera.io/platform/data-studio-ride:2025.04.1-0.11","recommended":"public.cr.seqera.io/platform/data-studio-ride:2026.01.2-0.12","tool":"ride"},"vscode":{"deprecated":"public.cr.seqera.io/platform/data-studio-vscode:1.101.2-0.11","recommended":"public.cr.seqera.io/platform/data-studio-vscode:1.101.2-0.12","tool":"vscode"},"xpra":{"deprecated":"public.cr.seqera.io/platform/data-studio-xpra:6.2.0-r2-1-0.11","recommended":"public.cr.seqera.io/platform/data-studio-xpra:6.2.0-r2-1-0.12","tool":"xpra"}}`` | Map of tools to make available in Studios. Recommended and deprecated versions can be specified for each tool to allow upgrading from an older version. Refer to the documentation for more details: https://docs.seqera.io/platform-enterprise/studios/managing#migrate-a-studio-from-an-earlier-container-image-template |
+| platform.studios.customImageRegistry | string | `""` | Image registry where Wave (defined at `.platform.waveServerUrl`) will push custom Studios images built for user sessions. Credentials to the registry/repository must be defined in each Platform Workspace. Example: `myregistry.example.com` |
+| platform.studios.customImageRepository | string | `""` | Image repository where Wave (defined at `.platform.waveServerUrl`) will push custom Studios images built for user sessions. Example: `myteam/studios-container-repo` |
+| platform.studios.tools | object | `{"jupyter":{"deprecated":"public.cr.seqera.io/platform/data-studio-jupyter:4.2.5-0.11","recommended":"public.cr.seqera.io/platform/data-studio-jupyter:4.2.5-0.12","tool":"jupyter"},"ride":{"deprecated":"public.cr.seqera.io/platform/data-studio-ride:2025.04.1-0.11","recommended":"public.cr.seqera.io/platform/data-studio-ride:2026.01.2-0.12","tool":"ride"},"vscode":{"deprecated":"public.cr.seqera.io/platform/data-studio-vscode:1.101.2-0.11","recommended":"public.cr.seqera.io/platform/data-studio-vscode:1.101.2-0.12","tool":"vscode"},"xpra":{"deprecated":"public.cr.seqera.io/platform/data-studio-xpra:6.2.0-r2-1-0.11","recommended":"public.cr.seqera.io/platform/data-studio-xpra:6.2.0-r2-1-0.12","tool":"xpra"}}` | Map of tools to make available in Studios. Recommended and deprecated versions can be specified for each tool to allow upgrading from an older version. Refer to the documentation for more details: https://docs.seqera.io/platform-enterprise/studios/managing#migrate-a-studio-from-an-earlier-container-image-template |
 
 ### Platform: Labels & Annotations
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| platform.configMapLabels | object | ``{}`` | Additional labels for the ConfigMap objects. Evaluated as a template |
-| platform.secretLabels | object | ``{}`` | Additional labels for the Secret objects. Evaluated as a template |
-| platform.serviceLabels | object | ``{}`` | Additional labels for the Service objects. Evaluated as a template |
-| platform.configMapAnnotations | object | ``{}`` | Additional annotations for the ConfigMap objects. Evaluated as a template |
-| platform.secretAnnotations | object | ``{}`` | Additional annotations for the Secret objects. Evaluated as a template |
-| platform.serviceAnnotations | object | ``{}`` | Additional annotations for the Service objects. Evaluated as a template |
+| platform.configMapLabels | object | `{}` | Additional labels for the ConfigMap objects. Evaluated as a template |
+| platform.secretLabels | object | `{}` | Additional labels for the Secret objects. Evaluated as a template |
+| platform.serviceLabels | object | `{}` | Additional labels for the Service objects. Evaluated as a template |
+| platform.configMapAnnotations | object | `{}` | Additional annotations for the ConfigMap objects. Evaluated as a template |
+| platform.secretAnnotations | object | `{}` | Additional annotations for the Secret objects. Evaluated as a template |
+| platform.serviceAnnotations | object | `{}` | Additional annotations for the Service objects. Evaluated as a template |
 
 ### Redis
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| redis.host | string | ``""`` | Redis hostname |
-| redis.port | int | ``6379`` | Redis port |
-| redis.password | string | ``""`` | Redis password if the installation requires it |
-| redis.existingSecretName | string | ``""`` | Name of an existing Secret containing credentials for Redis, as an alternative to the password field. Note: the Secret must already exist in the same namespace at the time of deployment |
-| redis.existingSecretKey | string | ``"TOWER_REDIS_PASSWORD"`` | Key in the existing Secret containing the password for Redis |
-| redis.enableTls | bool | ``false`` | Enable TLS when connecting to Redis |
+| redis.host | string | `""` | Redis hostname |
+| redis.port | int | `6379` | Redis port |
+| redis.password | string | `""` | Redis password if the installation requires it |
+| redis.existingSecretName | string | `""` | Name of an existing Secret containing credentials for Redis, as an alternative to the password field. Note: the Secret must already exist in the same namespace at the time of deployment |
+| redis.existingSecretKey | string | `"TOWER_REDIS_PASSWORD"` | Key in the existing Secret containing the password for Redis |
+| redis.enableTls | bool | `false` | Enable TLS when connecting to Redis |
 
 ### Backend: Image
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| backend.image.registry | string | ``""`` | Backend container image registry |
-| backend.image.repository | string | ``"enterprise/platform/backend"`` | Backend container image repository |
-| backend.image.tag | string | ``"{{ .chart.AppVersion }}"`` | Backend container image tag |
-| backend.image.digest | string | ``""`` | Backend container image digest in the format `sha256:1234abcdef` |
-| backend.image.pullPolicy | string | ``"IfNotPresent"`` | imagePullPolicy for the backend container Ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images |
-| backend.image.pullSecrets | list | ``[]`` | List of imagePullSecrets Secrets must be created in the same namespace, for example using the .extraDeploy array Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ |
-| backend.micronautEnvironments | list | ``["prod","redis","ha"]`` | List of Micronaut Environments to enable on the backend pod |
+| backend.image.registry | string | `""` | Backend container image registry |
+| backend.image.repository | string | `"enterprise/platform/backend"` | Backend container image repository |
+| backend.image.tag | string | `"{{ .chart.AppVersion }}"` | Backend container image tag |
+| backend.image.digest | string | `""` | Backend container image digest in the format `sha256:1234abcdef` |
+| backend.image.pullPolicy | string | `"IfNotPresent"` | imagePullPolicy for the backend container Ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images |
+| backend.image.pullSecrets | list | `[]` | List of imagePullSecrets Secrets must be created in the same namespace, for example using the .extraDeploy array Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ |
+| backend.micronautEnvironments | list | `["prod","redis","ha"]` | List of Micronaut Environments to enable on the backend pod |
 
 ### Backend: Service
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| backend.service.type | string | ``"ClusterIP"`` | Backend Service type. Note: ingresses using AWS ALB require the service to be NodePort |
-| backend.service.http.name | string | ``"http"`` | Service name to use |
-| backend.service.http.targetPort | int | ``8080`` | Port on the pod/container that the Service forwards traffic to (can be a number or named port, distinct from the Service's external port). Platform v25.3+ only; previous versions were hardcoded to 8080 |
-| backend.service.http.nodePort | int | ``0`` | Service node port, only used when service.type is Nodeport or LoadBalancer Choose port between 30000-32767, unless the cluster was configured differently than default |
-| backend.service.extraServices | list | ``[]`` | Other services that should live in the Service object https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service |
-| backend.service.extraOptions | object | ``{}`` | Extra Service options to place under .spec (for example, clusterIP, loadBalancerIP, externalTrafficPolicy, externalIPs). Evaluated as a template |
+| backend.service.type | string | `"ClusterIP"` | Backend Service type. Note: ingresses using AWS ALB require the service to be NodePort |
+| backend.service.http.name | string | `"http"` | Service name to use |
+| backend.service.http.targetPort | int | `8080` | Port on the pod/container that the Service forwards traffic to (can be a number or named port, distinct from the Service's external port). Platform v25.3+ only; previous versions were hardcoded to 8080 |
+| backend.service.http.nodePort | int | `0` | Service node port, only used when service.type is Nodeport or LoadBalancer Choose port between 30000-32767, unless the cluster was configured differently than default |
+| backend.service.extraServices | list | `[]` | Other services that should live in the Service object https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service |
+| backend.service.extraOptions | object | `{}` | Extra Service options to place under .spec (for example, clusterIP, loadBalancerIP, externalTrafficPolicy, externalIPs). Evaluated as a template |
 
 ### Backend: Pod
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| backend.initContainers | list | ``[]`` | Additional init containers for the backend pod. Evaluated as a template |
-| backend.command | list | ``[]`` | Override default container command (useful when using custom images) |
-| backend.args | list | ``[]`` | Override default container args (useful when using custom images) |
-| backend.podLabels | object | ``{}`` | Additional labels for the backend pod. Evaluated as a template |
-| backend.podAnnotations | object | ``{}`` | Additional annotations for the backend pod. Evaluated as a template |
-| backend.extraOptionsSpec | object | ``{"replicas":3}`` | Extra options to place under .spec (e.g. replicas, strategy, revisionHistoryLimit, etc). Evaluated as a template |
-| backend.extraOptionsTemplateSpec | object | ``{}`` | Extra options to place under .spec.template.spec (e.g. nodeSelector, affinity, restartPolicy, etc). Evaluated as a template |
-| backend.extraEnvVars | list | ``[]`` | Extra environment variables to set on the backend pod |
-| backend.extraEnvVarsCMs | list | ``[]`` | List of ConfigMaps containing extra env vars |
-| backend.extraEnvVarsSecrets | list | ``[]`` | List of Secrets containing extra env vars |
-| backend.extraVolumes | list | ``[]`` | List of volumes to add to the deployment (evaluated as template). Requires setting `extraVolumeMounts` |
-| backend.extraVolumeMounts | list | ``[]`` | List of volume mounts to add to the container (evaluated as template). Normally used with `extraVolumes` |
+| backend.initContainers | list | `[]` | Additional init containers for the backend pod. Evaluated as a template |
+| backend.command | list | `[]` | Override default container command (useful when using custom images) |
+| backend.args | list | `[]` | Override default container args (useful when using custom images) |
+| backend.podLabels | object | `{}` | Additional labels for the backend pod. Evaluated as a template |
+| backend.podAnnotations | object | `{}` | Additional annotations for the backend pod. Evaluated as a template |
+| backend.extraOptionsSpec | object | `{"replicas":3}` | Extra options to place under .spec (e.g. replicas, strategy, revisionHistoryLimit, etc). Evaluated as a template |
+| backend.extraOptionsTemplateSpec | object | `{}` | Extra options to place under .spec.template.spec (e.g. nodeSelector, affinity, restartPolicy, etc). Evaluated as a template |
+| backend.extraEnvVars | list | `[]` | Extra environment variables to set on the backend pod |
+| backend.extraEnvVarsCMs | list | `[]` | List of ConfigMaps containing extra env vars |
+| backend.extraEnvVarsSecrets | list | `[]` | List of Secrets containing extra env vars |
+| backend.extraVolumes | list | `[]` | List of volumes to add to the deployment (evaluated as template). Requires setting `extraVolumeMounts` |
+| backend.extraVolumeMounts | list | `[]` | List of volume mounts to add to the container (evaluated as template). Normally used with `extraVolumes` |
 
 ### Backend: Security Context
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| backend.podSecurityContext.enabled | bool | ``true`` | Enable pod Security Context |
-| backend.podSecurityContext.fsGroup | int | ``101`` | Sets the GID that Kubernetes will apply to mounted volumes and created files so processes in the pod can share group-owned access |
-| backend.containerSecurityContext.enabled | bool | ``true`` | Enable container Security Context |
-| backend.containerSecurityContext.runAsUser | int | ``101`` | UID the container processes run as (overrides container image default) |
-| backend.containerSecurityContext.runAsNonRoot | bool | ``true`` | Boolean that requires the container to run as a non-root UID (prevents starting if UID 0) |
-| backend.containerSecurityContext.readOnlyRootFilesystem | bool | ``true`` | Mounts the container root filesystem read-only to prevent in-place writes or tampering |
-| backend.containerSecurityContext.capabilities | object | ``{"drop":["ALL"]}`` | Fine-grained Linux kernel privileges to add or drop for the container |
+| backend.podSecurityContext.enabled | bool | `true` | Enable pod Security Context |
+| backend.podSecurityContext.fsGroup | int | `101` | Sets the GID that Kubernetes will apply to mounted volumes and created files so processes in the pod can share group-owned access |
+| backend.containerSecurityContext.enabled | bool | `true` | Enable container Security Context |
+| backend.containerSecurityContext.runAsUser | int | `101` | UID the container processes run as (overrides container image default) |
+| backend.containerSecurityContext.runAsNonRoot | bool | `true` | Boolean that requires the container to run as a non-root UID (prevents starting if UID 0) |
+| backend.containerSecurityContext.readOnlyRootFilesystem | bool | `true` | Mounts the container root filesystem read-only to prevent in-place writes or tampering |
+| backend.containerSecurityContext.capabilities | object | `{"drop":["ALL"]}` | Fine-grained Linux kernel privileges to add or drop for the container |
 
 ### Backend: Resources
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| backend.resources | object | ``{}`` | Container requests and limits for different resources like CPU or memory |
+| backend.resources | object | `{}` | Container requests and limits for different resources like CPU or memory |
 
 ### Backend: Startup Probe
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| backend.startupProbe.enabled | bool | ``false`` | Enable startup probe |
-| backend.startupProbe.httpGet.path | string | ``"/health"`` | HTTP GET path for startup probe |
-| backend.startupProbe.httpGet.port | string | ``"{{ .Values.backend.service.http.targetPort }}"`` | HTTP GET port for startup probe. Evaluated as a template. Note: before v25.3 this was hardcoded to 8080 |
-| backend.startupProbe.initialDelaySeconds | int | ``5`` | Longer initial wait to accommodate slow-starting apps |
-| backend.startupProbe.periodSeconds | int | ``10`` | Often set longer to avoid frequent checks while starting |
-| backend.startupProbe.timeoutSeconds | int | ``3`` | Can be longer to allow slow initialization responses |
-| backend.startupProbe.failureThreshold | int | ``5`` | Consecutive failures during startup before killing the container (instead of immediate restarts) |
-| backend.startupProbe.successThreshold | int | ``1`` | Number of consecutive successes required to consider startup complete and enable liveness/readiness |
+| backend.startupProbe.enabled | bool | `false` | Enable startup probe |
+| backend.startupProbe.httpGet.path | string | `"/health"` | HTTP GET path for startup probe |
+| backend.startupProbe.httpGet.port | string | `"{{ .Values.backend.service.http.targetPort }}"` | HTTP GET port for startup probe. Evaluated as a template. Note: before v25.3 this was hardcoded to 8080 |
+| backend.startupProbe.initialDelaySeconds | int | `5` | Longer initial wait to accommodate slow-starting apps |
+| backend.startupProbe.periodSeconds | int | `10` | Often set longer to avoid frequent checks while starting |
+| backend.startupProbe.timeoutSeconds | int | `3` | Can be longer to allow slow initialization responses |
+| backend.startupProbe.failureThreshold | int | `5` | Consecutive failures during startup before killing the container (instead of immediate restarts) |
+| backend.startupProbe.successThreshold | int | `1` | Number of consecutive successes required to consider startup complete and enable liveness/readiness |
 
 ### Backend: Readiness Probe
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| backend.readinessProbe.enabled | bool | ``true`` | Enable readiness probe |
-| backend.readinessProbe.httpGet.path | string | ``"/health"`` | HTTP GET path for readiness probe |
-| backend.readinessProbe.httpGet.port | string | ``"{{ .Values.backend.service.http.targetPort }}"`` | HTTP GET port for readiness probe. Evaluated as a template. Note: before v25.3 this was hardcoded to 8080 |
-| backend.readinessProbe.initialDelaySeconds | int | ``5`` | Delay before first check (normal start timing) |
-| backend.readinessProbe.periodSeconds | int | ``5`` | Regular check interval during normal operation |
-| backend.readinessProbe.timeoutSeconds | int | ``3`` | Short timeout to detect unresponsive containers for readiness |
-| backend.readinessProbe.failureThreshold | int | ``5`` | Consecutive failures before marking the container Unready (no restart) |
-| backend.readinessProbe.successThreshold | int | ``1`` | Number of consecutive successes required to mark the container Ready after failures |
+| backend.readinessProbe.enabled | bool | `true` | Enable readiness probe |
+| backend.readinessProbe.httpGet.path | string | `"/health"` | HTTP GET path for readiness probe |
+| backend.readinessProbe.httpGet.port | string | `"{{ .Values.backend.service.http.targetPort }}"` | HTTP GET port for readiness probe. Evaluated as a template. Note: before v25.3 this was hardcoded to 8080 |
+| backend.readinessProbe.initialDelaySeconds | int | `5` | Delay before first check (normal start timing) |
+| backend.readinessProbe.periodSeconds | int | `5` | Regular check interval during normal operation |
+| backend.readinessProbe.timeoutSeconds | int | `3` | Short timeout to detect unresponsive containers for readiness |
+| backend.readinessProbe.failureThreshold | int | `5` | Consecutive failures before marking the container Unready (no restart) |
+| backend.readinessProbe.successThreshold | int | `1` | Number of consecutive successes required to mark the container Ready after failures |
 
 ### Backend: Liveness Probe
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| backend.livenessProbe.enabled | bool | ``true`` | Enable liveness probe |
-| backend.livenessProbe.httpGet.path | string | ``"/health"`` | HTTP GET path for liveness probe |
-| backend.livenessProbe.httpGet.port | string | ``"{{ .Values.backend.service.http.targetPort }}"`` | HTTP GET port for liveness probe. Evaluated as a template. Note: before v25.3 this was hardcoded to 8080 |
-| backend.livenessProbe.initialDelaySeconds | int | ``5`` | Delay before first check (normal start timing) |
-| backend.livenessProbe.periodSeconds | int | ``10`` | Regular check interval during normal operation |
-| backend.livenessProbe.timeoutSeconds | int | ``3`` | Short timeout to detect hung containers quickly |
-| backend.livenessProbe.failureThreshold | int | ``10`` | Consecutive failures before restarting the container |
-| backend.livenessProbe.successThreshold | int | ``1`` | Typically 1 (usually ignored) |
+| backend.livenessProbe.enabled | bool | `true` | Enable liveness probe |
+| backend.livenessProbe.httpGet.path | string | `"/health"` | HTTP GET path for liveness probe |
+| backend.livenessProbe.httpGet.port | string | `"{{ .Values.backend.service.http.targetPort }}"` | HTTP GET port for liveness probe. Evaluated as a template. Note: before v25.3 this was hardcoded to 8080 |
+| backend.livenessProbe.initialDelaySeconds | int | `5` | Delay before first check (normal start timing) |
+| backend.livenessProbe.periodSeconds | int | `10` | Regular check interval during normal operation |
+| backend.livenessProbe.timeoutSeconds | int | `3` | Short timeout to detect hung containers quickly |
+| backend.livenessProbe.failureThreshold | int | `10` | Consecutive failures before restarting the container |
+| backend.livenessProbe.successThreshold | int | `1` | Typically 1 (usually ignored) |
 
 ### Frontend: Image
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| frontend.image.registry | string | ``""`` | Frontend container image registry |
-| frontend.image.repository | string | ``"enterprise/platform/frontend"`` | Frontend container image repository |
-| frontend.image.tag | string | ``"{{ .chart.AppVersion }}-unprivileged"`` | Specify a tag to override the version defined in .Chart.appVersion |
-| frontend.image.digest | string | ``""`` | Frontend container image digest in the format `sha256:1234abcdef` |
-| frontend.image.pullPolicy | string | ``"IfNotPresent"`` | imagePullPolicy for the frontend container Ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images |
-| frontend.image.pullSecrets | list | ``[]`` | List of imagePullSecrets Secrets must be created in the same namespace, for example using the .extraDeploy array Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ |
+| frontend.image.registry | string | `""` | Frontend container image registry |
+| frontend.image.repository | string | `"enterprise/platform/frontend"` | Frontend container image repository |
+| frontend.image.tag | string | `"{{ .chart.AppVersion }}-unprivileged"` | Specify a tag to override the version defined in .Chart.appVersion |
+| frontend.image.digest | string | `""` | Frontend container image digest in the format `sha256:1234abcdef` |
+| frontend.image.pullPolicy | string | `"IfNotPresent"` | imagePullPolicy for the frontend container Ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images |
+| frontend.image.pullSecrets | list | `[]` | List of imagePullSecrets Secrets must be created in the same namespace, for example using the .extraDeploy array Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ |
 
 ### Frontend: Service
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| frontend.service.type | string | ``"ClusterIP"`` | Frontend Service type. Note: ingresses using AWS ALB require the service to be NodePort |
-| frontend.service.http.name | string | ``"http"`` | Service name to use |
-| frontend.service.http.port | int | ``80`` | Service port |
-| frontend.service.http.targetPort | int | ``8083`` | Port on the pod/container that the Service forwards traffic to (can be a number or named port, distinct from the Service's external port) |
-| frontend.service.http.nodePort | int | ``0`` | Service node port, only used when service.type is Nodeport or LoadBalancer Choose port between 30000-32767, unless the cluster was configured differently than default |
-| frontend.service.extraServices | list | ``[]`` | Other services that should live in the Service object https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service |
-| frontend.service.extraOptions | object | ``{}`` | Extra Service options to place under .spec (for example, clusterIP, loadBalancerIP, externalTrafficPolicy, externalIPs). Evaluated as a template |
+| frontend.service.type | string | `"ClusterIP"` | Frontend Service type. Note: ingresses using AWS ALB require the service to be NodePort |
+| frontend.service.http.name | string | `"http"` | Service name to use |
+| frontend.service.http.port | int | `80` | Service port |
+| frontend.service.http.targetPort | int | `8083` | Port on the pod/container that the Service forwards traffic to (can be a number or named port, distinct from the Service's external port) |
+| frontend.service.http.nodePort | int | `0` | Service node port, only used when service.type is Nodeport or LoadBalancer Choose port between 30000-32767, unless the cluster was configured differently than default |
+| frontend.service.extraServices | list | `[]` | Other services that should live in the Service object https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service |
+| frontend.service.extraOptions | object | `{}` | Extra Service options to place under .spec (for example, clusterIP, loadBalancerIP, externalTrafficPolicy, externalIPs). Evaluated as a template |
 
 ### Frontend: Pod
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| frontend.initContainers | list | ``[]`` | Additional init containers for the frontend pod. Evaluated as a template |
-| frontend.command | list | ``[]`` | Override default container command (useful when using custom images) |
-| frontend.args | list | ``[]`` | Override default container args (useful when using custom images) |
-| frontend.podLabels | object | ``{}`` | Additional labels for the frontend pod. Evaluated as a template |
-| frontend.podAnnotations | object | ``{}`` | Additional annotations for the frontend pod. Evaluated as a template |
-| frontend.extraOptionsSpec | object | ``{}`` | Extra options to place under .spec (e.g. revisionHistoryLimit, etc). Evaluated as a template. Note: the cron deployment can only run a single replica and use Recreate strategy |
-| frontend.extraOptionsTemplateSpec | object | ``{}`` | Extra options to place under .spec.template.spec (for example, nodeSelector, affinity, restartPolicy). Evaluated as a template |
-| frontend.extraEnvVars | list | ``[]`` | Extra environment variables to set on the frontend pod |
-| frontend.extraEnvVarsCMs | list | ``[]`` | List of ConfigMaps containing extra env vars |
-| frontend.extraEnvVarsSecrets | list | ``[]`` | List of Secrets containing extra env vars |
-| frontend.extraVolumes | list | ``[]`` | Extra volumes to add to the deployment (evaluated as template). Requires setting `extraVolumeMounts` |
-| frontend.extraVolumeMounts | list | ``[]`` | List of volume mounts to add to the container (evaluated as template). Normally used with `extraVolumes` |
+| frontend.initContainers | list | `[]` | Additional init containers for the frontend pod. Evaluated as a template |
+| frontend.command | list | `[]` | Override default container command (useful when using custom images) |
+| frontend.args | list | `[]` | Override default container args (useful when using custom images) |
+| frontend.podLabels | object | `{}` | Additional labels for the frontend pod. Evaluated as a template |
+| frontend.podAnnotations | object | `{}` | Additional annotations for the frontend pod. Evaluated as a template |
+| frontend.extraOptionsSpec | object | `{}` | Extra options to place under .spec (e.g. revisionHistoryLimit, etc). Evaluated as a template. Note: the cron deployment can only run a single replica and use Recreate strategy |
+| frontend.extraOptionsTemplateSpec | object | `{}` | Extra options to place under .spec.template.spec (for example, nodeSelector, affinity, restartPolicy). Evaluated as a template |
+| frontend.extraEnvVars | list | `[]` | Extra environment variables to set on the frontend pod |
+| frontend.extraEnvVarsCMs | list | `[]` | List of ConfigMaps containing extra env vars |
+| frontend.extraEnvVarsSecrets | list | `[]` | List of Secrets containing extra env vars |
+| frontend.extraVolumes | list | `[]` | Extra volumes to add to the deployment (evaluated as template). Requires setting `extraVolumeMounts` |
+| frontend.extraVolumeMounts | list | `[]` | List of volume mounts to add to the container (evaluated as template). Normally used with `extraVolumes` |
 
 ### Frontend: Security Context
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| frontend.podSecurityContext.enabled | bool | ``true`` | Enable pod Security Context |
-| frontend.podSecurityContext.fsGroup | int | ``101`` | GID that Kubernetes applies to mounted volumes and created files so processes in the pod can share group-owned access |
-| frontend.containerSecurityContext.enabled | bool | ``true`` | Enable container Security Context |
-| frontend.containerSecurityContext.runAsUser | int | ``101`` | UID the container processes run as (overrides container image default) |
-| frontend.containerSecurityContext.runAsNonRoot | bool | ``true`` | Require the container to run as a non-root UID (prevents starting if UID 0) |
-| frontend.containerSecurityContext.readOnlyRootFilesystem | bool | ``true`` | Mount the container root filesystem read-only to prevent in-place writes or tampering |
-| frontend.containerSecurityContext.capabilities | object | ``{"drop":["ALL"]}`` | Fine-grained Linux kernel privileges to add or drop for the container |
+| frontend.podSecurityContext.enabled | bool | `true` | Enable pod Security Context |
+| frontend.podSecurityContext.fsGroup | int | `101` | GID that Kubernetes applies to mounted volumes and created files so processes in the pod can share group-owned access |
+| frontend.containerSecurityContext.enabled | bool | `true` | Enable container Security Context |
+| frontend.containerSecurityContext.runAsUser | int | `101` | UID the container processes run as (overrides container image default) |
+| frontend.containerSecurityContext.runAsNonRoot | bool | `true` | Require the container to run as a non-root UID (prevents starting if UID 0) |
+| frontend.containerSecurityContext.readOnlyRootFilesystem | bool | `true` | Mount the container root filesystem read-only to prevent in-place writes or tampering |
+| frontend.containerSecurityContext.capabilities | object | `{"drop":["ALL"]}` | Fine-grained Linux kernel privileges to add or drop for the container |
 
 ### Frontend: Resources
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| frontend.resources | object | ``{}`` | Container requests and limits for different resources like CPU or memory |
+| frontend.resources | object | `{}` | Container requests and limits for different resources like CPU or memory |
 
 ### Frontend: Startup Probe
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| frontend.startupProbe.enabled | bool | ``false`` | Enable startup probe |
-| frontend.startupProbe.httpGet.path | string | ``"/health"`` | HTTP GET path for startup probe |
-| frontend.startupProbe.httpGet.port | string | ``"{{ .Values.frontend.service.http.targetPort }}"`` | HTTP GET port for startup probe. Evaluated as a template |
-| frontend.startupProbe.initialDelaySeconds | int | ``5`` | Longer initial wait to accommodate slow-starting apps |
-| frontend.startupProbe.periodSeconds | int | ``10`` | Often set longer to avoid frequent checks while starting |
-| frontend.startupProbe.timeoutSeconds | int | ``3`` | Can be longer to allow slow initialization responses |
-| frontend.startupProbe.failureThreshold | int | ``5`` | Consecutive failures during startup before killing the container (instead of immediate restarts) |
-| frontend.startupProbe.successThreshold | int | ``1`` | Number of consecutive successes required to consider startup complete and enable liveness/readiness |
+| frontend.startupProbe.enabled | bool | `false` | Enable startup probe |
+| frontend.startupProbe.httpGet.path | string | `"/health"` | HTTP GET path for startup probe |
+| frontend.startupProbe.httpGet.port | string | `"{{ .Values.frontend.service.http.targetPort }}"` | HTTP GET port for startup probe. Evaluated as a template |
+| frontend.startupProbe.initialDelaySeconds | int | `5` | Longer initial wait to accommodate slow-starting apps |
+| frontend.startupProbe.periodSeconds | int | `10` | Often set longer to avoid frequent checks while starting |
+| frontend.startupProbe.timeoutSeconds | int | `3` | Can be longer to allow slow initialization responses |
+| frontend.startupProbe.failureThreshold | int | `5` | Consecutive failures during startup before killing the container (instead of immediate restarts) |
+| frontend.startupProbe.successThreshold | int | `1` | Number of consecutive successes required to consider startup complete and enable liveness/readiness |
 
 ### Frontend: Readiness Probe
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| frontend.readinessProbe.enabled | bool | ``true`` | Enable readiness probe |
-| frontend.readinessProbe.httpGet.path | string | ``"/health"`` | HTTP GET path for readiness probe |
-| frontend.readinessProbe.httpGet.port | string | ``"{{ .Values.frontend.service.http.targetPort }}"`` | HTTP GET port for readiness probe. Evaluated as a template |
-| frontend.readinessProbe.initialDelaySeconds | int | ``5`` | Delay before first check (normal start timing) |
-| frontend.readinessProbe.periodSeconds | int | ``5`` | Regular check interval during normal operation |
-| frontend.readinessProbe.timeoutSeconds | int | ``3`` | Short timeout to detect unresponsive containers for readiness |
-| frontend.readinessProbe.failureThreshold | int | ``5`` | Consecutive failures before marking the container Unready (no restart) |
-| frontend.readinessProbe.successThreshold | int | ``1`` | Number of consecutive successes required to mark the container Ready after failures |
+| frontend.readinessProbe.enabled | bool | `true` | Enable readiness probe |
+| frontend.readinessProbe.httpGet.path | string | `"/health"` | HTTP GET path for readiness probe |
+| frontend.readinessProbe.httpGet.port | string | `"{{ .Values.frontend.service.http.targetPort }}"` | HTTP GET port for readiness probe. Evaluated as a template |
+| frontend.readinessProbe.initialDelaySeconds | int | `5` | Delay before first check (normal start timing) |
+| frontend.readinessProbe.periodSeconds | int | `5` | Regular check interval during normal operation |
+| frontend.readinessProbe.timeoutSeconds | int | `3` | Short timeout to detect unresponsive containers for readiness |
+| frontend.readinessProbe.failureThreshold | int | `5` | Consecutive failures before marking the container Unready (no restart) |
+| frontend.readinessProbe.successThreshold | int | `1` | Number of consecutive successes required to mark the container Ready after failures |
 
 ### Frontend: Liveness Probe
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| frontend.livenessProbe.enabled | bool | ``true`` | Enable liveness probe |
-| frontend.livenessProbe.httpGet.path | string | ``"/health"`` | HTTP GET path for liveness probe |
-| frontend.livenessProbe.httpGet.port | string | ``"{{ .Values.frontend.service.http.targetPort }}"`` | HTTP GET port for liveness probe. Evaluated as a template |
-| frontend.livenessProbe.initialDelaySeconds | int | ``5`` | Delay before first check (normal start timing) |
-| frontend.livenessProbe.periodSeconds | int | ``10`` | Regular check interval during normal operation |
-| frontend.livenessProbe.timeoutSeconds | int | ``3`` | Short timeout to detect hung containers quickly |
-| frontend.livenessProbe.failureThreshold | int | ``10`` | Consecutive failures before restarting the container |
-| frontend.livenessProbe.successThreshold | int | ``1`` | Typically 1 (usually ignored) |
+| frontend.livenessProbe.enabled | bool | `true` | Enable liveness probe |
+| frontend.livenessProbe.httpGet.path | string | `"/health"` | HTTP GET path for liveness probe |
+| frontend.livenessProbe.httpGet.port | string | `"{{ .Values.frontend.service.http.targetPort }}"` | HTTP GET port for liveness probe. Evaluated as a template |
+| frontend.livenessProbe.initialDelaySeconds | int | `5` | Delay before first check (normal start timing) |
+| frontend.livenessProbe.periodSeconds | int | `10` | Regular check interval during normal operation |
+| frontend.livenessProbe.timeoutSeconds | int | `3` | Short timeout to detect hung containers quickly |
+| frontend.livenessProbe.failureThreshold | int | `10` | Consecutive failures before restarting the container |
+| frontend.livenessProbe.successThreshold | int | `1` | Typically 1 (usually ignored) |
 
 ### Cron: Image
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| cron.image.registry | string | ``""`` | Cron container image registry |
-| cron.image.repository | string | ``"enterprise/platform/backend"`` | Cron container image repository |
-| cron.image.tag | string | ``"{{ .chart.AppVersion }}"`` | Cron container image tag |
-| cron.image.digest | string | ``""`` | Cron container image digest in the format `sha256:1234abcdef` |
-| cron.image.pullPolicy | string | ``"IfNotPresent"`` | imagePullPolicy for the cron container Ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images |
-| cron.image.pullSecrets | list | ``[]`` | List of imagePullSecrets Secrets must be created in the same namespace, for example using the .extraDeploy array Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ |
+| cron.image.registry | string | `""` | Cron container image registry |
+| cron.image.repository | string | `"enterprise/platform/backend"` | Cron container image repository |
+| cron.image.tag | string | `"{{ .chart.AppVersion }}"` | Cron container image tag |
+| cron.image.digest | string | `""` | Cron container image digest in the format `sha256:1234abcdef` |
+| cron.image.pullPolicy | string | `"IfNotPresent"` | imagePullPolicy for the cron container Ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images |
+| cron.image.pullSecrets | list | `[]` | List of imagePullSecrets Secrets must be created in the same namespace, for example using the .extraDeploy array Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ |
 
 ### Cron: Service
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| cron.micronautEnvironments | list | ``["prod","redis","cron"]`` | List of Micronaut Environments to enable on the cron pod |
-| cron.service.type | string | ``"ClusterIP"`` | Cron Service type. Note: ingresses using AWS ALB require the service to be NodePort |
-| cron.service.http.name | string | ``"http"`` | Service name to use |
-| cron.service.http.port | int | ``8080`` | Service port |
-| cron.service.http.targetPort | int | ``8082`` | Port on the pod/container that the Service forwards traffic to (can be a number or named port, distinct from the Service's external port) |
-| cron.service.http.nodePort | int | ``0`` | Service node port, only used when service.type is Nodeport or LoadBalancer Choose port between 30000-32767, unless the cluster was configured differently than default |
-| cron.service.extraServices | list | ``[]`` | Other services that should live in the Service object https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service |
-| cron.service.extraOptions | object | ``{}`` | Extra Service options to place under .spec (for example, clusterIP, loadBalancerIP, externalTrafficPolicy, externalIPs). Evaluated as a template |
+| cron.micronautEnvironments | list | `["prod","redis","cron"]` | List of Micronaut Environments to enable on the cron pod |
+| cron.service.type | string | `"ClusterIP"` | Cron Service type. Note: ingresses using AWS ALB require the service to be NodePort |
+| cron.service.http.name | string | `"http"` | Service name to use |
+| cron.service.http.port | int | `8080` | Service port |
+| cron.service.http.targetPort | int | `8082` | Port on the pod/container that the Service forwards traffic to (can be a number or named port, distinct from the Service's external port) |
+| cron.service.http.nodePort | int | `0` | Service node port, only used when service.type is Nodeport or LoadBalancer Choose port between 30000-32767, unless the cluster was configured differently than default |
+| cron.service.extraServices | list | `[]` | Other services that should live in the Service object https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service |
+| cron.service.extraOptions | object | `{}` | Extra Service options to place under .spec (for example, clusterIP, loadBalancerIP, externalTrafficPolicy, externalIPs). Evaluated as a template |
 
 ### Cron: Pod
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| cron.initContainers | list | ``[]`` | Additional init containers for the cron pod. Evaluated as a template |
-| cron.command | list | ``[]`` | Override default container command (useful when using custom images) |
-| cron.args | list | ``[]`` | Override default container args (useful when using custom images) |
-| cron.podLabels | object | ``{}`` | Additional labels for the cron pod. Evaluated as a template |
-| cron.podAnnotations | object | ``{}`` | Additional annotations for the cron pod. Evaluated as a template |
-| cron.extraOptionsSpec | object | ``{}`` | Extra options to place under .spec (for example, revisionHistoryLimit). Evaluated as a template Note that cron deployment needs to have a single replica with Recreate strategy |
-| cron.extraOptionsTemplateSpec | object | ``{}`` | Extra options to place under .spec.template.spec (for example, nodeSelector, affinity, restartPolicy) Evaluated as a template |
-| cron.extraEnvVars | list | ``[]`` | Extra environment variables to set on the cron pod |
-| cron.extraEnvVarsCMs | list | ``[]`` | List of ConfigMaps containing extra env vars |
-| cron.extraEnvVarsSecrets | list | ``[]`` | List of Secrets containing extra env vars |
-| cron.extraVolumes | list | ``[]`` | Extra volumes to add to the deployment (evaluated as template). Requires setting `extraVolumeMounts` |
-| cron.extraVolumeMounts | list | ``[]`` | List of volume mounts to add to the container (evaluated as template). Normally used with `extraVolumes` |
+| cron.initContainers | list | `[]` | Additional init containers for the cron pod. Evaluated as a template |
+| cron.command | list | `[]` | Override default container command (useful when using custom images) |
+| cron.args | list | `[]` | Override default container args (useful when using custom images) |
+| cron.podLabels | object | `{}` | Additional labels for the cron pod. Evaluated as a template |
+| cron.podAnnotations | object | `{}` | Additional annotations for the cron pod. Evaluated as a template |
+| cron.extraOptionsSpec | object | `{}` | Extra options to place under .spec (for example, revisionHistoryLimit). Evaluated as a template Note that cron deployment needs to have a single replica with Recreate strategy |
+| cron.extraOptionsTemplateSpec | object | `{}` | Extra options to place under .spec.template.spec (for example, nodeSelector, affinity, restartPolicy) Evaluated as a template |
+| cron.extraEnvVars | list | `[]` | Extra environment variables to set on the cron pod |
+| cron.extraEnvVarsCMs | list | `[]` | List of ConfigMaps containing extra env vars |
+| cron.extraEnvVarsSecrets | list | `[]` | List of Secrets containing extra env vars |
+| cron.extraVolumes | list | `[]` | Extra volumes to add to the deployment (evaluated as template). Requires setting `extraVolumeMounts` |
+| cron.extraVolumeMounts | list | `[]` | List of volume mounts to add to the container (evaluated as template). Normally used with `extraVolumes` |
 
 ### Cron: Security Context
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| cron.podSecurityContext.enabled | bool | ``true`` | Enable pod Security Context |
-| cron.podSecurityContext.fsGroup | int | ``101`` | GID that Kubernetes applies to mounted volumes and created files so processes in the pod can share group-owned access |
-| cron.containerSecurityContext.enabled | bool | ``true`` | Enable container Security Context |
-| cron.containerSecurityContext.runAsUser | int | ``101`` | UID the container processes run as (overrides container image default) |
-| cron.containerSecurityContext.runAsNonRoot | bool | ``true`` | Require the container to run as a non-root UID (prevents starting if UID 0) |
-| cron.containerSecurityContext.readOnlyRootFilesystem | bool | ``true`` | Mount the container root filesystem read-only to prevent in-place writes or tampering |
-| cron.containerSecurityContext.capabilities | object | ``{"drop":["ALL"]}`` | Fine-grained Linux kernel privileges to add or drop for the container |
+| cron.podSecurityContext.enabled | bool | `true` | Enable pod Security Context |
+| cron.podSecurityContext.fsGroup | int | `101` | GID that Kubernetes applies to mounted volumes and created files so processes in the pod can share group-owned access |
+| cron.containerSecurityContext.enabled | bool | `true` | Enable container Security Context |
+| cron.containerSecurityContext.runAsUser | int | `101` | UID the container processes run as (overrides container image default) |
+| cron.containerSecurityContext.runAsNonRoot | bool | `true` | Require the container to run as a non-root UID (prevents starting if UID 0) |
+| cron.containerSecurityContext.readOnlyRootFilesystem | bool | `true` | Mount the container root filesystem read-only to prevent in-place writes or tampering |
+| cron.containerSecurityContext.capabilities | object | `{"drop":["ALL"]}` | Fine-grained Linux kernel privileges to add or drop for the container |
 
 ### Cron: Resources
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| cron.resources | object | ``{}`` | Container requests and limits for different resources like CPU or memory |
+| cron.resources | object | `{}` | Container requests and limits for different resources like CPU or memory |
 
 ### Cron: Startup Probe
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| cron.startupProbe.enabled | bool | ``false`` | Enable startup probe |
-| cron.startupProbe.httpGet.path | string | ``"/health"`` | HTTP GET path for startup probe |
-| cron.startupProbe.httpGet.port | string | ``"{{ .Values.cron.service.http.targetPort }}"`` | HTTP GET port for startup probe. Evaluated as a template |
-| cron.startupProbe.initialDelaySeconds | int | ``5`` | Longer initial wait to accommodate slow-starting apps |
-| cron.startupProbe.periodSeconds | int | ``10`` | Often set longer to avoid frequent checks while starting |
-| cron.startupProbe.timeoutSeconds | int | ``3`` | Can be longer to allow slow initialization responses |
-| cron.startupProbe.failureThreshold | int | ``5`` | Consecutive failures during startup before killing the container (instead of immediate restarts) |
-| cron.startupProbe.successThreshold | int | ``1`` | Number of consecutive successes required to consider startup complete and enable liveness/readiness |
+| cron.startupProbe.enabled | bool | `false` | Enable startup probe |
+| cron.startupProbe.httpGet.path | string | `"/health"` | HTTP GET path for startup probe |
+| cron.startupProbe.httpGet.port | string | `"{{ .Values.cron.service.http.targetPort }}"` | HTTP GET port for startup probe. Evaluated as a template |
+| cron.startupProbe.initialDelaySeconds | int | `5` | Longer initial wait to accommodate slow-starting apps |
+| cron.startupProbe.periodSeconds | int | `10` | Often set longer to avoid frequent checks while starting |
+| cron.startupProbe.timeoutSeconds | int | `3` | Can be longer to allow slow initialization responses |
+| cron.startupProbe.failureThreshold | int | `5` | Consecutive failures during startup before killing the container (instead of immediate restarts) |
+| cron.startupProbe.successThreshold | int | `1` | Number of consecutive successes required to consider startup complete and enable liveness/readiness |
 
 ### Cron: Readiness Probe
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| cron.readinessProbe.enabled | bool | ``true`` | Enable readiness probe |
-| cron.readinessProbe.httpGet.path | string | ``"/health"`` | HTTP GET path for readiness probe |
-| cron.readinessProbe.httpGet.port | string | ``"{{ .Values.cron.service.http.targetPort }}"`` | HTTP GET port for readiness probe. Evaluated as a template |
-| cron.readinessProbe.initialDelaySeconds | int | ``5`` | Delay before first check (normal start timing) |
-| cron.readinessProbe.periodSeconds | int | ``5`` | Regular check interval during normal operation |
-| cron.readinessProbe.timeoutSeconds | int | ``3`` | Short timeout to detect unresponsive containers for readiness |
-| cron.readinessProbe.failureThreshold | int | ``5`` | Consecutive failures before marking the container Unready (no restart) |
-| cron.readinessProbe.successThreshold | int | ``1`` | Number of consecutive successes required to mark the container Ready after failures |
+| cron.readinessProbe.enabled | bool | `true` | Enable readiness probe |
+| cron.readinessProbe.httpGet.path | string | `"/health"` | HTTP GET path for readiness probe |
+| cron.readinessProbe.httpGet.port | string | `"{{ .Values.cron.service.http.targetPort }}"` | HTTP GET port for readiness probe. Evaluated as a template |
+| cron.readinessProbe.initialDelaySeconds | int | `5` | Delay before first check (normal start timing) |
+| cron.readinessProbe.periodSeconds | int | `5` | Regular check interval during normal operation |
+| cron.readinessProbe.timeoutSeconds | int | `3` | Short timeout to detect unresponsive containers for readiness |
+| cron.readinessProbe.failureThreshold | int | `5` | Consecutive failures before marking the container Unready (no restart) |
+| cron.readinessProbe.successThreshold | int | `1` | Number of consecutive successes required to mark the container Ready after failures |
 
 ### Cron: Liveness Probe
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| cron.livenessProbe.enabled | bool | ``true`` | Enable liveness probe |
-| cron.livenessProbe.httpGet.path | string | ``"/health"`` | HTTP GET path for liveness probe |
-| cron.livenessProbe.httpGet.port | string | ``"{{ .Values.cron.service.http.targetPort }}"`` | HTTP GET port for liveness probe. Evaluated as a template |
-| cron.livenessProbe.initialDelaySeconds | int | ``5`` | Delay before first check (normal start timing) |
-| cron.livenessProbe.periodSeconds | int | ``10`` | Regular check interval during normal operation |
-| cron.livenessProbe.timeoutSeconds | int | ``3`` | Short timeout to detect hung containers quickly |
-| cron.livenessProbe.failureThreshold | int | ``10`` | Consecutive failures before restarting the container |
-| cron.livenessProbe.successThreshold | int | ``1`` | Typically 1 (usually ignored) |
+| cron.livenessProbe.enabled | bool | `true` | Enable liveness probe |
+| cron.livenessProbe.httpGet.path | string | `"/health"` | HTTP GET path for liveness probe |
+| cron.livenessProbe.httpGet.port | string | `"{{ .Values.cron.service.http.targetPort }}"` | HTTP GET port for liveness probe. Evaluated as a template |
+| cron.livenessProbe.initialDelaySeconds | int | `5` | Delay before first check (normal start timing) |
+| cron.livenessProbe.periodSeconds | int | `10` | Regular check interval during normal operation |
+| cron.livenessProbe.timeoutSeconds | int | `3` | Short timeout to detect hung containers quickly |
+| cron.livenessProbe.failureThreshold | int | `10` | Consecutive failures before restarting the container |
+| cron.livenessProbe.successThreshold | int | `1` | Typically 1 (usually ignored) |
 
 ### Cron: DB Migration Init Container
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| cron.dbMigrationInitContainer.image.registry | string | ``""`` | Database migration container image registry |
-| cron.dbMigrationInitContainer.image.repository | string | ``"enterprise/platform/migrate-db"`` | Database migration container image repository |
-| cron.dbMigrationInitContainer.image.tag | string | ``"{{ .chart.AppVersion }}"`` | Specify a tag to override the version defined in .Chart.appVersion |
-| cron.dbMigrationInitContainer.image.digest | string | ``""`` | Database migration container image digest in the format `sha256:1234abcdef` |
-| cron.dbMigrationInitContainer.image.pullPolicy | string | ``"IfNotPresent"`` | imagePullPolicy for the database migration init container Ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images |
-| cron.dbMigrationInitContainer.image.pullSecrets | list | ``[]`` | List of imagePullSecrets Secrets must be created in the same namespace, for example using the .extraDeploy array Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ |
-| cron.dbMigrationInitContainer.command | list | ``["/bin/sh","-c","/migrate-db.sh"]`` | Override default container command (useful when using custom images) |
-| cron.dbMigrationInitContainer.args | list | ``[]`` | Override default container args (useful when using custom images) |
-| cron.dbMigrationInitContainer.extraEnvVars | list | ``[]`` | Extra environment variables to set on the cron pod |
-| cron.dbMigrationInitContainer.extraEnvVarsCMs | list | ``[]`` | List of ConfigMaps containing extra env vars |
-| cron.dbMigrationInitContainer.extraEnvVarsSecrets | list | ``[]`` | List of Secrets containing extra env vars |
-| cron.dbMigrationInitContainer.extraVolumes | list | ``[]`` | Extra volumes to add to the deployment (evaluated as template). Requires setting `extraVolumeMounts` |
-| cron.dbMigrationInitContainer.extraVolumeMounts | list | ``[]`` | List of volume mounts to add to the container (evaluated as template). Normally used with `extraVolumes` |
-| cron.dbMigrationInitContainer.containerSecurityContext.enabled | bool | ``true`` | Enable container Security Context |
-| cron.dbMigrationInitContainer.containerSecurityContext.runAsUser | int | ``101`` | UID the container processes run as (overrides container image default) |
-| cron.dbMigrationInitContainer.containerSecurityContext.runAsNonRoot | bool | ``true`` | Require the container to run as a non-root UID (prevents starting if UID 0) |
-| cron.dbMigrationInitContainer.containerSecurityContext.readOnlyRootFilesystem | bool | ``true`` | Mount the container root filesystem read-only to prevent in-place writes or tampering |
-| cron.dbMigrationInitContainer.containerSecurityContext.capabilities | object | ``{"drop":["ALL"]}`` | Fine-grained Linux kernel privileges to add or drop for the container |
-| cron.dbMigrationInitContainer.resources | object | ``{}`` | Container requests and limits for different resources like CPU or memory |
+| cron.dbMigrationInitContainer.image.registry | string | `""` | Database migration container image registry |
+| cron.dbMigrationInitContainer.image.repository | string | `"enterprise/platform/migrate-db"` | Database migration container image repository |
+| cron.dbMigrationInitContainer.image.tag | string | `"{{ .chart.AppVersion }}"` | Specify a tag to override the version defined in .Chart.appVersion |
+| cron.dbMigrationInitContainer.image.digest | string | `""` | Database migration container image digest in the format `sha256:1234abcdef` |
+| cron.dbMigrationInitContainer.image.pullPolicy | string | `"IfNotPresent"` | imagePullPolicy for the database migration init container Ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images |
+| cron.dbMigrationInitContainer.image.pullSecrets | list | `[]` | List of imagePullSecrets Secrets must be created in the same namespace, for example using the .extraDeploy array Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ |
+| cron.dbMigrationInitContainer.command | list | `["/bin/sh","-c","/migrate-db.sh"]` | Override default container command (useful when using custom images) |
+| cron.dbMigrationInitContainer.args | list | `[]` | Override default container args (useful when using custom images) |
+| cron.dbMigrationInitContainer.extraEnvVars | list | `[]` | Extra environment variables to set on the cron pod |
+| cron.dbMigrationInitContainer.extraEnvVarsCMs | list | `[]` | List of ConfigMaps containing extra env vars |
+| cron.dbMigrationInitContainer.extraEnvVarsSecrets | list | `[]` | List of Secrets containing extra env vars |
+| cron.dbMigrationInitContainer.extraVolumes | list | `[]` | Extra volumes to add to the deployment (evaluated as template). Requires setting `extraVolumeMounts` |
+| cron.dbMigrationInitContainer.extraVolumeMounts | list | `[]` | List of volume mounts to add to the container (evaluated as template). Normally used with `extraVolumes` |
+| cron.dbMigrationInitContainer.containerSecurityContext.enabled | bool | `true` | Enable container Security Context |
+| cron.dbMigrationInitContainer.containerSecurityContext.runAsUser | int | `101` | UID the container processes run as (overrides container image default) |
+| cron.dbMigrationInitContainer.containerSecurityContext.runAsNonRoot | bool | `true` | Require the container to run as a non-root UID (prevents starting if UID 0) |
+| cron.dbMigrationInitContainer.containerSecurityContext.readOnlyRootFilesystem | bool | `true` | Mount the container root filesystem read-only to prevent in-place writes or tampering |
+| cron.dbMigrationInitContainer.containerSecurityContext.capabilities | object | `{"drop":["ALL"]}` | Fine-grained Linux kernel privileges to add or drop for the container |
+| cron.dbMigrationInitContainer.resources | object | `{}` | Container requests and limits for different resources like CPU or memory |
 
 ### Init Container Dependencies
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| initContainerDependencies.enabled | bool | ``true`` | Enable init containers that coordinate startup dependencies between Platform components (for example, wait for database readiness before cron starts, wait for cron before backend starts, etc) |
+| initContainerDependencies.enabled | bool | `true` | Enable init containers that coordinate startup dependencies between Platform components (for example, wait for database readiness before cron starts, wait for cron before backend starts, etc) |
 
 ### Init Container Dependencies: Wait For MySQL
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| initContainerDependencies.waitForMySQL.enabled | bool | ``true`` | Enable wait for MySQL init container before starting backend and cron |
-| initContainerDependencies.waitForMySQL.image.registry | string | ``""`` | Override default wait for MySQL init container image |
-| initContainerDependencies.waitForMySQL.image.repository | string | ``"mysql"`` | Init container image repository |
-| initContainerDependencies.waitForMySQL.image.tag | string | ``"9"`` | Init container image tag |
-| initContainerDependencies.waitForMySQL.image.digest | string | ``""`` | Init container image digest in the format `sha256:1234abcdef` |
-| initContainerDependencies.waitForMySQL.image.pullPolicy | string | ``"IfNotPresent"`` | imagePullPolicy for the init container |
-| initContainerDependencies.waitForMySQL.securityContext.runAsUser | int | ``101`` | UID the container processes run as (overrides container image default) |
-| initContainerDependencies.waitForMySQL.securityContext.runAsNonRoot | bool | ``true`` | Require the container to run as a non-root UID (prevents starting if UID 0) |
-| initContainerDependencies.waitForMySQL.securityContext.readOnlyRootFilesystem | bool | ``true`` | Mount the container root filesystem read-only to prevent in-place writes or tampering |
-| initContainerDependencies.waitForMySQL.securityContext.capabilities | object | ``{"drop":["ALL"]}`` | Fine-grained Linux kernel privileges to add or drop for the container |
-| initContainerDependencies.waitForMySQL.resources | object | ``{"limits":{"memory":"100Mi"},"requests":{"cpu":"0.5","memory":"50Mi"}}`` | Container requests and limits for different resources like CPU or memory |
-| initContainerDependencies.waitForMySQL.extraEnvVars | list | ``[]`` | Additional environment variables for the init container. The special variable `MYSQL_EXTRA_ARGS` is appended verbatim to the `mysql` readiness check command, and can be used to pass TLS flags when connecting to managed MySQL services such as AWS RDS or Azure Database for MySQL that require certificate verification. Pair with `extraVolumeMounts` to mount the CA certificate into the container. Example (TLS with CA certificate mounted from a volume): extraEnvVars:   - name: MYSQL_EXTRA_ARGS     value: "--ssl-ca=/certs/ca.pem --ssl-mode=VERIFY_IDENTITY" |
-| initContainerDependencies.waitForMySQL.extraVolumeMounts | list | ``[]`` | Additional volume mounts for the init container. Use this to mount CA certificates (e.g. from a Secret or ConfigMap populated by an extraInitContainer) so that `MYSQL_EXTRA_ARGS` can reference them. |
+| initContainerDependencies.waitForMySQL.enabled | bool | `true` | Enable wait for MySQL init container before starting backend and cron |
+| initContainerDependencies.waitForMySQL.image.registry | string | `""` | Override default wait for MySQL init container image |
+| initContainerDependencies.waitForMySQL.image.repository | string | `"mysql"` | Init container image repository |
+| initContainerDependencies.waitForMySQL.image.tag | string | `"9"` | Init container image tag |
+| initContainerDependencies.waitForMySQL.image.digest | string | `""` | Init container image digest in the format `sha256:1234abcdef` |
+| initContainerDependencies.waitForMySQL.image.pullPolicy | string | `"IfNotPresent"` | imagePullPolicy for the init container |
+| initContainerDependencies.waitForMySQL.securityContext.runAsUser | int | `101` | UID the container processes run as (overrides container image default) |
+| initContainerDependencies.waitForMySQL.securityContext.runAsNonRoot | bool | `true` | Require the container to run as a non-root UID (prevents starting if UID 0) |
+| initContainerDependencies.waitForMySQL.securityContext.readOnlyRootFilesystem | bool | `true` | Mount the container root filesystem read-only to prevent in-place writes or tampering |
+| initContainerDependencies.waitForMySQL.securityContext.capabilities | object | `{"drop":["ALL"]}` | Fine-grained Linux kernel privileges to add or drop for the container |
+| initContainerDependencies.waitForMySQL.resources | object | `{"limits":{"memory":"100Mi"},"requests":{"cpu":"0.5","memory":"50Mi"}}` | Container requests and limits for different resources like CPU or memory |
+| initContainerDependencies.waitForMySQL.extraEnvVars | list | `[]` | Additional environment variables for the init container. The special variable `MYSQL_EXTRA_ARGS` is appended verbatim to the `mysql` readiness check command, and can be used to pass TLS flags when connecting to managed MySQL services such as AWS RDS or Azure Database for MySQL that require certificate verification. Pair with `extraVolumeMounts` to mount the CA certificate into the container. Example (TLS with CA certificate mounted from a volume): extraEnvVars:   - name: MYSQL_EXTRA_ARGS     value: "--ssl-ca=/certs/ca.pem --ssl-mode=VERIFY_IDENTITY" |
+| initContainerDependencies.waitForMySQL.extraVolumeMounts | list | `[]` | Additional volume mounts for the init container. Use this to mount CA certificates (e.g. from a Secret or ConfigMap populated by an extraInitContainer) so that `MYSQL_EXTRA_ARGS` can reference them. |
 
 ### Init Container Dependencies: Wait For Redis
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| initContainerDependencies.waitForRedis.enabled | bool | ``true`` | Enable wait for Redis init container before starting backend and cron |
-| initContainerDependencies.waitForRedis.image.registry | string | ``""`` | Override default wait for Redis init container image |
-| initContainerDependencies.waitForRedis.image.repository | string | ``"redis"`` | Init container image repository |
-| initContainerDependencies.waitForRedis.image.tag | string | ``"7-alpine"`` | Init container image tag |
-| initContainerDependencies.waitForRedis.image.digest | string | ``""`` | Init container image digest in the format `sha256:1234abcdef` |
-| initContainerDependencies.waitForRedis.image.pullPolicy | string | ``"IfNotPresent"`` | imagePullPolicy for the init container |
-| initContainerDependencies.waitForRedis.securityContext.runAsUser | int | ``101`` | UID the container processes run as (overrides container image default) |
-| initContainerDependencies.waitForRedis.securityContext.runAsNonRoot | bool | ``true`` | Require the container to run as a non-root UID (prevents starting if UID 0) |
-| initContainerDependencies.waitForRedis.securityContext.readOnlyRootFilesystem | bool | ``true`` | Mount the container root filesystem read-only to prevent in-place writes or tampering |
-| initContainerDependencies.waitForRedis.securityContext.capabilities | object | ``{"drop":["ALL"]}`` | Fine-grained Linux kernel privileges to add or drop for the container |
-| initContainerDependencies.waitForRedis.resources | object | ``{"limits":{"memory":"100Mi"},"requests":{"cpu":"0.5","memory":"50Mi"}}`` | Container requests and limits for different resources like CPU or memory |
-| initContainerDependencies.waitForRedis.extraEnvVars | list | ``[]`` | Additional environment variables for the init container |
-| initContainerDependencies.waitForRedis.extraVolumeMounts | list | ``[]`` | Additional volume mounts for the init container (e.g. to mount a CA certificate) |
+| initContainerDependencies.waitForRedis.enabled | bool | `true` | Enable wait for Redis init container before starting backend and cron |
+| initContainerDependencies.waitForRedis.image.registry | string | `""` | Override default wait for Redis init container image |
+| initContainerDependencies.waitForRedis.image.repository | string | `"redis"` | Init container image repository |
+| initContainerDependencies.waitForRedis.image.tag | string | `"7-alpine"` | Init container image tag |
+| initContainerDependencies.waitForRedis.image.digest | string | `""` | Init container image digest in the format `sha256:1234abcdef` |
+| initContainerDependencies.waitForRedis.image.pullPolicy | string | `"IfNotPresent"` | imagePullPolicy for the init container |
+| initContainerDependencies.waitForRedis.securityContext.runAsUser | int | `101` | UID the container processes run as (overrides container image default) |
+| initContainerDependencies.waitForRedis.securityContext.runAsNonRoot | bool | `true` | Require the container to run as a non-root UID (prevents starting if UID 0) |
+| initContainerDependencies.waitForRedis.securityContext.readOnlyRootFilesystem | bool | `true` | Mount the container root filesystem read-only to prevent in-place writes or tampering |
+| initContainerDependencies.waitForRedis.securityContext.capabilities | object | `{"drop":["ALL"]}` | Fine-grained Linux kernel privileges to add or drop for the container |
+| initContainerDependencies.waitForRedis.resources | object | `{"limits":{"memory":"100Mi"},"requests":{"cpu":"0.5","memory":"50Mi"}}` | Container requests and limits for different resources like CPU or memory |
+| initContainerDependencies.waitForRedis.extraEnvVars | list | `[]` | Additional environment variables for the init container |
+| initContainerDependencies.waitForRedis.extraVolumeMounts | list | `[]` | Additional volume mounts for the init container (e.g. to mount a CA certificate) |
 
 ### Init Container Dependencies: Wait For Cron
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| initContainerDependencies.waitForCron.enabled | bool | ``true`` | Enable wait for Platform cron init container before starting backend |
-| initContainerDependencies.waitForCron.image.registry | string | ``""`` | Override default wait for cron init container image |
-| initContainerDependencies.waitForCron.image.repository | string | ``"curlimages/curl"`` | Init container image repository |
-| initContainerDependencies.waitForCron.image.tag | string | ``"latest"`` | Init container image tag |
-| initContainerDependencies.waitForCron.image.digest | string | ``""`` | Init container image digest in the format `sha256:1234abcdef` |
-| initContainerDependencies.waitForCron.image.pullPolicy | string | ``"IfNotPresent"`` | imagePullPolicy for the init container |
-| initContainerDependencies.waitForCron.securityContext.runAsUser | int | ``101`` | UID the container processes run as (overrides container image default) |
-| initContainerDependencies.waitForCron.securityContext.runAsNonRoot | bool | ``true`` | Require the container to run as a non-root UID (prevents starting if UID 0) |
-| initContainerDependencies.waitForCron.securityContext.readOnlyRootFilesystem | bool | ``true`` | Mount the container root filesystem read-only to prevent in-place writes or tampering |
-| initContainerDependencies.waitForCron.securityContext.capabilities | object | ``{"drop":["ALL"]}`` | Fine-grained Linux kernel privileges to add or drop for the container |
-| initContainerDependencies.waitForCron.resources | object | ``{"limits":{"memory":"100Mi"},"requests":{"cpu":"0.5","memory":"50Mi"}}`` | Container requests and limits for different resources like CPU or memory |
-| initContainerDependencies.waitForCron.extraEnvVars | list | ``[]`` | Additional environment variables for the init container |
-| initContainerDependencies.waitForCron.extraVolumeMounts | list | ``[]`` | Additional volume mounts for the init container (e.g. to mount a CA certificate) |
+| initContainerDependencies.waitForCron.enabled | bool | `true` | Enable wait for Platform cron init container before starting backend |
+| initContainerDependencies.waitForCron.image.registry | string | `""` | Override default wait for cron init container image |
+| initContainerDependencies.waitForCron.image.repository | string | `"curlimages/curl"` | Init container image repository |
+| initContainerDependencies.waitForCron.image.tag | string | `"latest"` | Init container image tag |
+| initContainerDependencies.waitForCron.image.digest | string | `""` | Init container image digest in the format `sha256:1234abcdef` |
+| initContainerDependencies.waitForCron.image.pullPolicy | string | `"IfNotPresent"` | imagePullPolicy for the init container |
+| initContainerDependencies.waitForCron.securityContext.runAsUser | int | `101` | UID the container processes run as (overrides container image default) |
+| initContainerDependencies.waitForCron.securityContext.runAsNonRoot | bool | `true` | Require the container to run as a non-root UID (prevents starting if UID 0) |
+| initContainerDependencies.waitForCron.securityContext.readOnlyRootFilesystem | bool | `true` | Mount the container root filesystem read-only to prevent in-place writes or tampering |
+| initContainerDependencies.waitForCron.securityContext.capabilities | object | `{"drop":["ALL"]}` | Fine-grained Linux kernel privileges to add or drop for the container |
+| initContainerDependencies.waitForCron.resources | object | `{"limits":{"memory":"100Mi"},"requests":{"cpu":"0.5","memory":"50Mi"}}` | Container requests and limits for different resources like CPU or memory |
+| initContainerDependencies.waitForCron.extraEnvVars | list | `[]` | Additional environment variables for the init container |
+| initContainerDependencies.waitForCron.extraVolumeMounts | list | `[]` | Additional volume mounts for the init container (e.g. to mount a CA certificate) |
 
 ### Service Account
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| serviceAccount.name | string | ``""`` | Name of an existing ServiceAccount. If not set, a new ServiceAccount is generated based on the release name |
-| serviceAccount.annotations | object | ``{}`` | Additional annotations for the ServiceAccount to generate |
-| serviceAccount.imagePullSecretNames | list | ``[]`` | Names of Secrets containing credentials to pull images from registries |
-| serviceAccount.automountServiceAccountToken | bool | ``false`` | Automount service account token when the service account is generated |
+| serviceAccount.name | string | `""` | Name of an existing ServiceAccount. If not set, a new ServiceAccount is generated based on the release name |
+| serviceAccount.annotations | object | `{}` | Additional annotations for the ServiceAccount to generate |
+| serviceAccount.imagePullSecretNames | list | `[]` | Names of Secrets containing credentials to pull images from registries |
+| serviceAccount.automountServiceAccountToken | bool | `false` | Automount service account token when the service account is generated |
 
 ### Ingress
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| ingress.enabled | bool | ``false`` | Enable ingress for Platform |
-| ingress.path | string | ``""`` | Path for the main ingress rule. When empty, falls back to `global.ingress.path` |
-| ingress.contentPath | string | ``""`` | Path for the content domain ingress rule. When empty, falls back to `ingress.path` |
-| ingress.defaultPathType | string | ``""`` | Default path type for the Ingress. When empty, falls back to `global.ingress.defaultPathType` |
-| ingress.defaultBackend | object | ``{}`` | Configure the default service for the ingress (evaluated as template) Important: make sure only one defaultBackend is defined across the k8s cluster: if the ingress doesn't reconcile successfully, 'describe ingress <name>' will report problems |
-| ingress.extraHosts | list | ``[]`` | Additional hosts you want to include. Evaluated as a template |
-| ingress.annotations | object | ``{}`` | Ingress annotations specific to your load balancer. Evaluated as a template |
-| ingress.extraLabels | object | ``{}`` | Additional labels for the ingress object. Evaluated as a template |
-| ingress.ingressClassName | string | ``""`` | Name of the ingress class (replaces the deprecated annotation `kubernetes.io/ingress.class`). When empty, falls back to `global.ingress.ingressClassName` |
-| ingress.tls | list | ``[]`` | TLS configuration. Evaluated as a template |
+| ingress.enabled | bool | `false` | Enable ingress for Platform |
+| ingress.path | string | `""` | Path for the main ingress rule. When empty, falls back to `global.ingress.path` |
+| ingress.contentPath | string | `""` | Path for the content domain ingress rule. When empty, falls back to `ingress.path` |
+| ingress.defaultPathType | string | `""` | Default path type for the Ingress. When empty, falls back to `global.ingress.defaultPathType` |
+| ingress.defaultBackend | object | `{}` | Configure the default service for the ingress (evaluated as template) Important: make sure only one defaultBackend is defined across the k8s cluster: if the ingress doesn't reconcile successfully, 'describe ingress <name>' will report problems |
+| ingress.extraHosts | list | `[]` | Additional hosts you want to include. Evaluated as a template |
+| ingress.annotations | object | `{}` | Ingress annotations specific to your load balancer. Evaluated as a template |
+| ingress.extraLabels | object | `{}` | Additional labels for the ingress object. Evaluated as a template |
+| ingress.ingressClassName | string | `""` | Name of the ingress class (replaces the deprecated annotation `kubernetes.io/ingress.class`). When empty, falls back to `global.ingress.ingressClassName` |
+| ingress.tls | list | `[]` | TLS configuration. Evaluated as a template |
 
 ### Common
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| extraDeploy | list | ``[]`` | Array of extra objects to deploy with the release |
-| commonAnnotations | object | ``{}`` | Annotations to add to all deployed objects |
-| commonLabels | object | ``{}`` | Labels to add to all deployed objects |
+| extraDeploy | list | `[]` | Array of extra objects to deploy with the release |
+| commonAnnotations | object | `{}` | Annotations to add to all deployed objects |
+| commonLabels | object | `{}` | Labels to add to all deployed objects |
 
 ### Subcharts: Studios
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| studios.enabled | bool | ``true`` | Enable Studios feature. Refer to the subchart README for more details and the full list of configuration options |
-| studios.proxy.oidcClientRegistrationTokenSecretName | string | ``"{{ printf \"%s-backend\" (include \"common.names.dependency.fullname\" (dict \"chartName\" \"platform\" \"chartValues\" .Values \"context\" .)) }}"`` | studios needs to pass a client registration token to the platform backend so that it can register studios clients to the platform OIDC provider. If the platform oidc registration token is coming from a separate secret, you need to update it here too. `common.names.dependency.fullname` is used (rather than `common.names.fullname`) because this value is `tpl`-evaluated inside the studios subchart context where `.Chart.Name` is `studios`, not `platform`; passing `chartName: platform` explicitly reproduces the parent's fullname. Name of the existing Secret containing the OIDC client registration token to share with the Studios proxy. Evaluated as a template |
-| studios.proxy.oidcClientRegistrationTokenSecretKey | string | ``"OIDC_CLIENT_REGISTRATION_TOKEN"`` | Key in the existing Secret containing the OIDC client registration token |
+| studios.enabled | bool | `true` | Enable Studios feature. Refer to the subchart README for more details and the full list of configuration options |
+| studios.proxy.oidcClientRegistrationTokenSecretName | string | `"{{ printf \"%s-backend\" (include \"common.names.dependency.fullname\" (dict \"chartName\" \"platform\" \"chartValues\" .Values \"context\" .)) }}"` | studios needs to pass a client registration token to the platform backend so that it can register studios clients to the platform OIDC provider. If the platform oidc registration token is coming from a separate secret, you need to update it here too. `common.names.dependency.fullname` is used (rather than `common.names.fullname`) because this value is `tpl`-evaluated inside the studios subchart context where `.Chart.Name` is `studios`, not `platform`; passing `chartName: platform` explicitly reproduces the parent's fullname. Name of the existing Secret containing the OIDC client registration token to share with the Studios proxy. Evaluated as a template |
+| studios.proxy.oidcClientRegistrationTokenSecretKey | string | `"OIDC_CLIENT_REGISTRATION_TOKEN"` | Key in the existing Secret containing the OIDC client registration token |
 
 ### Subcharts: Pipeline Optimization
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| pipeline-optimization.enabled | bool | ``true`` | Enable pipeline optimization feature. Refer to the subchart README for more details and the full list of configuration options |
+| pipeline-optimization.enabled | bool | `true` | Enable pipeline optimization feature. Refer to the subchart README for more details and the full list of configuration options |
 
 ### Subcharts: MCP
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| mcp.enabled | bool | ``true`` | Enable the Seqera Model Context Protocol (MCP) service. Refer to the subchart README for more details and the full list of configuration options |
-| mcp.oidcToken.existingSecretName | string | ``"{{ printf \"%s-backend\" (include \"common.names.dependency.fullname\" (dict \"chartName\" \"platform\" \"chartValues\" .Values \"context\" .)) }}"`` | mcp needs to pass a client registration token to the platform backend so that it can register mcp clients to the platform OIDC provider. If the platform oidc registration token is coming from a separate secret, you need to update it here too. `common.names.dependency.fullname` is used (rather than `common.names.fullname`) because this value is `tpl`-evaluated inside the mcp subchart context where `.Chart.Name` is `mcp`, not `platform`; passing `chartName: platform` explicitly reproduces the parent's fullname. Name of the existing Secret containing the OIDC client registration token to share with MCP. Evaluated as a template |
-| mcp.oidcToken.existingSecretKey | string | ``"OIDC_CLIENT_REGISTRATION_TOKEN"`` | Key in the existing Secret containing the OIDC client registration token |
+| mcp.enabled | bool | `true` | Enable the Seqera Model Context Protocol (MCP) service. Refer to the subchart README for more details and the full list of configuration options |
+| mcp.oidcToken.existingSecretName | string | `"{{ printf \"%s-backend\" (include \"common.names.dependency.fullname\" (dict \"chartName\" \"platform\" \"chartValues\" .Values \"context\" .)) }}"` | mcp needs to pass a client registration token to the platform backend so that it can register mcp clients to the platform OIDC provider. If the platform oidc registration token is coming from a separate secret, you need to update it here too. `common.names.dependency.fullname` is used (rather than `common.names.fullname`) because this value is `tpl`-evaluated inside the mcp subchart context where `.Chart.Name` is `mcp`, not `platform`; passing `chartName: platform` explicitly reproduces the parent's fullname. Name of the existing Secret containing the OIDC client registration token to share with MCP. Evaluated as a template |
+| mcp.oidcToken.existingSecretKey | string | `"OIDC_CLIENT_REGISTRATION_TOKEN"` | Key in the existing Secret containing the OIDC client registration token |
 
 ### Subcharts: Agent Backend
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| agent-backend.enabled | bool | ``true`` | Enable agent backend feature used by seqera cli ai command. Refer to the subchart README for more details and the full list of configuration options |
+| agent-backend.enabled | bool | `true` | Enable agent backend feature used by seqera cli ai command. Refer to the subchart README for more details and the full list of configuration options |
 
 ### Subcharts: Portal Web
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| portal-web.enabled | bool | ``true`` | Enable portal web frontend. Refer to the subchart README for more details and the full list of configuration options |
+| portal-web.enabled | bool | `true` | Enable portal web frontend. Refer to the subchart README for more details and the full list of configuration options |
 
 ## Licensing
 

--- a/charts/platform/README.md.gotmpl
+++ b/charts/platform/README.md.gotmpl
@@ -95,7 +95,7 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 {{- range .SectionItems }}
-| {{ .Key }} | {{ .Type }} | {{ if .Default }}`{{ .Default }}`{{ else }}`{{ .AutoDefault }}`{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
+| {{ .Key }} | {{ .Type }} | {{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
 {{- end }}
 {{- end }}
 
@@ -106,7 +106,7 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 {{- range . }}
-| {{ .Key }} | {{ .Type }} | {{ if .Default }}`{{ .Default }}`{{ else }}`{{ .AutoDefault }}`{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
+| {{ .Key }} | {{ .Type }} | {{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
 {{- end }}
 {{- end }}
 

--- a/charts/platform/charts/agent-backend/README.md
+++ b/charts/platform/charts/agent-backend/README.md
@@ -95,310 +95,310 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| global.platformExternalDomain | string | ``"example.com"`` | Domain where Seqera Platform listens |
-| global.platformServiceAddress | string | ``""`` | Seqera Platform Service name: can be the internal Kubernetes hostname or an external ingress hostname. Evaluated as a template. Required when deploying this subchart standalone. When deploying as part of the parent `platform` umbrella chart, this value is inherited from the parent chart's `global` section |
-| global.platformServicePort | int | ``nil`` | Seqera Platform Service port. Required when deploying this subchart standalone. When deploying as part of the parent `platform` umbrella chart, this value is inherited from the parent chart's `global` section |
-| global.agentBackendDomain | string | ``"{{ printf \"ai-api.%s\" .Values.global.platformExternalDomain }}"`` | Domain where the Agent Backend service listens. Evaluated as a template |
-| global.mcpDomain | string | ``"{{ printf \"mcp.%s\" .Values.global.platformExternalDomain }}"`` | Domain where Seqera MCP listens. Evaluated as a template |
+| global.platformExternalDomain | string | `"example.com"` | Domain where Seqera Platform listens |
+| global.platformServiceAddress | string | `""` | Seqera Platform Service name: can be the internal Kubernetes hostname or an external ingress hostname. Evaluated as a template. Required when deploying this subchart standalone. When deploying as part of the parent `platform` umbrella chart, this value is inherited from the parent chart's `global` section |
+| global.platformServicePort | int | `nil` | Seqera Platform Service port. Required when deploying this subchart standalone. When deploying as part of the parent `platform` umbrella chart, this value is inherited from the parent chart's `global` section |
+| global.agentBackendDomain | string | `"{{ printf \"ai-api.%s\" .Values.global.platformExternalDomain }}"` | Domain where the Agent Backend service listens. Evaluated as a template |
+| global.mcpDomain | string | `"{{ printf \"mcp.%s\" .Values.global.platformExternalDomain }}"` | Domain where Seqera MCP listens. Evaluated as a template |
 
 ### Global: Ingress
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| global.ingress.enabled | bool | ``false`` | Enable Ingress for this chart. OR'd with the chart's local `ingress.enabled` so setting this once at the parent enables all subchart Ingresses. |
-| global.ingress.path | string | ``"/"`` | Default path applied to ingress rules when `ingress.path` is not set. AWS ALB users should override to `/*`. |
-| global.ingress.defaultPathType | string | ``"Prefix"`` | Default path type applied to ingress rules when `ingress.defaultPathType` is not set. `Prefix` works for nginx, traefik, AWS ALB, and most modern controllers. |
-| global.ingress.ingressClassName | string | ``""`` | Default ingress class name applied when `ingress.ingressClassName` is not set |
-| global.ingress.annotations | object | ``{}`` | Annotations merged into the Ingress. Local `ingress.annotations` wins on key collision. Evaluated as a template |
-| global.ingress.extraLabels | object | ``{}`` | Extra labels merged into the Ingress. Local `ingress.extraLabels` wins on key collision. Evaluated as a template |
-| global.ingress.tls | list | ``[]`` | TLS entries concatenated with the local `ingress.tls`. Evaluated as a template |
+| global.ingress.enabled | bool | `false` | Enable Ingress for this chart. OR'd with the chart's local `ingress.enabled` so setting this once at the parent enables all subchart Ingresses. |
+| global.ingress.path | string | `"/"` | Default path applied to ingress rules when `ingress.path` is not set. AWS ALB users should override to `/*`. |
+| global.ingress.defaultPathType | string | `"Prefix"` | Default path type applied to ingress rules when `ingress.defaultPathType` is not set. `Prefix` works for nginx, traefik, AWS ALB, and most modern controllers. |
+| global.ingress.ingressClassName | string | `""` | Default ingress class name applied when `ingress.ingressClassName` is not set |
+| global.ingress.annotations | object | `{}` | Annotations merged into the Ingress. Local `ingress.annotations` wins on key collision. Evaluated as a template |
+| global.ingress.extraLabels | object | `{}` | Extra labels merged into the Ingress. Local `ingress.extraLabels` wins on key collision. Evaluated as a template |
+| global.ingress.tls | list | `[]` | TLS entries concatenated with the local `ingress.tls`. Evaluated as a template |
 
 ### Global: Image Credentials
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| global.imageCredentials | list | ``[]`` | Optional credentials to log in and fetch images from a private registry. These credentials are shared with all the subcharts automatically |
-| global.imageCredentialsSecrets | list | ``[]`` | Optional list of existing Secrets containing image pull credentials to use for pulling images from private registries. These Secrets are shared with all the subcharts automatically |
+| global.imageCredentials | list | `[]` | Optional credentials to log in and fetch images from a private registry. These credentials are shared with all the subcharts automatically |
+| global.imageCredentialsSecrets | list | `[]` | Optional list of existing Secrets containing image pull credentials to use for pulling images from private registries. These Secrets are shared with all the subcharts automatically |
 
 ### Service Routing
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| inference.provider | string | ``""`` | Inference provider. One of: "bedrock", "anthropic". Required. |
-| embeddings.provider | string | ``""`` | Embeddings provider. One of: "bedrock". When empty, embeddings are disabled. |
-| sandbox.provider | string | ``""`` | Sandbox provider. One of: "bedrock". When empty, sandbox is disabled. |
+| inference.provider | string | `""` | Inference provider. One of: "bedrock", "anthropic". Required. |
+| embeddings.provider | string | `""` | Embeddings provider. One of: "bedrock". When empty, embeddings are disabled. |
+| sandbox.provider | string | `""` | Sandbox provider. One of: "bedrock". When empty, sandbox is disabled. |
 
 ### Bedrock: Default
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| bedrock.default.assumeRoleArn | string | ``""`` | Optional default IAM role ARN to assume before invoking the Bedrock APIs. |
-| bedrock.default.region | string | ``""`` | Default AWS region to use for all Bedrock services. |
+| bedrock.default.assumeRoleArn | string | `""` | Optional default IAM role ARN to assume before invoking the Bedrock APIs. |
+| bedrock.default.region | string | `""` | Default AWS region to use for all Bedrock services. |
 
 ### Bedrock: Inference
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| bedrock.inference.assumeRoleArn | string | ``""`` | Optional IAM role ARN to assume for Bedrock inference (overrides bedrock.default.assumeRoleArn). |
-| bedrock.inference.region | string | ``""`` | AWS region for Bedrock inference (overrides bedrock.default.region). |
-| bedrock.inference.anthropicModel | string | ``""`` | Anthropic inference profile ARN to use on Bedrock (e.g. a custom or cross-region/cross-account profile). |
+| bedrock.inference.assumeRoleArn | string | `""` | Optional IAM role ARN to assume for Bedrock inference (overrides bedrock.default.assumeRoleArn). |
+| bedrock.inference.region | string | `""` | AWS region for Bedrock inference (overrides bedrock.default.region). |
+| bedrock.inference.anthropicModel | string | `""` | Anthropic inference profile ARN to use on Bedrock (e.g. a custom or cross-region/cross-account profile). |
 
 ### Bedrock: Embeddings
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| bedrock.embeddings.assumeRoleArn | string | ``""`` | Optional IAM role ARN to assume for Bedrock embeddings (overrides bedrock.default.assumeRoleArn). |
-| bedrock.embeddings.region | string | ``""`` | AWS region for Bedrock embeddings (overrides bedrock.default.region). |
-| bedrock.embeddings.model | string | ``"amazon.titan-embed-text-v2:0"`` | Bedrock model ID used for embeddings. |
+| bedrock.embeddings.assumeRoleArn | string | `""` | Optional IAM role ARN to assume for Bedrock embeddings (overrides bedrock.default.assumeRoleArn). |
+| bedrock.embeddings.region | string | `""` | AWS region for Bedrock embeddings (overrides bedrock.default.region). |
+| bedrock.embeddings.model | string | `"amazon.titan-embed-text-v2:0"` | Bedrock model ID used for embeddings. |
 
 ### Bedrock: Sandbox
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| bedrock.sandbox.assumeRoleArn | string | ``""`` | Optional IAM role ARN to assume before invoking AgentCore (overrides bedrock.default.assumeRoleArn). |
-| bedrock.sandbox.region | string | ``""`` | AWS region for AgentCore. |
-| bedrock.sandbox.runtimeArn | string | ``""`` | AWS Bedrock AgentCore runtime ARN for sandbox sessions. |
+| bedrock.sandbox.assumeRoleArn | string | `""` | Optional IAM role ARN to assume before invoking AgentCore (overrides bedrock.default.assumeRoleArn). |
+| bedrock.sandbox.region | string | `""` | AWS region for AgentCore. |
+| bedrock.sandbox.runtimeArn | string | `""` | AWS Bedrock AgentCore runtime ARN for sandbox sessions. |
 
 ### Anthropic
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| anthropic.apiKey | string | ``""`` | Anthropic API key. Set this OR existingSecretName, not both. |
-| anthropic.existingSecretName | string | ``""`` | Name of an existing Secret containing the Anthropic API key. Note: the Secret must already exist in the same namespace at the time of deployment |
-| anthropic.existingSecretKey | string | ``"ANTHROPIC_API_KEY"`` | Key in the existing Secret containing the Anthropic API key |
+| anthropic.apiKey | string | `""` | Anthropic API key. Set this OR existingSecretName, not both. |
+| anthropic.existingSecretName | string | `""` | Name of an existing Secret containing the Anthropic API key. Note: the Secret must already exist in the same namespace at the time of deployment |
+| anthropic.existingSecretKey | string | `"ANTHROPIC_API_KEY"` | Key in the existing Secret containing the Anthropic API key |
 
 ### Database
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| database.host | string | ``""`` | MySQL database hostname |
-| database.port | int | ``3306`` | MySQL database port |
-| database.name | string | ``""`` | MySQL database name |
-| database.username | string | ``""`` | MySQL database username |
-| database.password | string | ``""`` | MySQL database password |
-| database.existingSecretName | string | ``""`` | Name of an existing Secret containing credentials for the MySQL database, as an alternative to the password field. Note: the Secret must already exist in the  same namespace at the time of deployment |
-| database.existingSecretKey | string | ``"AGENT_BACKEND_DB_PASSWORD"`` | Key in the existing Secret containing the password for the MySQL database |
-| database.enableTls | bool | ``false`` | Enable TLS for the MySQL database connection |
-| database.tlsCaVerify | bool | ``true`` | Verify the CA certificate when connecting via TLS (set to false to skip verification, insecure - for development/testing only) |
-| database.sslCa | string | ``""`` | Path to a CA certificate file for server certificate verification |
+| database.host | string | `""` | MySQL database hostname |
+| database.port | int | `3306` | MySQL database port |
+| database.name | string | `""` | MySQL database name |
+| database.username | string | `""` | MySQL database username |
+| database.password | string | `""` | MySQL database password |
+| database.existingSecretName | string | `""` | Name of an existing Secret containing credentials for the MySQL database, as an alternative to the password field. Note: the Secret must already exist in the  same namespace at the time of deployment |
+| database.existingSecretKey | string | `"AGENT_BACKEND_DB_PASSWORD"` | Key in the existing Secret containing the password for the MySQL database |
+| database.enableTls | bool | `false` | Enable TLS for the MySQL database connection |
+| database.tlsCaVerify | bool | `true` | Verify the CA certificate when connecting via TLS (set to false to skip verification, insecure - for development/testing only) |
+| database.sslCa | string | `""` | Path to a CA certificate file for server certificate verification |
 
 ### Redis
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| redis.host | string | ``""`` | Redis hostname |
-| redis.port | int | ``6379`` | Redis port |
-| redis.database | int | ``0`` | Redis database index |
-| redis.enableTls | bool | ``false`` | Enable TLS when connecting to Redis |
-| redis.password | string | ``""`` | Redis password |
-| redis.existingSecretName | string | ``""`` | Name of an existing Secret containing the Redis password, as an alternative to the password field. Note: the Secret must already exist in the same namespace at the time of deployment |
-| redis.existingSecretKey | string | ``"AGENT_BACKEND_REDIS_PASSWORD"`` | Key in the existing Secret containing the Redis password |
+| redis.host | string | `""` | Redis hostname |
+| redis.port | int | `6379` | Redis port |
+| redis.database | int | `0` | Redis database index |
+| redis.enableTls | bool | `false` | Enable TLS when connecting to Redis |
+| redis.password | string | `""` | Redis password |
+| redis.existingSecretName | string | `""` | Name of an existing Secret containing the Redis password, as an alternative to the password field. Note: the Secret must already exist in the same namespace at the time of deployment |
+| redis.existingSecretKey | string | `"AGENT_BACKEND_REDIS_PASSWORD"` | Key in the existing Secret containing the Redis password |
 
 ### Token Encryption Key
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| tokenEncryptionKey | string | ``""`` | Token encryption key (must be a valid Fernet key). Define the value as a String or a Secret, not both at the same time. If not defined, a random Fernet key will be auto-generated at each deployment. WARNING: Always explicitly set this value or use an existing secret when using Kustomize. Auto-generated random values are incompatible with Kustomize. When upgrading releases via Kustomize, Helm cannot query the cluster to check if a secret already exists, causing it to regenerate a new random value on each upgrade |
-| tokenEncryptionKeyExistingSecretName | string | ``""`` | Name of an existing Secret containing the token encryption key. Note: the Secret must already exist in the same namespace at the time of deployment |
-| tokenEncryptionKeyExistingSecretKey | string | ``"AGENT_BACKEND_TOKEN_ENCRYPTION_KEY"`` | Key in the existing Secret containing the token encryption key |
+| tokenEncryptionKey | string | `""` | Token encryption key (must be a valid Fernet key). Define the value as a String or a Secret, not both at the same time. If not defined, a random Fernet key will be auto-generated at each deployment. WARNING: Always explicitly set this value or use an existing secret when using Kustomize. Auto-generated random values are incompatible with Kustomize. When upgrading releases via Kustomize, Helm cannot query the cluster to check if a secret already exists, causing it to regenerate a new random value on each upgrade |
+| tokenEncryptionKeyExistingSecretName | string | `""` | Name of an existing Secret containing the token encryption key. Note: the Secret must already exist in the same namespace at the time of deployment |
+| tokenEncryptionKeyExistingSecretKey | string | `"AGENT_BACKEND_TOKEN_ENCRYPTION_KEY"` | Key in the existing Secret containing the token encryption key |
 
 ### Image
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| image.registry | string | ``""`` | Container image registry |
-| image.repository | string | ``"ai/agent-backend/backend"`` | Container image repository |
-| image.tag | string | ``"{{ .chart.AppVersion }}"`` | Container image tag |
-| image.digest | string | ``""`` | Container image digest in the format `sha256:1234abcdef` |
-| image.pullPolicy | string | ``"IfNotPresent"`` | imagePullPolicy for the container Ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images |
-| image.pullSecrets | list | ``[]`` | List of imagePullSecrets Secrets must be created in the same namespace, for example using the .extraDeploy array Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ |
+| image.registry | string | `""` | Container image registry |
+| image.repository | string | `"ai/agent-backend/backend"` | Container image repository |
+| image.tag | string | `"{{ .chart.AppVersion }}"` | Container image tag |
+| image.digest | string | `""` | Container image digest in the format `sha256:1234abcdef` |
+| image.pullPolicy | string | `"IfNotPresent"` | imagePullPolicy for the container Ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images |
+| image.pullSecrets | list | `[]` | List of imagePullSecrets Secrets must be created in the same namespace, for example using the .extraDeploy array Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ |
 
 ### Deployment
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| logLevel | string | ``"INFO"`` | Log level (one of CRITICAL, ERROR, WARNING, INFO, DEBUG) |
-| initContainers | list | ``[]`` | Additional init containers for the pod. Evaluated as a template |
-| command | list | ``[]`` | Override default container command (useful when using custom images) |
-| args | list | ``[]`` | Override default container args (useful when using custom images) |
-| podLabels | object | ``{}`` | Additional labels for the pod. Evaluated as a template |
-| podAnnotations | object | ``{}`` | Additional annotations for the pod. Evaluated as a template |
-| extraOptionsSpec | object | ``{}`` | Extra options to place under .spec (e.g. replicas, strategy, revisionHistoryLimit, etc). Evaluated as a template |
-| extraOptionsTemplateSpec | object | ``{}`` | Extra options to place under .spec.template.spec (e.g. nodeSelector, affinity, restartPolicy, etc). Evaluated as a template |
-| extraEnvVars | list | ``[]`` | Extra environment variables |
-| extraEnvVarsCMs | list | ``[]`` | List of ConfigMaps containing extra env vars |
-| extraEnvVarsSecrets | list | ``[]`` | List of Secrets containing extra env vars |
-| extraVolumes | list | ``[]`` | List of volumes to add to the deployment (evaluated as template). Requires setting `extraVolumeMounts` |
-| extraVolumeMounts | list | ``[]`` | List of volume mounts to add to the container (evaluated as template). Normally used with `extraVolumes` |
-| resources | object | ``{}`` | Container requests and limits for different resources like CPU or memory |
+| logLevel | string | `"INFO"` | Log level (one of CRITICAL, ERROR, WARNING, INFO, DEBUG) |
+| initContainers | list | `[]` | Additional init containers for the pod. Evaluated as a template |
+| command | list | `[]` | Override default container command (useful when using custom images) |
+| args | list | `[]` | Override default container args (useful when using custom images) |
+| podLabels | object | `{}` | Additional labels for the pod. Evaluated as a template |
+| podAnnotations | object | `{}` | Additional annotations for the pod. Evaluated as a template |
+| extraOptionsSpec | object | `{}` | Extra options to place under .spec (e.g. replicas, strategy, revisionHistoryLimit, etc). Evaluated as a template |
+| extraOptionsTemplateSpec | object | `{}` | Extra options to place under .spec.template.spec (e.g. nodeSelector, affinity, restartPolicy, etc). Evaluated as a template |
+| extraEnvVars | list | `[]` | Extra environment variables |
+| extraEnvVarsCMs | list | `[]` | List of ConfigMaps containing extra env vars |
+| extraEnvVarsSecrets | list | `[]` | List of Secrets containing extra env vars |
+| extraVolumes | list | `[]` | List of volumes to add to the deployment (evaluated as template). Requires setting `extraVolumeMounts` |
+| extraVolumeMounts | list | `[]` | List of volume mounts to add to the container (evaluated as template). Normally used with `extraVolumes` |
+| resources | object | `{}` | Container requests and limits for different resources like CPU or memory |
 
 ### Service
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| service | object | ``{"extraOptions":{},"extraServices":[],"http":{"name":"http","nodePort":null,"port":80,"targetPort":8002},"type":"ClusterIP"}`` | Service configuration |
-| service.type | string | ``"ClusterIP"`` | Service type. Note: ingresses using AWS ALB require the service to be NodePort |
-| service.http.name | string | ``"http"`` | Service name to use |
-| service.http.port | int | ``80`` | Service port |
-| service.http.targetPort | int | ``8002`` | Port on the pod/container that the Service forwards traffic to (can be a number or named port, distinct from the Service's external port) |
-| service.http.nodePort | string | ``nil`` | Service node port, only used when service.type is Nodeport or LoadBalancer Choose port between 30000-32767, unless the cluster was configured differently than default |
-| service.extraServices | list | ``[]`` | Other services that should live in the Service object https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service |
-| service.extraOptions | object | ``{}`` | Extra Service options to place under .spec (for example, clusterIP, loadBalancerIP, externalTrafficPolicy, externalIPs). Evaluated as a template |
+| service | object | `{"extraOptions":{},"extraServices":[],"http":{"name":"http","nodePort":null,"port":80,"targetPort":8002},"type":"ClusterIP"}` | Service configuration |
+| service.type | string | `"ClusterIP"` | Service type. Note: ingresses using AWS ALB require the service to be NodePort |
+| service.http.name | string | `"http"` | Service name to use |
+| service.http.port | int | `80` | Service port |
+| service.http.targetPort | int | `8002` | Port on the pod/container that the Service forwards traffic to (can be a number or named port, distinct from the Service's external port) |
+| service.http.nodePort | string | `nil` | Service node port, only used when service.type is Nodeport or LoadBalancer Choose port between 30000-32767, unless the cluster was configured differently than default |
+| service.extraServices | list | `[]` | Other services that should live in the Service object https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service |
+| service.extraOptions | object | `{}` | Extra Service options to place under .spec (for example, clusterIP, loadBalancerIP, externalTrafficPolicy, externalIPs). Evaluated as a template |
 
 ### DB Migration Init Container
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| dbMigrationInitContainer.command | list | ``["./init.sh"]`` | Command to run in the init container performing DB migrations |
-| dbMigrationInitContainer.resources | object | ``{"limits":{"memory":"100Mi"},"requests":{"cpu":"0.5","memory":"50Mi"}}`` | Container requests and limits for different resources like CPU or memory |
+| dbMigrationInitContainer.command | list | `["./init.sh"]` | Command to run in the init container performing DB migrations |
+| dbMigrationInitContainer.resources | object | `{"limits":{"memory":"100Mi"},"requests":{"cpu":"0.5","memory":"50Mi"}}` | Container requests and limits for different resources like CPU or memory |
 
 ### DB Migration Init Container: Security Context
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| dbMigrationInitContainer.securityContext.runAsUser | int | ``101`` | UID the container processes run as (overrides container image default) |
-| dbMigrationInitContainer.securityContext.runAsNonRoot | bool | ``true`` | Require the container to run as a non-root UID (prevents starting if UID 0) |
-| dbMigrationInitContainer.securityContext.readOnlyRootFilesystem | bool | ``true`` | Mount the container root filesystem read-only to prevent in-place writes or tampering |
-| dbMigrationInitContainer.securityContext.capabilities | object | ``{"drop":["ALL"]}`` | Fine-grained Linux kernel privileges to add or drop for the container |
+| dbMigrationInitContainer.securityContext.runAsUser | int | `101` | UID the container processes run as (overrides container image default) |
+| dbMigrationInitContainer.securityContext.runAsNonRoot | bool | `true` | Require the container to run as a non-root UID (prevents starting if UID 0) |
+| dbMigrationInitContainer.securityContext.readOnlyRootFilesystem | bool | `true` | Mount the container root filesystem read-only to prevent in-place writes or tampering |
+| dbMigrationInitContainer.securityContext.capabilities | object | `{"drop":["ALL"]}` | Fine-grained Linux kernel privileges to add or drop for the container |
 
 ### Pod Security Context
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| podSecurityContext.enabled | bool | ``true`` | Enable pod Security Context |
-| podSecurityContext.fsGroup | int | ``101`` | Sets the GID that Kubernetes will apply to mounted volumes and created files so processes in the pod can share group-owned access |
+| podSecurityContext.enabled | bool | `true` | Enable pod Security Context |
+| podSecurityContext.fsGroup | int | `101` | Sets the GID that Kubernetes will apply to mounted volumes and created files so processes in the pod can share group-owned access |
 
 ### Container Security Context
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| containerSecurityContext.enabled | bool | ``true`` | Enable container Security Context |
-| containerSecurityContext.runAsUser | int | ``101`` | UID the container processes run as (overrides container image default) |
-| containerSecurityContext.runAsNonRoot | bool | ``true`` | Boolean that requires the container to run as a non-root UID (prevents starting if UID 0) |
-| containerSecurityContext.readOnlyRootFilesystem | bool | ``true`` | Mounts the container root filesystem read-only to prevent in-place writes or tampering |
-| containerSecurityContext.capabilities | object | ``{"drop":["ALL"]}`` | Fine-grained Linux kernel privileges to add or drop for the container |
+| containerSecurityContext.enabled | bool | `true` | Enable container Security Context |
+| containerSecurityContext.runAsUser | int | `101` | UID the container processes run as (overrides container image default) |
+| containerSecurityContext.runAsNonRoot | bool | `true` | Boolean that requires the container to run as a non-root UID (prevents starting if UID 0) |
+| containerSecurityContext.readOnlyRootFilesystem | bool | `true` | Mounts the container root filesystem read-only to prevent in-place writes or tampering |
+| containerSecurityContext.capabilities | object | `{"drop":["ALL"]}` | Fine-grained Linux kernel privileges to add or drop for the container |
 
 ### Init Container Dependencies
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| initContainerDependencies.enabled | bool | ``true`` | Enable init containers that coordinate startup dependencies |
+| initContainerDependencies.enabled | bool | `true` | Enable init containers that coordinate startup dependencies |
 
 ### Init Container Dependencies: Wait For Redis
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| initContainerDependencies.waitForRedis.enabled | bool | ``true`` | Enable wait for Redis init container before starting the main container |
-| initContainerDependencies.waitForRedis.image.registry | string | ``""`` | Override default wait for Redis init container image |
-| initContainerDependencies.waitForRedis.image.repository | string | ``"redis"`` | Init container image repository |
-| initContainerDependencies.waitForRedis.image.tag | string | ``"7-alpine"`` | Init container image tag |
-| initContainerDependencies.waitForRedis.image.digest | string | ``""`` | Init container image digest in the format `sha256:1234abcdef` |
-| initContainerDependencies.waitForRedis.image.pullPolicy | string | ``"IfNotPresent"`` | imagePullPolicy for the init container |
-| initContainerDependencies.waitForRedis.securityContext.runAsUser | int | ``101`` | UID the container processes run as (overrides container image default) |
-| initContainerDependencies.waitForRedis.securityContext.runAsNonRoot | bool | ``true`` | Require the container to run as a non-root UID (prevents starting if UID is 0) |
-| initContainerDependencies.waitForRedis.securityContext.readOnlyRootFilesystem | bool | ``true`` | Mount the container root filesystem read-only to prevent in-place writes or tampering |
-| initContainerDependencies.waitForRedis.securityContext.capabilities | object | ``{"drop":["ALL"]}`` | Fine-grained Linux kernel privileges to add or drop for the container |
-| initContainerDependencies.waitForRedis.resources | object | ``{"limits":{"memory":"100Mi"},"requests":{"cpu":"0.5","memory":"50Mi"}}`` | Container requests and limits for different resources like CPU or memory |
-| initContainerDependencies.waitForRedis.extraEnvVars | list | ``[]`` | Additional environment variables for the init container |
-| initContainerDependencies.waitForRedis.extraVolumeMounts | list | ``[]`` | Additional volume mounts for the init container (e.g. to mount a CA certificate) |
+| initContainerDependencies.waitForRedis.enabled | bool | `true` | Enable wait for Redis init container before starting the main container |
+| initContainerDependencies.waitForRedis.image.registry | string | `""` | Override default wait for Redis init container image |
+| initContainerDependencies.waitForRedis.image.repository | string | `"redis"` | Init container image repository |
+| initContainerDependencies.waitForRedis.image.tag | string | `"7-alpine"` | Init container image tag |
+| initContainerDependencies.waitForRedis.image.digest | string | `""` | Init container image digest in the format `sha256:1234abcdef` |
+| initContainerDependencies.waitForRedis.image.pullPolicy | string | `"IfNotPresent"` | imagePullPolicy for the init container |
+| initContainerDependencies.waitForRedis.securityContext.runAsUser | int | `101` | UID the container processes run as (overrides container image default) |
+| initContainerDependencies.waitForRedis.securityContext.runAsNonRoot | bool | `true` | Require the container to run as a non-root UID (prevents starting if UID is 0) |
+| initContainerDependencies.waitForRedis.securityContext.readOnlyRootFilesystem | bool | `true` | Mount the container root filesystem read-only to prevent in-place writes or tampering |
+| initContainerDependencies.waitForRedis.securityContext.capabilities | object | `{"drop":["ALL"]}` | Fine-grained Linux kernel privileges to add or drop for the container |
+| initContainerDependencies.waitForRedis.resources | object | `{"limits":{"memory":"100Mi"},"requests":{"cpu":"0.5","memory":"50Mi"}}` | Container requests and limits for different resources like CPU or memory |
+| initContainerDependencies.waitForRedis.extraEnvVars | list | `[]` | Additional environment variables for the init container |
+| initContainerDependencies.waitForRedis.extraVolumeMounts | list | `[]` | Additional volume mounts for the init container (e.g. to mount a CA certificate) |
 
 ### Init Container Dependencies: Wait For MySQL
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| initContainerDependencies.waitForMySQL.enabled | bool | ``true`` | Enable wait for MySQL init container before starting the main container |
-| initContainerDependencies.waitForMySQL.image.registry | string | ``""`` | Override default wait for MySQL init container image |
-| initContainerDependencies.waitForMySQL.image.repository | string | ``"mysql"`` | Init container image repository |
-| initContainerDependencies.waitForMySQL.image.tag | string | ``"9"`` | Init container image tag |
-| initContainerDependencies.waitForMySQL.image.digest | string | ``""`` | Init container image digest in the format `sha256:1234abcdef` |
-| initContainerDependencies.waitForMySQL.image.pullPolicy | string | ``"IfNotPresent"`` | imagePullPolicy for the init container |
-| initContainerDependencies.waitForMySQL.securityContext.runAsUser | int | ``101`` | UID the container processes run as (overrides container image default) |
-| initContainerDependencies.waitForMySQL.securityContext.runAsNonRoot | bool | ``true`` | Require the container to run as a non-root UID (prevents starting if UID is 0) |
-| initContainerDependencies.waitForMySQL.securityContext.readOnlyRootFilesystem | bool | ``true`` | Mount the container root filesystem read-only to prevent in-place writes or tampering |
-| initContainerDependencies.waitForMySQL.securityContext.capabilities | object | ``{"drop":["ALL"]}`` | Fine-grained Linux kernel privileges to add or drop for the container |
-| initContainerDependencies.waitForMySQL.resources | object | ``{"limits":{"memory":"100Mi"},"requests":{"cpu":"0.5","memory":"50Mi"}}`` | Container requests and limits for different resources like CPU or memory |
-| initContainerDependencies.waitForMySQL.extraEnvVars | list | ``[]`` | Additional environment variables for the init container. The special variable `MYSQL_EXTRA_ARGS` is appended verbatim to the `mysql` readiness check command, and can be used to pass TLS flags when connecting to managed MySQL services such as AWS RDS or Azure Database for MySQL that require certificate verification. Pair with `extraVolumeMounts` to mount the CA certificate into the container. Example (TLS with CA certificate mounted from a volume): extraEnvVars:   - name: MYSQL_EXTRA_ARGS     value: "--ssl-ca=/certs/ca.pem --ssl-mode=VERIFY_IDENTITY" |
-| initContainerDependencies.waitForMySQL.extraVolumeMounts | list | ``[]`` | Additional volume mounts for the init container. Use this to mount CA certificates (e.g. from a Secret or ConfigMap populated by an extraInitContainer) so that `MYSQL_EXTRA_ARGS` can reference them. |
+| initContainerDependencies.waitForMySQL.enabled | bool | `true` | Enable wait for MySQL init container before starting the main container |
+| initContainerDependencies.waitForMySQL.image.registry | string | `""` | Override default wait for MySQL init container image |
+| initContainerDependencies.waitForMySQL.image.repository | string | `"mysql"` | Init container image repository |
+| initContainerDependencies.waitForMySQL.image.tag | string | `"9"` | Init container image tag |
+| initContainerDependencies.waitForMySQL.image.digest | string | `""` | Init container image digest in the format `sha256:1234abcdef` |
+| initContainerDependencies.waitForMySQL.image.pullPolicy | string | `"IfNotPresent"` | imagePullPolicy for the init container |
+| initContainerDependencies.waitForMySQL.securityContext.runAsUser | int | `101` | UID the container processes run as (overrides container image default) |
+| initContainerDependencies.waitForMySQL.securityContext.runAsNonRoot | bool | `true` | Require the container to run as a non-root UID (prevents starting if UID is 0) |
+| initContainerDependencies.waitForMySQL.securityContext.readOnlyRootFilesystem | bool | `true` | Mount the container root filesystem read-only to prevent in-place writes or tampering |
+| initContainerDependencies.waitForMySQL.securityContext.capabilities | object | `{"drop":["ALL"]}` | Fine-grained Linux kernel privileges to add or drop for the container |
+| initContainerDependencies.waitForMySQL.resources | object | `{"limits":{"memory":"100Mi"},"requests":{"cpu":"0.5","memory":"50Mi"}}` | Container requests and limits for different resources like CPU or memory |
+| initContainerDependencies.waitForMySQL.extraEnvVars | list | `[]` | Additional environment variables for the init container. The special variable `MYSQL_EXTRA_ARGS` is appended verbatim to the `mysql` readiness check command, and can be used to pass TLS flags when connecting to managed MySQL services such as AWS RDS or Azure Database for MySQL that require certificate verification. Pair with `extraVolumeMounts` to mount the CA certificate into the container. Example (TLS with CA certificate mounted from a volume): extraEnvVars:   - name: MYSQL_EXTRA_ARGS     value: "--ssl-ca=/certs/ca.pem --ssl-mode=VERIFY_IDENTITY" |
+| initContainerDependencies.waitForMySQL.extraVolumeMounts | list | `[]` | Additional volume mounts for the init container. Use this to mount CA certificates (e.g. from a Secret or ConfigMap populated by an extraInitContainer) so that `MYSQL_EXTRA_ARGS` can reference them. |
 
 ### Startup Probe
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| startupProbe.enabled | bool | ``false`` | Enable startup probe |
-| startupProbe.httpGet.path | string | ``"/health"`` | HTTP GET path for startup probe |
-| startupProbe.httpGet.port | string | ``"{{ .Values.service.http.targetPort }}"`` | HTTP GET port for startup probe. Evaluated as a template |
-| startupProbe.initialDelaySeconds | int | ``5`` | Longer initial wait to accommodate slow-starting apps |
-| startupProbe.periodSeconds | int | ``10`` | Often set longer to avoid frequent checks while starting |
-| startupProbe.timeoutSeconds | int | ``3`` | Can be longer to allow slow initialization responses |
-| startupProbe.failureThreshold | int | ``5`` | Consecutive failures during startup before killing the container (instead of immediate restarts) |
-| startupProbe.successThreshold | int | ``1`` | Number of consecutive successes required to consider startup complete and enable liveness/readiness |
+| startupProbe.enabled | bool | `false` | Enable startup probe |
+| startupProbe.httpGet.path | string | `"/health"` | HTTP GET path for startup probe |
+| startupProbe.httpGet.port | string | `"{{ .Values.service.http.targetPort }}"` | HTTP GET port for startup probe. Evaluated as a template |
+| startupProbe.initialDelaySeconds | int | `5` | Longer initial wait to accommodate slow-starting apps |
+| startupProbe.periodSeconds | int | `10` | Often set longer to avoid frequent checks while starting |
+| startupProbe.timeoutSeconds | int | `3` | Can be longer to allow slow initialization responses |
+| startupProbe.failureThreshold | int | `5` | Consecutive failures during startup before killing the container (instead of immediate restarts) |
+| startupProbe.successThreshold | int | `1` | Number of consecutive successes required to consider startup complete and enable liveness/readiness |
 
 ### Readiness Probe
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| readinessProbe.enabled | bool | ``true`` | Enable readiness probe |
-| readinessProbe.httpGet.path | string | ``"/health"`` | HTTP GET path for readiness probe |
-| readinessProbe.httpGet.port | string | ``"{{ .Values.service.http.targetPort }}"`` | HTTP GET port for readiness probe. Evaluated as a template |
-| readinessProbe.initialDelaySeconds | int | ``5`` | Delay before first check (normal start timing) |
-| readinessProbe.periodSeconds | int | ``5`` | Regular check interval during normal operation |
-| readinessProbe.timeoutSeconds | int | ``3`` | Short timeout to detect unresponsive containers for readiness |
-| readinessProbe.failureThreshold | int | ``5`` | Consecutive failures before marking the container Unready (no restart) |
-| readinessProbe.successThreshold | int | ``1`` | Number of consecutive successes required to mark the container Ready after failures |
+| readinessProbe.enabled | bool | `true` | Enable readiness probe |
+| readinessProbe.httpGet.path | string | `"/health"` | HTTP GET path for readiness probe |
+| readinessProbe.httpGet.port | string | `"{{ .Values.service.http.targetPort }}"` | HTTP GET port for readiness probe. Evaluated as a template |
+| readinessProbe.initialDelaySeconds | int | `5` | Delay before first check (normal start timing) |
+| readinessProbe.periodSeconds | int | `5` | Regular check interval during normal operation |
+| readinessProbe.timeoutSeconds | int | `3` | Short timeout to detect unresponsive containers for readiness |
+| readinessProbe.failureThreshold | int | `5` | Consecutive failures before marking the container Unready (no restart) |
+| readinessProbe.successThreshold | int | `1` | Number of consecutive successes required to mark the container Ready after failures |
 
 ### Liveness Probe
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| livenessProbe.enabled | bool | ``true`` | Enable liveness probe |
-| livenessProbe.httpGet.path | string | ``"/health"`` | HTTP GET path for liveness probe |
-| livenessProbe.httpGet.port | string | ``"{{ .Values.service.http.targetPort }}"`` | HTTP GET port for liveness probe. Evaluated as a template |
-| livenessProbe.initialDelaySeconds | int | ``5`` | Delay before first check (normal start timing) |
-| livenessProbe.periodSeconds | int | ``10`` | Regular check interval during normal operation |
-| livenessProbe.timeoutSeconds | int | ``3`` | Short timeout to detect hung containers quickly |
-| livenessProbe.failureThreshold | int | ``10`` | Consecutive failures before restarting the container |
-| livenessProbe.successThreshold | int | ``1`` | Typically 1 (usually ignored) |
+| livenessProbe.enabled | bool | `true` | Enable liveness probe |
+| livenessProbe.httpGet.path | string | `"/health"` | HTTP GET path for liveness probe |
+| livenessProbe.httpGet.port | string | `"{{ .Values.service.http.targetPort }}"` | HTTP GET port for liveness probe. Evaluated as a template |
+| livenessProbe.initialDelaySeconds | int | `5` | Delay before first check (normal start timing) |
+| livenessProbe.periodSeconds | int | `10` | Regular check interval during normal operation |
+| livenessProbe.timeoutSeconds | int | `3` | Short timeout to detect hung containers quickly |
+| livenessProbe.failureThreshold | int | `10` | Consecutive failures before restarting the container |
+| livenessProbe.successThreshold | int | `1` | Typically 1 (usually ignored) |
 
 ### Service Account
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| serviceAccount | object | ``{"annotations":{},"automountServiceAccountToken":true,"imagePullSecretNames":[],"name":""}`` | Service account configuration |
-| serviceAccount.name | string | ``""`` | Service account name |
-| serviceAccount.annotations | object | ``{}`` | Service account annotations |
-| serviceAccount.imagePullSecretNames | list | ``[]`` | Names of Secrets containing credentials to pull images from registries |
-| serviceAccount.automountServiceAccountToken | bool | ``true`` | Automatically mount service account token |
+| serviceAccount | object | `{"annotations":{},"automountServiceAccountToken":true,"imagePullSecretNames":[],"name":""}` | Service account configuration |
+| serviceAccount.name | string | `""` | Service account name |
+| serviceAccount.annotations | object | `{}` | Service account annotations |
+| serviceAccount.imagePullSecretNames | list | `[]` | Names of Secrets containing credentials to pull images from registries |
+| serviceAccount.automountServiceAccountToken | bool | `true` | Automatically mount service account token |
 
 ### Ingress
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| ingress.enabled | bool | ``false`` | Enable ingress for Agent Backend |
-| ingress.path | string | ``""`` | Path for the main ingress rule. When empty, falls back to `global.ingress.path` |
-| ingress.defaultPathType | string | ``""`` | Default path type for the Ingress. When empty, falls back to `global.ingress.defaultPathType` |
-| ingress.defaultBackend | object | ``{}`` | Configure the default service for the ingress (evaluated as template) Important: make sure only one defaultBackend is defined across the k8s cluster: if the ingress doesn't reconcile successfully, 'describe ingress <name>' will report problems |
-| ingress.extraHosts | list | ``[]`` | Additional hosts you want to include. Evaluated as a template |
-| ingress.annotations | object | ``{}`` | Ingress annotations specific to your load balancer. Evaluated as a template |
-| ingress.extraLabels | object | ``{}`` | Additional labels for the ingress object. Evaluated as a template |
-| ingress.ingressClassName | string | ``""`` | Name of the ingress class (replaces the deprecated annotation `kubernetes.io/ingress.class`). When empty, falls back to `global.ingress.ingressClassName` |
-| ingress.tls | list | ``[]`` | TLS configuration. Evaluated as a template |
+| ingress.enabled | bool | `false` | Enable ingress for Agent Backend |
+| ingress.path | string | `""` | Path for the main ingress rule. When empty, falls back to `global.ingress.path` |
+| ingress.defaultPathType | string | `""` | Default path type for the Ingress. When empty, falls back to `global.ingress.defaultPathType` |
+| ingress.defaultBackend | object | `{}` | Configure the default service for the ingress (evaluated as template) Important: make sure only one defaultBackend is defined across the k8s cluster: if the ingress doesn't reconcile successfully, 'describe ingress <name>' will report problems |
+| ingress.extraHosts | list | `[]` | Additional hosts you want to include. Evaluated as a template |
+| ingress.annotations | object | `{}` | Ingress annotations specific to your load balancer. Evaluated as a template |
+| ingress.extraLabels | object | `{}` | Additional labels for the ingress object. Evaluated as a template |
+| ingress.ingressClassName | string | `""` | Name of the ingress class (replaces the deprecated annotation `kubernetes.io/ingress.class`). When empty, falls back to `global.ingress.ingressClassName` |
+| ingress.tls | list | `[]` | TLS configuration. Evaluated as a template |
 
 ### Extra Deploy
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| extraDeploy | list | ``[]`` | Array of extra objects to deploy with the release |
+| extraDeploy | list | `[]` | Array of extra objects to deploy with the release |
 
 ### Common Metadata
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| commonAnnotations | object | ``{}`` | Annotations to add to all deployed objects |
-| commonLabels | object | ``{}`` | Labels to add to all deployed objects |
-| secretLabels | object | ``{}`` | Additional labels for the Secret objects. Evaluated as a template |
-| secretAnnotations | object | ``{}`` | Additional annotations for the Secret objects. Evaluated as a template |
-| configMapLabels | object | ``{}`` | Additional labels for the ConfigMap objects. Evaluated as a template |
-| configMapAnnotations | object | ``{}`` | Additional annotations for the ConfigMap objects. Evaluated as a template |
+| commonAnnotations | object | `{}` | Annotations to add to all deployed objects |
+| commonLabels | object | `{}` | Labels to add to all deployed objects |
+| secretLabels | object | `{}` | Additional labels for the Secret objects. Evaluated as a template |
+| secretAnnotations | object | `{}` | Additional annotations for the Secret objects. Evaluated as a template |
+| configMapLabels | object | `{}` | Additional labels for the ConfigMap objects. Evaluated as a template |
+| configMapAnnotations | object | `{}` | Additional annotations for the ConfigMap objects. Evaluated as a template |
 
 ## Licensing
 

--- a/charts/platform/charts/agent-backend/README.md.gotmpl
+++ b/charts/platform/charts/agent-backend/README.md.gotmpl
@@ -92,7 +92,7 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 {{- range .SectionItems }}
-| {{ .Key }} | {{ .Type }} | {{ if .Default }}`{{ .Default }}`{{ else }}`{{ .AutoDefault }}`{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
+| {{ .Key }} | {{ .Type }} | {{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
 {{- end }}
 {{- end }}
 
@@ -103,7 +103,7 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 {{- range . }}
-| {{ .Key }} | {{ .Type }} | {{ if .Default }}`{{ .Default }}`{{ else }}`{{ .AutoDefault }}`{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
+| {{ .Key }} | {{ .Type }} | {{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
 {{- end }}
 {{- end }}
 

--- a/charts/platform/charts/mcp/README.md
+++ b/charts/platform/charts/mcp/README.md
@@ -89,232 +89,232 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| global.platformExternalDomain | string | ``"example.com"`` | Domain where Seqera Platform listens |
-| global.platformServiceAddress | string | ``""`` | Seqera Platform Service name: can be the internal Kubernetes hostname or an external ingress hostname. Evaluated as a template. Required when deploying this subchart standalone. When deploying as part of the parent `platform` umbrella chart, this value is inherited from the parent chart's `global` section |
-| global.platformServicePort | int | ``nil`` | Seqera Platform Service port. Required when deploying this subchart standalone. When deploying as part of the parent `platform` umbrella chart, this value is inherited from the parent chart's `global` section |
-| global.mcpDomain | string | ``"{{ printf \"mcp.%s\" .Values.global.platformExternalDomain }}"`` | Domain where Seqera MCP listens. Evaluated as a template. Note: The OAuth redirect URL is automatically derived by appending /oauth/callback to the domain |
+| global.platformExternalDomain | string | `"example.com"` | Domain where Seqera Platform listens |
+| global.platformServiceAddress | string | `""` | Seqera Platform Service name: can be the internal Kubernetes hostname or an external ingress hostname. Evaluated as a template. Required when deploying this subchart standalone. When deploying as part of the parent `platform` umbrella chart, this value is inherited from the parent chart's `global` section |
+| global.platformServicePort | int | `nil` | Seqera Platform Service port. Required when deploying this subchart standalone. When deploying as part of the parent `platform` umbrella chart, this value is inherited from the parent chart's `global` section |
+| global.mcpDomain | string | `"{{ printf \"mcp.%s\" .Values.global.platformExternalDomain }}"` | Domain where Seqera MCP listens. Evaluated as a template. Note: The OAuth redirect URL is automatically derived by appending /oauth/callback to the domain |
 
 ### Global: Ingress
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| global.ingress.enabled | bool | ``false`` | Enable Ingress for this chart. OR'd with the chart's local `ingress.enabled` so setting this once at the parent enables all subchart Ingresses. |
-| global.ingress.path | string | ``"/"`` | Default path applied to ingress rules when `ingress.path` is not set. AWS ALB users should override to `/*`. |
-| global.ingress.defaultPathType | string | ``"Prefix"`` | Default path type applied to ingress rules when `ingress.defaultPathType` is not set. `Prefix` works for nginx, traefik, AWS ALB, and most modern controllers. |
-| global.ingress.ingressClassName | string | ``""`` | Default ingress class name applied when `ingress.ingressClassName` is not set |
-| global.ingress.annotations | object | ``{}`` | Annotations merged into the Ingress. Local `ingress.annotations` wins on key collision. Evaluated as a template |
-| global.ingress.extraLabels | object | ``{}`` | Extra labels merged into the Ingress. Local `ingress.extraLabels` wins on key collision. Evaluated as a template |
-| global.ingress.tls | list | ``[]`` | TLS entries concatenated with the local `ingress.tls`. Evaluated as a template |
+| global.ingress.enabled | bool | `false` | Enable Ingress for this chart. OR'd with the chart's local `ingress.enabled` so setting this once at the parent enables all subchart Ingresses. |
+| global.ingress.path | string | `"/"` | Default path applied to ingress rules when `ingress.path` is not set. AWS ALB users should override to `/*`. |
+| global.ingress.defaultPathType | string | `"Prefix"` | Default path type applied to ingress rules when `ingress.defaultPathType` is not set. `Prefix` works for nginx, traefik, AWS ALB, and most modern controllers. |
+| global.ingress.ingressClassName | string | `""` | Default ingress class name applied when `ingress.ingressClassName` is not set |
+| global.ingress.annotations | object | `{}` | Annotations merged into the Ingress. Local `ingress.annotations` wins on key collision. Evaluated as a template |
+| global.ingress.extraLabels | object | `{}` | Extra labels merged into the Ingress. Local `ingress.extraLabels` wins on key collision. Evaluated as a template |
+| global.ingress.tls | list | `[]` | TLS entries concatenated with the local `ingress.tls`. Evaluated as a template |
 
 ### Global: Image credentials
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| global.imageCredentials | list | ``[]`` | Optional credentials to log in and fetch images from a private registry. These credentials are shared with all the subcharts automatically |
-| global.imageCredentialsSecrets | list | ``[]`` | Optional list of existing Secrets containing image pull credentials to use for pulling images from private registries. These Secrets are shared with all the subcharts automatically |
+| global.imageCredentials | list | `[]` | Optional credentials to log in and fetch images from a private registry. These credentials are shared with all the subcharts automatically |
+| global.imageCredentialsSecrets | list | `[]` | Optional list of existing Secrets containing image pull credentials to use for pulling images from private registries. These Secrets are shared with all the subcharts automatically |
 
 ### MCP application
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| micronautEnvironments | list | ``["oauth-platform"]`` | List of Micronaut environments to enable. Evaluated as a template |
-| hubApiEndpoint | string | ``"https://hub.seqera.io"`` | API endpoint of Seqera Hub. |
-| waveApiEndpoint | string | ``"https://wave.seqera.io"`` | API endpoint of Seqera Wave. |
-| registryApiEndpoint | string | ``"https://registry.nextflow.io"`` | API endpoint of Seqera Nextflow Registry. |
+| micronautEnvironments | list | `["oauth-platform"]` | List of Micronaut environments to enable. Evaluated as a template |
+| hubApiEndpoint | string | `"https://hub.seqera.io"` | API endpoint of Seqera Hub. |
+| waveApiEndpoint | string | `"https://wave.seqera.io"` | API endpoint of Seqera Wave. |
+| registryApiEndpoint | string | `"https://registry.nextflow.io"` | API endpoint of Seqera Nextflow Registry. |
 
 ### OIDC token
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| oidcToken.tokenString | string | ``""`` | OIDC client registration token as a string. Used to dynamically register an OAuth client with Seqera Platform's OIDC provider. If neither this nor existingSecretName is set, a random value is generated. When deployed via the platform parent chart, this is automatically defined with the value of the OIDC client registration token from the platform backend secret, so it should not be set in that case. When deploying independently of the platform parent chart, this must be set to the same value defined in the platform backend secret. WARNING: Always explicitly set this value or use an existing secret when using Kustomize. Auto-generated random values are incompatible with Kustomize. When upgrading releases via Kustomize, Helm cannot query the cluster to check if a secret already exists, causing it to regenerate a new random value on each upgrade, which will break authentication |
-| oidcToken.existingSecretName | string | ``""`` | Name of an existing Secret containing the OIDC client registration token, as an alternative to the string field. Note: the Secret must already exist in the same namespace at the time of deployment. |
-| oidcToken.existingSecretKey | string | ``"MCP_OAUTH_INITIAL_ACCESS_TOKEN"`` | Key in the existing Secret containing the OIDC client registration token. |
+| oidcToken.tokenString | string | `""` | OIDC client registration token as a string. Used to dynamically register an OAuth client with Seqera Platform's OIDC provider. If neither this nor existingSecretName is set, a random value is generated. When deployed via the platform parent chart, this is automatically defined with the value of the OIDC client registration token from the platform backend secret, so it should not be set in that case. When deploying independently of the platform parent chart, this must be set to the same value defined in the platform backend secret. WARNING: Always explicitly set this value or use an existing secret when using Kustomize. Auto-generated random values are incompatible with Kustomize. When upgrading releases via Kustomize, Helm cannot query the cluster to check if a secret already exists, causing it to regenerate a new random value on each upgrade, which will break authentication |
+| oidcToken.existingSecretName | string | `""` | Name of an existing Secret containing the OIDC client registration token, as an alternative to the string field. Note: the Secret must already exist in the same namespace at the time of deployment. |
+| oidcToken.existingSecretKey | string | `"MCP_OAUTH_INITIAL_ACCESS_TOKEN"` | Key in the existing Secret containing the OIDC client registration token. |
 
 ### OAuth
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| oauth.jwtSeedString | string | ``""`` | JWT seed, defined as string, used to sign authentication tokens. Define the value as a String or a Secret, not both at the same time. If neither is defined, Helm generates a random 35-character string. WARNING: Always explicitly set this value or use an existing secret when using Kustomize. Auto-generated random values are incompatible with Kustomize. When upgrading releases via Kustomize, Helm cannot query the cluster to check if a secret already exists, causing it to regenerate a new random value on each upgrade, which will break authentication |
-| oauth.jwtSeedSecretName | string | ``""`` | Name of an existing Secret containing the JWT seed, as an alternative to the string field. Note: the Secret must already exist in the same namespace at the time of deployment |
-| oauth.jwtSeedSecretKey | string | ``"MCP_OAUTH_JWT_SECRET"`` | Key in the existing Secret containing the JWT seed |
+| oauth.jwtSeedString | string | `""` | JWT seed, defined as string, used to sign authentication tokens. Define the value as a String or a Secret, not both at the same time. If neither is defined, Helm generates a random 35-character string. WARNING: Always explicitly set this value or use an existing secret when using Kustomize. Auto-generated random values are incompatible with Kustomize. When upgrading releases via Kustomize, Helm cannot query the cluster to check if a secret already exists, causing it to regenerate a new random value on each upgrade, which will break authentication |
+| oauth.jwtSeedSecretName | string | `""` | Name of an existing Secret containing the JWT seed, as an alternative to the string field. Note: the Secret must already exist in the same namespace at the time of deployment |
+| oauth.jwtSeedSecretKey | string | `"MCP_OAUTH_JWT_SECRET"` | Key in the existing Secret containing the JWT seed |
 
 ### Image
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| image.registry | string | ``""`` | Container image registry |
-| image.repository | string | ``"ai/mcp/server"`` | Container image repository |
-| image.tag | string | ``"{{ .chart.AppVersion }}"`` | Container image tag |
-| image.digest | string | ``""`` | Container image digest in the format `sha256:1234abcdef` |
-| image.pullPolicy | string | ``"IfNotPresent"`` | imagePullPolicy for the container Ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images |
-| image.pullSecrets | list | ``[]`` | List of imagePullSecrets Secrets must be created in the same namespace, for example using the .extraDeploy array Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ |
+| image.registry | string | `""` | Container image registry |
+| image.repository | string | `"ai/mcp/server"` | Container image repository |
+| image.tag | string | `"{{ .chart.AppVersion }}"` | Container image tag |
+| image.digest | string | `""` | Container image digest in the format `sha256:1234abcdef` |
+| image.pullPolicy | string | `"IfNotPresent"` | imagePullPolicy for the container Ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images |
+| image.pullSecrets | list | `[]` | List of imagePullSecrets Secrets must be created in the same namespace, for example using the .extraDeploy array Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ |
 
 ### Service
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| service | object | ``{"extraOptions":{},"extraServices":[],"http":{"name":"http","nodePort":null,"port":6010,"targetPort":6010},"type":"ClusterIP"}`` | Service configuration |
-| service.type | string | ``"ClusterIP"`` | Service type. Note: ingresses using AWS ALB require the service to be NodePort |
-| service.http.name | string | ``"http"`` | Service name to use |
-| service.http.port | int | ``6010`` | Service port |
-| service.http.targetPort | int | ``6010`` | Port on the pod/container that the Service forwards traffic to (can be a number or named port, distinct from the Service's external port) |
-| service.http.nodePort | string | ``nil`` | Service node port, only used when service.type is Nodeport or LoadBalancer Choose port between 30000-32767, unless the cluster was configured differently than default |
-| service.extraServices | list | ``[]`` | Other services that should live in the Service object https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service |
-| service.extraOptions | object | ``{}`` | Extra Service options to place under .spec (for example, clusterIP, loadBalancerIP, externalTrafficPolicy, externalIPs). Evaluated as a template |
+| service | object | `{"extraOptions":{},"extraServices":[],"http":{"name":"http","nodePort":null,"port":6010,"targetPort":6010},"type":"ClusterIP"}` | Service configuration |
+| service.type | string | `"ClusterIP"` | Service type. Note: ingresses using AWS ALB require the service to be NodePort |
+| service.http.name | string | `"http"` | Service name to use |
+| service.http.port | int | `6010` | Service port |
+| service.http.targetPort | int | `6010` | Port on the pod/container that the Service forwards traffic to (can be a number or named port, distinct from the Service's external port) |
+| service.http.nodePort | string | `nil` | Service node port, only used when service.type is Nodeport or LoadBalancer Choose port between 30000-32767, unless the cluster was configured differently than default |
+| service.extraServices | list | `[]` | Other services that should live in the Service object https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service |
+| service.extraOptions | object | `{}` | Extra Service options to place under .spec (for example, clusterIP, loadBalancerIP, externalTrafficPolicy, externalIPs). Evaluated as a template |
 
 ### Init containers
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| initContainerDependencies.enabled | bool | ``true`` | Enable init containers that coordinate startup dependencies (for example, wait for Seqera Platform readiness before starting, etc) |
-| initContainers | list | ``[]`` | Additional init containers for the pod. Evaluated as a template |
+| initContainerDependencies.enabled | bool | `true` | Enable init containers that coordinate startup dependencies (for example, wait for Seqera Platform readiness before starting, etc) |
+| initContainers | list | `[]` | Additional init containers for the pod. Evaluated as a template |
 
 ### Init containers: Wait for Platform
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| initContainerDependencies.waitForPlatform.enabled | bool | ``true`` | Enable wait for Seqera Platform init container before starting the MCP server |
-| initContainerDependencies.waitForPlatform.image.registry | string | ``""`` | Wait for Platform init container image registry |
-| initContainerDependencies.waitForPlatform.image.repository | string | ``"curlimages/curl"`` | Wait for Platform init container image repository |
-| initContainerDependencies.waitForPlatform.image.tag | string | ``"latest"`` | Wait for Platform init container image tag |
-| initContainerDependencies.waitForPlatform.image.digest | string | ``""`` | Wait for Platform init container image digest in the format `sha256:1234abcdef` |
-| initContainerDependencies.waitForPlatform.image.pullPolicy | string | ``"IfNotPresent"`` | imagePullPolicy for the wait for Platform init container |
-| initContainerDependencies.waitForPlatform.securityContext.runAsUser | int | ``101`` | UID the container processes run as (overrides container image default) |
-| initContainerDependencies.waitForPlatform.securityContext.runAsNonRoot | bool | ``true`` | Require the container to run as a non-root UID (prevents starting if UID 0) |
-| initContainerDependencies.waitForPlatform.securityContext.readOnlyRootFilesystem | bool | ``true`` | Mount the container root filesystem read-only to prevent in-place writes or tampering |
-| initContainerDependencies.waitForPlatform.securityContext.capabilities | object | ``{"drop":["ALL"]}`` | Fine-grained Linux kernel privileges to add or drop for the container |
-| initContainerDependencies.waitForPlatform.resources | object | ``{"limits":{"memory":"100Mi"},"requests":{"cpu":"0.1","memory":"50Mi"}}`` | Container requests and limits for different resources like CPU or memory |
-| initContainerDependencies.waitForPlatform.extraEnvVars | list | ``[]`` | Additional environment variables for the init container |
-| initContainerDependencies.waitForPlatform.extraVolumeMounts | list | ``[]`` | Additional volume mounts for the init container (e.g. to mount a CA certificate) |
+| initContainerDependencies.waitForPlatform.enabled | bool | `true` | Enable wait for Seqera Platform init container before starting the MCP server |
+| initContainerDependencies.waitForPlatform.image.registry | string | `""` | Wait for Platform init container image registry |
+| initContainerDependencies.waitForPlatform.image.repository | string | `"curlimages/curl"` | Wait for Platform init container image repository |
+| initContainerDependencies.waitForPlatform.image.tag | string | `"latest"` | Wait for Platform init container image tag |
+| initContainerDependencies.waitForPlatform.image.digest | string | `""` | Wait for Platform init container image digest in the format `sha256:1234abcdef` |
+| initContainerDependencies.waitForPlatform.image.pullPolicy | string | `"IfNotPresent"` | imagePullPolicy for the wait for Platform init container |
+| initContainerDependencies.waitForPlatform.securityContext.runAsUser | int | `101` | UID the container processes run as (overrides container image default) |
+| initContainerDependencies.waitForPlatform.securityContext.runAsNonRoot | bool | `true` | Require the container to run as a non-root UID (prevents starting if UID 0) |
+| initContainerDependencies.waitForPlatform.securityContext.readOnlyRootFilesystem | bool | `true` | Mount the container root filesystem read-only to prevent in-place writes or tampering |
+| initContainerDependencies.waitForPlatform.securityContext.capabilities | object | `{"drop":["ALL"]}` | Fine-grained Linux kernel privileges to add or drop for the container |
+| initContainerDependencies.waitForPlatform.resources | object | `{"limits":{"memory":"100Mi"},"requests":{"cpu":"0.1","memory":"50Mi"}}` | Container requests and limits for different resources like CPU or memory |
+| initContainerDependencies.waitForPlatform.extraEnvVars | list | `[]` | Additional environment variables for the init container |
+| initContainerDependencies.waitForPlatform.extraVolumeMounts | list | `[]` | Additional volume mounts for the init container (e.g. to mount a CA certificate) |
 
 ### Pod
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| command | list | ``[]`` | Override default container command (useful when using custom images) |
-| args | list | ``[]`` | Override default container args (useful when using custom images) |
-| podLabels | object | ``{}`` | Additional labels for the pod. Evaluated as a template |
-| podAnnotations | object | ``{}`` | Additional annotations for the pod. Evaluated as a template |
-| extraOptionsSpec | object | ``{}`` | Extra options to place under .spec (e.g. replicas, strategy, revisionHistoryLimit, etc). Evaluated as a template |
-| extraOptionsTemplateSpec | object | ``{}`` | Extra options to place under .spec.template.spec (e.g. nodeSelector, affinity, restartPolicy, etc). Evaluated as a template |
+| command | list | `[]` | Override default container command (useful when using custom images) |
+| args | list | `[]` | Override default container args (useful when using custom images) |
+| podLabels | object | `{}` | Additional labels for the pod. Evaluated as a template |
+| podAnnotations | object | `{}` | Additional annotations for the pod. Evaluated as a template |
+| extraOptionsSpec | object | `{}` | Extra options to place under .spec (e.g. replicas, strategy, revisionHistoryLimit, etc). Evaluated as a template |
+| extraOptionsTemplateSpec | object | `{}` | Extra options to place under .spec.template.spec (e.g. nodeSelector, affinity, restartPolicy, etc). Evaluated as a template |
 
 ### Pod: Environment
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| extraEnvVars | list | ``[]`` | Extra environment variables |
-| extraEnvVarsCMs | list | ``[]`` | List of ConfigMaps containing extra env vars |
-| extraEnvVarsSecrets | list | ``[]`` | List of Secrets containing extra env vars |
+| extraEnvVars | list | `[]` | Extra environment variables |
+| extraEnvVarsCMs | list | `[]` | List of ConfigMaps containing extra env vars |
+| extraEnvVarsSecrets | list | `[]` | List of Secrets containing extra env vars |
 
 ### Pod: Volumes
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| extraVolumes | list | ``[]`` | List of volumes to add to the deployment (evaluated as template). Requires setting `extraVolumeMounts` |
-| extraVolumeMounts | list | ``[]`` | List of volume mounts to add to the container (evaluated as template). Normally used with `extraVolumes` |
+| extraVolumes | list | `[]` | List of volumes to add to the deployment (evaluated as template). Requires setting `extraVolumeMounts` |
+| extraVolumeMounts | list | `[]` | List of volume mounts to add to the container (evaluated as template). Normally used with `extraVolumes` |
 
 ### Pod: Security context
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| podSecurityContext.enabled | bool | ``true`` | Enable pod Security Context |
-| podSecurityContext.fsGroup | int | ``101`` | Sets the GID that Kubernetes will apply to mounted volumes and created files so processes in the pod can share group-owned access |
+| podSecurityContext.enabled | bool | `true` | Enable pod Security Context |
+| podSecurityContext.fsGroup | int | `101` | Sets the GID that Kubernetes will apply to mounted volumes and created files so processes in the pod can share group-owned access |
 
 ### Container: Security context
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| containerSecurityContext.enabled | bool | ``true`` | Enable container Security Context |
-| containerSecurityContext.runAsUser | int | ``101`` | UID the container processes run as (overrides container image default) |
-| containerSecurityContext.runAsNonRoot | bool | ``true`` | Boolean that requires the container to run as a non-root UID (prevents starting if UID 0) |
-| containerSecurityContext.readOnlyRootFilesystem | bool | ``true`` | Mounts the container root filesystem read-only to prevent in-place writes or tampering |
-| containerSecurityContext.capabilities | object | ``{"drop":["ALL"]}`` | Fine-grained Linux kernel privileges to add or drop for the container |
+| containerSecurityContext.enabled | bool | `true` | Enable container Security Context |
+| containerSecurityContext.runAsUser | int | `101` | UID the container processes run as (overrides container image default) |
+| containerSecurityContext.runAsNonRoot | bool | `true` | Boolean that requires the container to run as a non-root UID (prevents starting if UID 0) |
+| containerSecurityContext.readOnlyRootFilesystem | bool | `true` | Mounts the container root filesystem read-only to prevent in-place writes or tampering |
+| containerSecurityContext.capabilities | object | `{"drop":["ALL"]}` | Fine-grained Linux kernel privileges to add or drop for the container |
 
 ### Container: Resources
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| resources | object | ``{}`` | Container requests and limits for different resources like CPU or memory |
+| resources | object | `{}` | Container requests and limits for different resources like CPU or memory |
 
 ### Probes: Startup
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| startupProbe.enabled | bool | ``false`` | Enable startup probe |
-| startupProbe.httpGet.path | string | ``"/health"`` | HTTP GET path for startup probe |
-| startupProbe.httpGet.port | string | ``"{{ .Values.service.http.targetPort }}"`` | HTTP GET port for startup probe. Evaluated as a template |
-| startupProbe.initialDelaySeconds | int | ``5`` | Longer initial wait to accommodate slow-starting apps |
-| startupProbe.periodSeconds | int | ``10`` | Often set longer to avoid frequent checks while starting |
-| startupProbe.timeoutSeconds | int | ``3`` | Can be longer to allow slow initialization responses |
-| startupProbe.failureThreshold | int | ``5`` | Consecutive failures during startup before killing the container (instead of immediate restarts) |
-| startupProbe.successThreshold | int | ``1`` | Number of consecutive successes required to consider startup complete and enable liveness/readiness |
+| startupProbe.enabled | bool | `false` | Enable startup probe |
+| startupProbe.httpGet.path | string | `"/health"` | HTTP GET path for startup probe |
+| startupProbe.httpGet.port | string | `"{{ .Values.service.http.targetPort }}"` | HTTP GET port for startup probe. Evaluated as a template |
+| startupProbe.initialDelaySeconds | int | `5` | Longer initial wait to accommodate slow-starting apps |
+| startupProbe.periodSeconds | int | `10` | Often set longer to avoid frequent checks while starting |
+| startupProbe.timeoutSeconds | int | `3` | Can be longer to allow slow initialization responses |
+| startupProbe.failureThreshold | int | `5` | Consecutive failures during startup before killing the container (instead of immediate restarts) |
+| startupProbe.successThreshold | int | `1` | Number of consecutive successes required to consider startup complete and enable liveness/readiness |
 
 ### Probes: Readiness
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| readinessProbe.enabled | bool | ``true`` | Enable readiness probe |
-| readinessProbe.httpGet.path | string | ``"/health"`` | HTTP GET path for readiness probe |
-| readinessProbe.httpGet.port | string | ``"{{ .Values.service.http.targetPort }}"`` | HTTP GET port for readiness probe. Evaluated as a template |
-| readinessProbe.initialDelaySeconds | int | ``5`` | Delay before first check (normal start timing) |
-| readinessProbe.periodSeconds | int | ``5`` | Regular check interval during normal operation |
-| readinessProbe.timeoutSeconds | int | ``3`` | Short timeout to detect unresponsive containers for readiness |
-| readinessProbe.failureThreshold | int | ``5`` | Consecutive failures before marking the container Unready (no restart) |
-| readinessProbe.successThreshold | int | ``1`` | Number of consecutive successes required to mark the container Ready after failures |
+| readinessProbe.enabled | bool | `true` | Enable readiness probe |
+| readinessProbe.httpGet.path | string | `"/health"` | HTTP GET path for readiness probe |
+| readinessProbe.httpGet.port | string | `"{{ .Values.service.http.targetPort }}"` | HTTP GET port for readiness probe. Evaluated as a template |
+| readinessProbe.initialDelaySeconds | int | `5` | Delay before first check (normal start timing) |
+| readinessProbe.periodSeconds | int | `5` | Regular check interval during normal operation |
+| readinessProbe.timeoutSeconds | int | `3` | Short timeout to detect unresponsive containers for readiness |
+| readinessProbe.failureThreshold | int | `5` | Consecutive failures before marking the container Unready (no restart) |
+| readinessProbe.successThreshold | int | `1` | Number of consecutive successes required to mark the container Ready after failures |
 
 ### Probes: Liveness
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| livenessProbe.enabled | bool | ``true`` | Enable liveness probe |
-| livenessProbe.httpGet.path | string | ``"/health"`` | HTTP GET path for liveness probe |
-| livenessProbe.httpGet.port | string | ``"{{ .Values.service.http.targetPort }}"`` | HTTP GET port for liveness probe. Evaluated as a template |
-| livenessProbe.initialDelaySeconds | int | ``5`` | Delay before first check (normal start timing) |
-| livenessProbe.periodSeconds | int | ``10`` | Regular check interval during normal operation |
-| livenessProbe.timeoutSeconds | int | ``3`` | Short timeout to detect hung containers quickly |
-| livenessProbe.failureThreshold | int | ``10`` | Consecutive failures before restarting the container |
-| livenessProbe.successThreshold | int | ``1`` | Typically 1 (usually ignored) |
+| livenessProbe.enabled | bool | `true` | Enable liveness probe |
+| livenessProbe.httpGet.path | string | `"/health"` | HTTP GET path for liveness probe |
+| livenessProbe.httpGet.port | string | `"{{ .Values.service.http.targetPort }}"` | HTTP GET port for liveness probe. Evaluated as a template |
+| livenessProbe.initialDelaySeconds | int | `5` | Delay before first check (normal start timing) |
+| livenessProbe.periodSeconds | int | `10` | Regular check interval during normal operation |
+| livenessProbe.timeoutSeconds | int | `3` | Short timeout to detect hung containers quickly |
+| livenessProbe.failureThreshold | int | `10` | Consecutive failures before restarting the container |
+| livenessProbe.successThreshold | int | `1` | Typically 1 (usually ignored) |
 
 ### Service account
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| serviceAccount | object | ``{"annotations":{},"automountServiceAccountToken":true,"imagePullSecretNames":[],"name":""}`` | Service account configuration |
-| serviceAccount.name | string | ``""`` | Service account name |
-| serviceAccount.annotations | object | ``{}`` | Service account annotations |
-| serviceAccount.imagePullSecretNames | list | ``[]`` | Names of Secrets containing credentials to pull images from registries |
-| serviceAccount.automountServiceAccountToken | bool | ``true`` | Automatically mount service account token |
+| serviceAccount | object | `{"annotations":{},"automountServiceAccountToken":true,"imagePullSecretNames":[],"name":""}` | Service account configuration |
+| serviceAccount.name | string | `""` | Service account name |
+| serviceAccount.annotations | object | `{}` | Service account annotations |
+| serviceAccount.imagePullSecretNames | list | `[]` | Names of Secrets containing credentials to pull images from registries |
+| serviceAccount.automountServiceAccountToken | bool | `true` | Automatically mount service account token |
 
 ### Ingress
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| ingress.enabled | bool | ``false`` | Enable ingress for MCP |
-| ingress.path | string | ``""`` | Path for the main ingress rule. When empty, falls back to `global.ingress.path` |
-| ingress.defaultPathType | string | ``""`` | Default path type for the Ingress. When empty, falls back to `global.ingress.defaultPathType` |
-| ingress.defaultBackend | object | ``{}`` | Configure the default service for the ingress (evaluated as template) Important: make sure only one defaultBackend is defined across the k8s cluster: if the ingress doesn't reconcile successfully, 'describe ingress <name>' will report problems |
-| ingress.extraHosts | list | ``[]`` | Additional hosts you want to include. Evaluated as a template |
-| ingress.annotations | object | ``{}`` | Ingress annotations specific to your load balancer. Evaluated as a template |
-| ingress.extraLabels | object | ``{}`` | Additional labels for the ingress object. Evaluated as a template |
-| ingress.ingressClassName | string | ``""`` | Name of the ingress class (replaces the deprecated annotation `kubernetes.io/ingress.class`). When empty, falls back to `global.ingress.ingressClassName` |
-| ingress.tls | list | ``[]`` | TLS configuration. Evaluated as a template |
+| ingress.enabled | bool | `false` | Enable ingress for MCP |
+| ingress.path | string | `""` | Path for the main ingress rule. When empty, falls back to `global.ingress.path` |
+| ingress.defaultPathType | string | `""` | Default path type for the Ingress. When empty, falls back to `global.ingress.defaultPathType` |
+| ingress.defaultBackend | object | `{}` | Configure the default service for the ingress (evaluated as template) Important: make sure only one defaultBackend is defined across the k8s cluster: if the ingress doesn't reconcile successfully, 'describe ingress <name>' will report problems |
+| ingress.extraHosts | list | `[]` | Additional hosts you want to include. Evaluated as a template |
+| ingress.annotations | object | `{}` | Ingress annotations specific to your load balancer. Evaluated as a template |
+| ingress.extraLabels | object | `{}` | Additional labels for the ingress object. Evaluated as a template |
+| ingress.ingressClassName | string | `""` | Name of the ingress class (replaces the deprecated annotation `kubernetes.io/ingress.class`). When empty, falls back to `global.ingress.ingressClassName` |
+| ingress.tls | list | `[]` | TLS configuration. Evaluated as a template |
 
 ### Extra deployment
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| extraDeploy | list | ``[]`` | Array of extra objects to deploy with the release |
+| extraDeploy | list | `[]` | Array of extra objects to deploy with the release |
 
 ### Common metadata
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| commonAnnotations | object | ``{}`` | Annotations to add to all deployed objects |
-| commonLabels | object | ``{}`` | Labels to add to all deployed objects |
-| secretLabels | object | ``{}`` | Additional labels for the Secret objects. Evaluated as a template |
-| secretAnnotations | object | ``{}`` | Additional annotations for the Secret objects. Evaluated as a template |
-| configMapLabels | object | ``{}`` | Additional labels for the ConfigMap objects. Evaluated as a template |
-| configMapAnnotations | object | ``{}`` | Additional annotations for the ConfigMap objects. Evaluated as a template |
+| commonAnnotations | object | `{}` | Annotations to add to all deployed objects |
+| commonLabels | object | `{}` | Labels to add to all deployed objects |
+| secretLabels | object | `{}` | Additional labels for the Secret objects. Evaluated as a template |
+| secretAnnotations | object | `{}` | Additional annotations for the Secret objects. Evaluated as a template |
+| configMapLabels | object | `{}` | Additional labels for the ConfigMap objects. Evaluated as a template |
+| configMapAnnotations | object | `{}` | Additional annotations for the ConfigMap objects. Evaluated as a template |
 
 ## Licensing
 

--- a/charts/platform/charts/mcp/README.md.gotmpl
+++ b/charts/platform/charts/mcp/README.md.gotmpl
@@ -84,7 +84,7 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 {{- range .SectionItems }}
-| {{ .Key }} | {{ .Type }} | {{ if .Default }}`{{ .Default }}`{{ else }}`{{ .AutoDefault }}`{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
+| {{ .Key }} | {{ .Type }} | {{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
 {{- end }}
 {{- end }}
 
@@ -95,7 +95,7 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 {{- range . }}
-| {{ .Key }} | {{ .Type }} | {{ if .Default }}`{{ .Default }}`{{ else }}`{{ .AutoDefault }}`{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
+| {{ .Key }} | {{ .Type }} | {{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
 {{- end }}
 {{- end }}
 

--- a/charts/platform/charts/pipeline-optimization/README.md
+++ b/charts/platform/charts/pipeline-optimization/README.md
@@ -85,225 +85,225 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| global.imageCredentials | list | ``[]`` | Optional credentials to log in and fetch images from a private registry. These credentials are shared with all the subcharts automatically |
-| global.imageCredentialsSecrets | list | ``[]`` | Optional list of existing Secrets containing image pull credentials to use for pulling images from private registries. These Secrets are shared with all the subcharts automatically |
+| global.imageCredentials | list | `[]` | Optional credentials to log in and fetch images from a private registry. These credentials are shared with all the subcharts automatically |
+| global.imageCredentialsSecrets | list | `[]` | Optional list of existing Secrets containing image pull credentials to use for pulling images from private registries. These Secrets are shared with all the subcharts automatically |
 
 ### Database
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| database.host | string | ``""`` | Pipeline Optimization MySQL database hostname |
-| database.port | int | ``3306`` | Pipeline Optimization MySQL database port |
-| database.name | string | ``""`` | Pipeline Optimization MySQL database name |
-| database.username | string | ``""`` | Pipeline Optimization MySQL database username |
-| database.password | string | ``""`` | Pipeline Optimization MySQL database password |
-| database.existingSecretName | string | ``""`` | Name of an existing Secret containing credentials for the Pipeline Optimization MySQL database, as an alternative to the password field. Note: the Secret must already exist in the same namespace at the time of deployment |
-| database.existingSecretKey | string | ``"SWELL_DB_PASSWORD"`` | Key in the existing Secret containing the password for the Pipeline Optimization MySQL database |
-| database.dialect | string | ``"mysql"`` | Pipeline Optimization database dialect. Currently only 'mysql' is supported |
+| database.host | string | `""` | Pipeline Optimization MySQL database hostname |
+| database.port | int | `3306` | Pipeline Optimization MySQL database port |
+| database.name | string | `""` | Pipeline Optimization MySQL database name |
+| database.username | string | `""` | Pipeline Optimization MySQL database username |
+| database.password | string | `""` | Pipeline Optimization MySQL database password |
+| database.existingSecretName | string | `""` | Name of an existing Secret containing credentials for the Pipeline Optimization MySQL database, as an alternative to the password field. Note: the Secret must already exist in the same namespace at the time of deployment |
+| database.existingSecretKey | string | `"SWELL_DB_PASSWORD"` | Key in the existing Secret containing the password for the Pipeline Optimization MySQL database |
+| database.dialect | string | `"mysql"` | Pipeline Optimization database dialect. Currently only 'mysql' is supported |
 
 ### Database: TLS
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| database.enableTls | bool | ``true`` | Enable TLS for the Pipeline Optimization MySQL database connection |
-| database.tlsCaVerify | bool | ``true`` | Verify the CA certificate when connecting via TLS (set to false to skip verification, insecure - for development/testing only) |
-| database.sslCa | string | ``""`` | Path to a CA certificate file for server certificate verification |
-| database.sslCert | string | ``""`` | Path to a client certificate file for mutual TLS authentication |
-| database.sslKey | string | ``""`` | Path to a client key file for mutual TLS authentication |
+| database.enableTls | bool | `true` | Enable TLS for the Pipeline Optimization MySQL database connection |
+| database.tlsCaVerify | bool | `true` | Verify the CA certificate when connecting via TLS (set to false to skip verification, insecure - for development/testing only) |
+| database.sslCa | string | `""` | Path to a CA certificate file for server certificate verification |
+| database.sslCert | string | `""` | Path to a client certificate file for mutual TLS authentication |
+| database.sslKey | string | `""` | Path to a client key file for mutual TLS authentication |
 
 ### Platform Database
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| platformDatabase.host | string | ``""`` | Platform MySQL database hostname |
-| platformDatabase.port | int | ``3306`` | Platform MySQL database port |
-| platformDatabase.name | string | ``""`` | Platform MySQL database name |
-| platformDatabase.username | string | ``""`` | Platform MySQL database username. Can be a read-only user, since Platform Optimization does not perform write operations on the Platform database |
-| platformDatabase.password | string | ``""`` | Platform MySQL database password |
-| platformDatabase.existingSecretName | string | ``""`` | Name of an existing Secret containing credentials for the Platform MySQL database, as an alternative to the password field. Note: the Secret must already exist in the same namespace at the time of deployment |
-| platformDatabase.existingSecretKey | string | ``"TOWER_DB_PASSWORD"`` | Key in the existing Secret containing the password for the Platform MySQL database |
+| platformDatabase.host | string | `""` | Platform MySQL database hostname |
+| platformDatabase.port | int | `3306` | Platform MySQL database port |
+| platformDatabase.name | string | `""` | Platform MySQL database name |
+| platformDatabase.username | string | `""` | Platform MySQL database username. Can be a read-only user, since Platform Optimization does not perform write operations on the Platform database |
+| platformDatabase.password | string | `""` | Platform MySQL database password |
+| platformDatabase.existingSecretName | string | `""` | Name of an existing Secret containing credentials for the Platform MySQL database, as an alternative to the password field. Note: the Secret must already exist in the same namespace at the time of deployment |
+| platformDatabase.existingSecretKey | string | `"TOWER_DB_PASSWORD"` | Key in the existing Secret containing the password for the Platform MySQL database |
 
 ### Platform Database: TLS
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| platformDatabase.enableTls | bool | ``true`` | Enable TLS for the Platform MySQL database connection |
-| platformDatabase.tlsCaVerify | bool | ``true`` | Verify the CA certificate when connecting via TLS (set to false to skip verification, insecure - for development/testing only) |
-| platformDatabase.sslCa | string | ``""`` | Path to a CA certificate file for server certificate verification |
-| platformDatabase.sslCert | string | ``""`` | Path to a client certificate file for mutual TLS authentication |
-| platformDatabase.sslKey | string | ``""`` | Path to a client key file for mutual TLS authentication |
+| platformDatabase.enableTls | bool | `true` | Enable TLS for the Platform MySQL database connection |
+| platformDatabase.tlsCaVerify | bool | `true` | Verify the CA certificate when connecting via TLS (set to false to skip verification, insecure - for development/testing only) |
+| platformDatabase.sslCa | string | `""` | Path to a CA certificate file for server certificate verification |
+| platformDatabase.sslCert | string | `""` | Path to a client certificate file for mutual TLS authentication |
+| platformDatabase.sslKey | string | `""` | Path to a client key file for mutual TLS authentication |
 
 ### Image
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| image.registry | string | ``""`` | Pipeline Optimization container image registry |
-| image.repository | string | ``"enterprise/platform/pipeline-optimization"`` | Pipeline Optimization container image repository |
-| image.tag | string | ``"{{ .chart.AppVersion }}"`` | Pipeline Optimization container image tag |
-| image.digest | string | ``""`` | Pipeline Optimization container image digest in the format `sha256:1234abcdef` |
-| image.pullPolicy | string | ``"IfNotPresent"`` | imagePullPolicy for the Pipeline Optimization container Ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images |
-| image.pullSecrets | list | ``[]`` | List of imagePullSecrets Secrets must be created in the same namespace, for example using the .extraDeploy array Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ |
+| image.registry | string | `""` | Pipeline Optimization container image registry |
+| image.repository | string | `"enterprise/platform/pipeline-optimization"` | Pipeline Optimization container image repository |
+| image.tag | string | `"{{ .chart.AppVersion }}"` | Pipeline Optimization container image tag |
+| image.digest | string | `""` | Pipeline Optimization container image digest in the format `sha256:1234abcdef` |
+| image.pullPolicy | string | `"IfNotPresent"` | imagePullPolicy for the Pipeline Optimization container Ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images |
+| image.pullSecrets | list | `[]` | List of imagePullSecrets Secrets must be created in the same namespace, for example using the .extraDeploy array Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ |
 
 ### DB Migration Init Container
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| dbMigrationInitContainer.image.registry | string | ``""`` | Migrate DB init container image registry |
-| dbMigrationInitContainer.image.repository | string | ``"enterprise/platform/pipeline-optimization"`` | Migrate DB init container image repository |
-| dbMigrationInitContainer.image.tag | string | ``"{{ .chart.AppVersion }}"`` | Migrate DB init container image tag |
-| dbMigrationInitContainer.image.digest | string | ``""`` | Migrate DB init container image digest in the format `sha256:1234abcdef` |
-| dbMigrationInitContainer.image.pullPolicy | string | ``"IfNotPresent"`` | imagePullPolicy for the Migrate DB init container Ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images |
-| dbMigrationInitContainer.command | list | ``["/opt/groundswell/bin/migrate-db.sh"]`` | Command to run to migrate the database schema |
-| dbMigrationInitContainer.args | list | ``[]`` | Arguments to pass to the pod command |
+| dbMigrationInitContainer.image.registry | string | `""` | Migrate DB init container image registry |
+| dbMigrationInitContainer.image.repository | string | `"enterprise/platform/pipeline-optimization"` | Migrate DB init container image repository |
+| dbMigrationInitContainer.image.tag | string | `"{{ .chart.AppVersion }}"` | Migrate DB init container image tag |
+| dbMigrationInitContainer.image.digest | string | `""` | Migrate DB init container image digest in the format `sha256:1234abcdef` |
+| dbMigrationInitContainer.image.pullPolicy | string | `"IfNotPresent"` | imagePullPolicy for the Migrate DB init container Ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images |
+| dbMigrationInitContainer.command | list | `["/opt/groundswell/bin/migrate-db.sh"]` | Command to run to migrate the database schema |
+| dbMigrationInitContainer.args | list | `[]` | Arguments to pass to the pod command |
 
 ### Service
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| service.type | string | ``"ClusterIP"`` | Pipeline Optimization Service type. Note: ingresses using AWS ALB require the service to be NodePort |
-| service.extraServices | list | ``[]`` | Other services that should live in the Service object https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service |
-| service.extraOptions | object | ``{}`` | Extra Service options to place under .spec (for example, clusterIP, loadBalancerIP, externalTrafficPolicy, externalIPs). Evaluated as a template |
+| service.type | string | `"ClusterIP"` | Pipeline Optimization Service type. Note: ingresses using AWS ALB require the service to be NodePort |
+| service.extraServices | list | `[]` | Other services that should live in the Service object https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service |
+| service.extraOptions | object | `{}` | Extra Service options to place under .spec (for example, clusterIP, loadBalancerIP, externalTrafficPolicy, externalIPs). Evaluated as a template |
 
 ### Service: HTTP
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| service.http.name | string | ``"http"`` | Service name to use |
-| service.http.port | int | ``8090`` | Service port number |
-| service.http.targetPort | int | ``8090`` | Port on the pod/container that the Service forwards traffic to (can be a number or named port, distinct from the Service's external port). |
-| service.http.nodePort | string | ``nil`` | Service node port, only used when service.type is Nodeport or LoadBalancer Choose port between 30000-32767, unless the cluster was configured differently than default |
+| service.http.name | string | `"http"` | Service name to use |
+| service.http.port | int | `8090` | Service port number |
+| service.http.targetPort | int | `8090` | Port on the pod/container that the Service forwards traffic to (can be a number or named port, distinct from the Service's external port). |
+| service.http.nodePort | string | `nil` | Service node port, only used when service.type is Nodeport or LoadBalancer Choose port between 30000-32767, unless the cluster was configured differently than default |
 
 ### Deployment
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| initContainers | list | ``[]`` | Additional init containers for the pipeline optimization pod. Evaluated as a template |
-| command | list | ``[]`` | Override default container command (useful when using custom images) |
-| args | list | ``[]`` | Override default container args (useful when using custom images) |
-| podLabels | object | ``{}`` | Additional labels for the pipeline optimization pod. Evaluated as a template |
-| podAnnotations | object | ``{}`` | Additional annotations for the pipeline optimization pod. Evaluated as a template |
-| extraOptionsSpec | object | ``{}`` | Extra options to place under .spec (e.g. replicas, strategy, revisionHistoryLimit, etc). Evaluated as a template |
-| extraOptionsTemplateSpec | object | ``{}`` | Extra options to place under .spec.template.spec (e.g. nodeSelector, affinity, restartPolicy, etc). Evaluated as a template |
+| initContainers | list | `[]` | Additional init containers for the pipeline optimization pod. Evaluated as a template |
+| command | list | `[]` | Override default container command (useful when using custom images) |
+| args | list | `[]` | Override default container args (useful when using custom images) |
+| podLabels | object | `{}` | Additional labels for the pipeline optimization pod. Evaluated as a template |
+| podAnnotations | object | `{}` | Additional annotations for the pipeline optimization pod. Evaluated as a template |
+| extraOptionsSpec | object | `{}` | Extra options to place under .spec (e.g. replicas, strategy, revisionHistoryLimit, etc). Evaluated as a template |
+| extraOptionsTemplateSpec | object | `{}` | Extra options to place under .spec.template.spec (e.g. nodeSelector, affinity, restartPolicy, etc). Evaluated as a template |
 
 ### Common Metadata
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| commonAnnotations | object | ``{}`` | Annotations to add to all deployed objects |
-| commonLabels | object | ``{}`` | Labels to add to all deployed objects |
-| configMapAnnotations | object | ``{}`` | Annotations to add specifically to the ConfigMap |
-| configMapLabels | object | ``{}`` | Labels to add specifically to the ConfigMap |
+| commonAnnotations | object | `{}` | Annotations to add to all deployed objects |
+| commonLabels | object | `{}` | Labels to add to all deployed objects |
+| configMapAnnotations | object | `{}` | Annotations to add specifically to the ConfigMap |
+| configMapLabels | object | `{}` | Labels to add specifically to the ConfigMap |
 
 ### Environment & Volumes
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| extraEnvVars | list | ``[]`` | Extra environment variables to set on the pipeline optimization pod |
-| extraEnvVarsCMs | list | ``[]`` | List of ConfigMaps containing extra env vars |
-| extraEnvVarsSecrets | list | ``[]`` | List of Secrets containing extra env vars |
-| extraVolumes | list | ``[]`` | List of volumes to add to the deployment (evaluated as template). Requires setting `extraVolumeMounts` |
-| extraVolumeMounts | list | ``[]`` | List of volume mounts to add to the container (evaluated as template). Normally used with `extraVolumes` |
+| extraEnvVars | list | `[]` | Extra environment variables to set on the pipeline optimization pod |
+| extraEnvVarsCMs | list | `[]` | List of ConfigMaps containing extra env vars |
+| extraEnvVarsSecrets | list | `[]` | List of Secrets containing extra env vars |
+| extraVolumes | list | `[]` | List of volumes to add to the deployment (evaluated as template). Requires setting `extraVolumeMounts` |
+| extraVolumeMounts | list | `[]` | List of volume mounts to add to the container (evaluated as template). Normally used with `extraVolumes` |
 
 ### Pod Security Context
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| podSecurityContext.enabled | bool | ``true`` | Enable pod Security Context |
-| podSecurityContext.fsGroup | int | ``1000`` | Sets the GID that Kubernetes will apply to mounted volumes and created files so processes in the pod can share group-owned access |
+| podSecurityContext.enabled | bool | `true` | Enable pod Security Context |
+| podSecurityContext.fsGroup | int | `1000` | Sets the GID that Kubernetes will apply to mounted volumes and created files so processes in the pod can share group-owned access |
 
 ### Container Security Context
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| containerSecurityContext.enabled | bool | ``true`` | Enable container Security Context |
-| containerSecurityContext.runAsUser | int | ``1000`` | UID the container processes run as (overrides container image default) |
-| containerSecurityContext.runAsNonRoot | bool | ``true`` | Boolean that requires the container to run as a non-root UID (prevents starting if UID 0) |
-| containerSecurityContext.readOnlyRootFilesystem | bool | ``true`` | Mounts the container root filesystem read-only to prevent in-place writes or tampering |
-| containerSecurityContext.capabilities | object | ``{"drop":["ALL"]}`` | Fine-grained Linux kernel privileges to add or drop for the container |
+| containerSecurityContext.enabled | bool | `true` | Enable container Security Context |
+| containerSecurityContext.runAsUser | int | `1000` | UID the container processes run as (overrides container image default) |
+| containerSecurityContext.runAsNonRoot | bool | `true` | Boolean that requires the container to run as a non-root UID (prevents starting if UID 0) |
+| containerSecurityContext.readOnlyRootFilesystem | bool | `true` | Mounts the container root filesystem read-only to prevent in-place writes or tampering |
+| containerSecurityContext.capabilities | object | `{"drop":["ALL"]}` | Fine-grained Linux kernel privileges to add or drop for the container |
 
 ### Resources
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| resources | object | ``{}`` | Container requests and limits for different resources like CPU or memory |
+| resources | object | `{}` | Container requests and limits for different resources like CPU or memory |
 
 ### Startup Probe
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| startupProbe.enabled | bool | ``false`` | Enable startup probe |
-| startupProbe.httpGet.path | string | ``"/api/v1/health"`` | HTTP GET path for startup probe |
-| startupProbe.httpGet.port | string | ``"{{ .Values.service.http.targetPort }}"`` | HTTP GET port for startup probe. Evaluated as a template |
-| startupProbe.initialDelaySeconds | int | ``5`` | Longer initial wait to accommodate slow-starting apps |
-| startupProbe.periodSeconds | int | ``10`` | Often set longer to avoid frequent checks while starting |
-| startupProbe.timeoutSeconds | int | ``3`` | Can be longer to allow slow initialization responses |
-| startupProbe.failureThreshold | int | ``5`` | Consecutive failures during startup before killing the container (instead of immediate restarts) |
-| startupProbe.successThreshold | int | ``1`` | Number of consecutive successes required to consider startup complete and enable liveness/readiness |
+| startupProbe.enabled | bool | `false` | Enable startup probe |
+| startupProbe.httpGet.path | string | `"/api/v1/health"` | HTTP GET path for startup probe |
+| startupProbe.httpGet.port | string | `"{{ .Values.service.http.targetPort }}"` | HTTP GET port for startup probe. Evaluated as a template |
+| startupProbe.initialDelaySeconds | int | `5` | Longer initial wait to accommodate slow-starting apps |
+| startupProbe.periodSeconds | int | `10` | Often set longer to avoid frequent checks while starting |
+| startupProbe.timeoutSeconds | int | `3` | Can be longer to allow slow initialization responses |
+| startupProbe.failureThreshold | int | `5` | Consecutive failures during startup before killing the container (instead of immediate restarts) |
+| startupProbe.successThreshold | int | `1` | Number of consecutive successes required to consider startup complete and enable liveness/readiness |
 
 ### Readiness Probe
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| readinessProbe.enabled | bool | ``true`` | Enable readiness probe |
-| readinessProbe.httpGet.path | string | ``"/api/v1/health"`` | HTTP GET path for readiness probe |
-| readinessProbe.httpGet.port | string | ``"{{ .Values.service.http.targetPort }}"`` | HTTP GET port for readiness probe. Evaluated as a template |
-| readinessProbe.initialDelaySeconds | int | ``5`` | Delay before first check (normal start timing) |
-| readinessProbe.periodSeconds | int | ``5`` | Regular check interval during normal operation |
-| readinessProbe.timeoutSeconds | int | ``3`` | Short timeout to detect unresponsive containers for readiness |
-| readinessProbe.failureThreshold | int | ``5`` | Consecutive failures before marking the container Unready (no restart) |
-| readinessProbe.successThreshold | int | ``1`` | Number of consecutive successes required to mark the container Ready after failures |
+| readinessProbe.enabled | bool | `true` | Enable readiness probe |
+| readinessProbe.httpGet.path | string | `"/api/v1/health"` | HTTP GET path for readiness probe |
+| readinessProbe.httpGet.port | string | `"{{ .Values.service.http.targetPort }}"` | HTTP GET port for readiness probe. Evaluated as a template |
+| readinessProbe.initialDelaySeconds | int | `5` | Delay before first check (normal start timing) |
+| readinessProbe.periodSeconds | int | `5` | Regular check interval during normal operation |
+| readinessProbe.timeoutSeconds | int | `3` | Short timeout to detect unresponsive containers for readiness |
+| readinessProbe.failureThreshold | int | `5` | Consecutive failures before marking the container Unready (no restart) |
+| readinessProbe.successThreshold | int | `1` | Number of consecutive successes required to mark the container Ready after failures |
 
 ### Liveness Probe
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| livenessProbe.enabled | bool | ``true`` | Enable liveness probe |
-| livenessProbe.httpGet.path | string | ``"/api/v1/health"`` | HTTP GET path for liveness probe |
-| livenessProbe.httpGet.port | string | ``"{{ .Values.service.http.targetPort }}"`` | HTTP GET port for liveness probe. Evaluated as a template |
-| livenessProbe.initialDelaySeconds | int | ``5`` | Delay before first check (normal start timing) |
-| livenessProbe.periodSeconds | int | ``10`` | Regular check interval during normal operation |
-| livenessProbe.timeoutSeconds | int | ``3`` | Short timeout to detect hung containers quickly |
-| livenessProbe.failureThreshold | int | ``10`` | Consecutive failures before restarting the container |
-| livenessProbe.successThreshold | int | ``1`` | Typically 1 (usually ignored) |
+| livenessProbe.enabled | bool | `true` | Enable liveness probe |
+| livenessProbe.httpGet.path | string | `"/api/v1/health"` | HTTP GET path for liveness probe |
+| livenessProbe.httpGet.port | string | `"{{ .Values.service.http.targetPort }}"` | HTTP GET port for liveness probe. Evaluated as a template |
+| livenessProbe.initialDelaySeconds | int | `5` | Delay before first check (normal start timing) |
+| livenessProbe.periodSeconds | int | `10` | Regular check interval during normal operation |
+| livenessProbe.timeoutSeconds | int | `3` | Short timeout to detect hung containers quickly |
+| livenessProbe.failureThreshold | int | `10` | Consecutive failures before restarting the container |
+| livenessProbe.successThreshold | int | `1` | Typically 1 (usually ignored) |
 
 ### Init Container Dependencies
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| initContainerDependencies.enabled | bool | ``true`` | Enable init containers that coordinate startup dependencies (for example, wait for database readiness before starting, etc) |
+| initContainerDependencies.enabled | bool | `true` | Enable init containers that coordinate startup dependencies (for example, wait for database readiness before starting, etc) |
 
 ### Init Container Dependencies: Wait For MySQL
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| initContainerDependencies.waitForMySQL.enabled | bool | ``true`` | Enable wait for MySQL init container before starting pipeline optimization and cron |
-| initContainerDependencies.waitForMySQL.image.registry | string | ``""`` | Override default wait for MySQL init container image |
-| initContainerDependencies.waitForMySQL.image.repository | string | ``"mysql"`` | Init container image repository |
-| initContainerDependencies.waitForMySQL.image.tag | string | ``"9"`` | Init container image tag |
-| initContainerDependencies.waitForMySQL.image.digest | string | ``""`` | Init container image digest in the format `sha256:1234abcdef` |
-| initContainerDependencies.waitForMySQL.image.pullPolicy | string | ``"IfNotPresent"`` | imagePullPolicy for the init container |
-| initContainerDependencies.waitForMySQL.securityContext.runAsUser | int | ``101`` | UID the container processes run as (overrides container image default) |
-| initContainerDependencies.waitForMySQL.securityContext.runAsNonRoot | bool | ``true`` | Require the container to run as a non-root UID (prevents starting if UID 0) |
-| initContainerDependencies.waitForMySQL.securityContext.readOnlyRootFilesystem | bool | ``true`` | Mount the container root filesystem read-only to prevent in-place writes or tampering |
-| initContainerDependencies.waitForMySQL.securityContext.capabilities | object | ``{"drop":["ALL"]}`` | Fine-grained Linux kernel privileges to add or drop for the container |
-| initContainerDependencies.waitForMySQL.resources | object | ``{"limits":{"memory":"100Mi"},"requests":{"cpu":"0.5","memory":"50Mi"}}`` | Container requests and limits for different resources like CPU or memory |
-| initContainerDependencies.waitForMySQL.extraEnvVars | list | ``[]`` | Additional environment variables for the init container. The special variable `MYSQL_EXTRA_ARGS` is appended verbatim to the `mysql` readiness check command, and can be used to pass TLS flags when connecting to managed MySQL services such as AWS RDS or Azure Database for MySQL that require certificate verification. Pair with `extraVolumeMounts` to mount the CA certificate into the container. Example (TLS with CA certificate mounted from a volume): extraEnvVars:   - name: MYSQL_EXTRA_ARGS     value: "--ssl-ca=/certs/ca.pem --ssl-mode=VERIFY_IDENTITY" |
-| initContainerDependencies.waitForMySQL.extraVolumeMounts | list | ``[]`` | Additional volume mounts for the init container. Use this to mount CA certificates (e.g. from a Secret or ConfigMap populated by an extraInitContainer) so that `MYSQL_EXTRA_ARGS` can reference them. |
+| initContainerDependencies.waitForMySQL.enabled | bool | `true` | Enable wait for MySQL init container before starting pipeline optimization and cron |
+| initContainerDependencies.waitForMySQL.image.registry | string | `""` | Override default wait for MySQL init container image |
+| initContainerDependencies.waitForMySQL.image.repository | string | `"mysql"` | Init container image repository |
+| initContainerDependencies.waitForMySQL.image.tag | string | `"9"` | Init container image tag |
+| initContainerDependencies.waitForMySQL.image.digest | string | `""` | Init container image digest in the format `sha256:1234abcdef` |
+| initContainerDependencies.waitForMySQL.image.pullPolicy | string | `"IfNotPresent"` | imagePullPolicy for the init container |
+| initContainerDependencies.waitForMySQL.securityContext.runAsUser | int | `101` | UID the container processes run as (overrides container image default) |
+| initContainerDependencies.waitForMySQL.securityContext.runAsNonRoot | bool | `true` | Require the container to run as a non-root UID (prevents starting if UID 0) |
+| initContainerDependencies.waitForMySQL.securityContext.readOnlyRootFilesystem | bool | `true` | Mount the container root filesystem read-only to prevent in-place writes or tampering |
+| initContainerDependencies.waitForMySQL.securityContext.capabilities | object | `{"drop":["ALL"]}` | Fine-grained Linux kernel privileges to add or drop for the container |
+| initContainerDependencies.waitForMySQL.resources | object | `{"limits":{"memory":"100Mi"},"requests":{"cpu":"0.5","memory":"50Mi"}}` | Container requests and limits for different resources like CPU or memory |
+| initContainerDependencies.waitForMySQL.extraEnvVars | list | `[]` | Additional environment variables for the init container. The special variable `MYSQL_EXTRA_ARGS` is appended verbatim to the `mysql` readiness check command, and can be used to pass TLS flags when connecting to managed MySQL services such as AWS RDS or Azure Database for MySQL that require certificate verification. Pair with `extraVolumeMounts` to mount the CA certificate into the container. Example (TLS with CA certificate mounted from a volume): extraEnvVars:   - name: MYSQL_EXTRA_ARGS     value: "--ssl-ca=/certs/ca.pem --ssl-mode=VERIFY_IDENTITY" |
+| initContainerDependencies.waitForMySQL.extraVolumeMounts | list | `[]` | Additional volume mounts for the init container. Use this to mount CA certificates (e.g. from a Secret or ConfigMap populated by an extraInitContainer) so that `MYSQL_EXTRA_ARGS` can reference them. |
 
 ### Extra Deploy
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| extraDeploy | list | ``[]`` | Array of extra objects to deploy with the release |
+| extraDeploy | list | `[]` | Array of extra objects to deploy with the release |
 
 ### Service Account
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| serviceAccount.name | string | ``""`` | Name of an existing ServiceAccount. If not set, a new ServiceAccount is generated based on the release name |
-| serviceAccount.annotations | object | ``{}`` | Additional annotations for the Platform ServiceAccount to generate |
-| serviceAccount.imagePullSecretNames | list | ``[]`` | Names of Secrets containing credentials to pull images from registries |
-| serviceAccount.automountServiceAccountToken | bool | ``false`` | Automount service account token when the server service account is generated |
+| serviceAccount.name | string | `""` | Name of an existing ServiceAccount. If not set, a new ServiceAccount is generated based on the release name |
+| serviceAccount.annotations | object | `{}` | Additional annotations for the Platform ServiceAccount to generate |
+| serviceAccount.imagePullSecretNames | list | `[]` | Names of Secrets containing credentials to pull images from registries |
+| serviceAccount.automountServiceAccountToken | bool | `false` | Automount service account token when the server service account is generated |
 
 ## Licensing
 

--- a/charts/platform/charts/pipeline-optimization/README.md.gotmpl
+++ b/charts/platform/charts/pipeline-optimization/README.md.gotmpl
@@ -82,7 +82,7 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 {{- range .SectionItems }}
-| {{ .Key }} | {{ .Type }} | {{ if .Default }}`{{ .Default }}`{{ else }}`{{ .AutoDefault }}`{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
+| {{ .Key }} | {{ .Type }} | {{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
 {{- end }}
 {{- end }}
 
@@ -93,7 +93,7 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 {{- range . }}
-| {{ .Key }} | {{ .Type }} | {{ if .Default }}`{{ .Default }}`{{ else }}`{{ .AutoDefault }}`{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
+| {{ .Key }} | {{ .Type }} | {{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
 {{- end }}
 {{- end }}
 

--- a/charts/platform/charts/portal-web/README.md
+++ b/charts/platform/charts/portal-web/README.md
@@ -82,180 +82,180 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| global.platformExternalDomain | string | ``"example.com"`` | Domain where Seqera Platform listens |
-| global.platformServiceAddress | string | ``""`` | Seqera Platform Service name: can be the internal Kubernetes hostname or an external ingress hostname. Evaluated as a template. Required when deploying this subchart standalone. When deploying as part of the parent `platform` umbrella chart, this value is inherited from the parent chart's `global` section |
-| global.platformServicePort | int | ``nil`` | Seqera Platform Service port. Required when deploying this subchart standalone. When deploying as part of the parent `platform` umbrella chart, this value is inherited from the parent chart's `global` section |
-| global.agentBackendDomain | string | ``"{{ printf \"ai-api.%s\" .Values.global.platformExternalDomain }}"`` | Domain where the Agent Backend service listens. Evaluated as a template |
-| global.portalWebDomain | string | ``"{{ printf \"ai.%s\" .Values.global.platformExternalDomain }}"`` | Domain where the Portal Web frontend listens. Evaluated as a template |
+| global.platformExternalDomain | string | `"example.com"` | Domain where Seqera Platform listens |
+| global.platformServiceAddress | string | `""` | Seqera Platform Service name: can be the internal Kubernetes hostname or an external ingress hostname. Evaluated as a template. Required when deploying this subchart standalone. When deploying as part of the parent `platform` umbrella chart, this value is inherited from the parent chart's `global` section |
+| global.platformServicePort | int | `nil` | Seqera Platform Service port. Required when deploying this subchart standalone. When deploying as part of the parent `platform` umbrella chart, this value is inherited from the parent chart's `global` section |
+| global.agentBackendDomain | string | `"{{ printf \"ai-api.%s\" .Values.global.platformExternalDomain }}"` | Domain where the Agent Backend service listens. Evaluated as a template |
+| global.portalWebDomain | string | `"{{ printf \"ai.%s\" .Values.global.platformExternalDomain }}"` | Domain where the Portal Web frontend listens. Evaluated as a template |
 
 ### Global: Ingress defaults
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| global.ingress.enabled | bool | ``false`` | Enable Ingress for this chart. OR'd with the chart's local `ingress.enabled` so setting this once at the parent enables all subchart Ingresses. |
-| global.ingress.path | string | ``"/"`` | Default path applied to ingress rules when `ingress.path` is not set. AWS ALB users should override to `/*`. |
-| global.ingress.defaultPathType | string | ``"Prefix"`` | Default path type applied to ingress rules when `ingress.defaultPathType` is not set. `Prefix` works for nginx, traefik, AWS ALB, and most modern controllers. |
-| global.ingress.ingressClassName | string | ``""`` | Default ingress class name applied when `ingress.ingressClassName` is not set |
-| global.ingress.annotations | object | ``{}`` | Annotations merged into the Ingress. Local `ingress.annotations` wins on key collision. Evaluated as a template |
-| global.ingress.extraLabels | object | ``{}`` | Extra labels merged into the Ingress. Local `ingress.extraLabels` wins on key collision. Evaluated as a template |
-| global.ingress.tls | list | ``[]`` | TLS entries concatenated with the local `ingress.tls`. Evaluated as a template |
+| global.ingress.enabled | bool | `false` | Enable Ingress for this chart. OR'd with the chart's local `ingress.enabled` so setting this once at the parent enables all subchart Ingresses. |
+| global.ingress.path | string | `"/"` | Default path applied to ingress rules when `ingress.path` is not set. AWS ALB users should override to `/*`. |
+| global.ingress.defaultPathType | string | `"Prefix"` | Default path type applied to ingress rules when `ingress.defaultPathType` is not set. `Prefix` works for nginx, traefik, AWS ALB, and most modern controllers. |
+| global.ingress.ingressClassName | string | `""` | Default ingress class name applied when `ingress.ingressClassName` is not set |
+| global.ingress.annotations | object | `{}` | Annotations merged into the Ingress. Local `ingress.annotations` wins on key collision. Evaluated as a template |
+| global.ingress.extraLabels | object | `{}` | Extra labels merged into the Ingress. Local `ingress.extraLabels` wins on key collision. Evaluated as a template |
+| global.ingress.tls | list | `[]` | TLS entries concatenated with the local `ingress.tls`. Evaluated as a template |
 
 ### Global: Image credentials
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| global.imageCredentials | list | ``[]`` | Optional credentials to log in and fetch images from a private registry. These credentials are shared with all the subcharts automatically |
-| global.imageCredentialsSecrets | list | ``[]`` | Optional list of existing Secrets containing image pull credentials to use for pulling images from private registries. These Secrets are shared with all the subcharts automatically |
+| global.imageCredentials | list | `[]` | Optional credentials to log in and fetch images from a private registry. These credentials are shared with all the subcharts automatically |
+| global.imageCredentialsSecrets | list | `[]` | Optional list of existing Secrets containing image pull credentials to use for pulling images from private registries. These Secrets are shared with all the subcharts automatically |
 
 ### Image
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| image.registry | string | ``""`` | Container image registry |
-| image.repository | string | ``"ai/portal/web"`` | Container image repository |
-| image.tag | string | ``"{{ .chart.AppVersion }}"`` | Container image tag |
-| image.digest | string | ``""`` | Container image digest in the format `sha256:1234abcdef` |
-| image.pullPolicy | string | ``"IfNotPresent"`` | imagePullPolicy for the container Ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images |
-| image.pullSecrets | list | ``[]`` | List of imagePullSecrets Secrets must be created in the same namespace, for example using the .extraDeploy array Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ |
+| image.registry | string | `""` | Container image registry |
+| image.repository | string | `"ai/portal/web"` | Container image repository |
+| image.tag | string | `"{{ .chart.AppVersion }}"` | Container image tag |
+| image.digest | string | `""` | Container image digest in the format `sha256:1234abcdef` |
+| image.pullPolicy | string | `"IfNotPresent"` | imagePullPolicy for the container Ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images |
+| image.pullSecrets | list | `[]` | List of imagePullSecrets Secrets must be created in the same namespace, for example using the .extraDeploy array Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ |
 
 ### Service
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| service.type | string | ``"ClusterIP"`` | Service type. Note: ingresses using AWS ALB require the service to be NodePort |
-| service.http.name | string | ``"http"`` | Service name to use |
-| service.http.port | int | ``80`` | Service port |
-| service.http.targetPort | int | ``3000`` | Port on the pod/container that the Service forwards traffic to (can be a number or named port, distinct from the Service's external port) |
-| service.http.nodePort | string | ``nil`` | Service node port, only used when service.type is Nodeport or LoadBalancer Choose port between 30000-32767, unless the cluster was configured differently than default |
-| service.extraServices | list | ``[]`` | Other services that should live in the Service object https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service |
-| service.extraOptions | object | ``{}`` | Extra Service options to place under .spec (for example, clusterIP, loadBalancerIP, externalTrafficPolicy, externalIPs). Evaluated as a template |
+| service.type | string | `"ClusterIP"` | Service type. Note: ingresses using AWS ALB require the service to be NodePort |
+| service.http.name | string | `"http"` | Service name to use |
+| service.http.port | int | `80` | Service port |
+| service.http.targetPort | int | `3000` | Port on the pod/container that the Service forwards traffic to (can be a number or named port, distinct from the Service's external port) |
+| service.http.nodePort | string | `nil` | Service node port, only used when service.type is Nodeport or LoadBalancer Choose port between 30000-32767, unless the cluster was configured differently than default |
+| service.extraServices | list | `[]` | Other services that should live in the Service object https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service |
+| service.extraOptions | object | `{}` | Extra Service options to place under .spec (for example, clusterIP, loadBalancerIP, externalTrafficPolicy, externalIPs). Evaluated as a template |
 
 ### Deployment
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| tmpDirSizeLimit | string | ``"500Mi"`` | Size limit for the /tmp emptyDir volume |
-| nextjsCacheSizeLimit | string | ``"500Mi"`` | Size limit for the /app/.next/cache emptyDir volume |
-| initContainers | list | ``[]`` | Additional init containers for the pod. Evaluated as a template |
-| command | list | ``[]`` | Override default container command (useful when using custom images) |
-| args | list | ``[]`` | Override default container args (useful when using custom images) |
-| podLabels | object | ``{}`` | Additional labels for the pod. Evaluated as a template |
-| podAnnotations | object | ``{}`` | Additional annotations for the pod. Evaluated as a template |
-| extraOptionsSpec | object | ``{}`` | Extra options to place under .spec (e.g. replicas, strategy, revisionHistoryLimit, etc). Evaluated as a template |
-| extraOptionsTemplateSpec | object | ``{}`` | Extra options to place under .spec.template.spec (e.g. nodeSelector, affinity, restartPolicy, etc). Evaluated as a template |
+| tmpDirSizeLimit | string | `"500Mi"` | Size limit for the /tmp emptyDir volume |
+| nextjsCacheSizeLimit | string | `"500Mi"` | Size limit for the /app/.next/cache emptyDir volume |
+| initContainers | list | `[]` | Additional init containers for the pod. Evaluated as a template |
+| command | list | `[]` | Override default container command (useful when using custom images) |
+| args | list | `[]` | Override default container args (useful when using custom images) |
+| podLabels | object | `{}` | Additional labels for the pod. Evaluated as a template |
+| podAnnotations | object | `{}` | Additional annotations for the pod. Evaluated as a template |
+| extraOptionsSpec | object | `{}` | Extra options to place under .spec (e.g. replicas, strategy, revisionHistoryLimit, etc). Evaluated as a template |
+| extraOptionsTemplateSpec | object | `{}` | Extra options to place under .spec.template.spec (e.g. nodeSelector, affinity, restartPolicy, etc). Evaluated as a template |
 
 ### Deployment: Environment
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| extraEnvVars | list | ``[]`` | Extra environment variables |
-| extraEnvVarsCMs | list | ``[]`` | List of ConfigMaps containing extra env vars |
-| extraEnvVarsSecrets | list | ``[]`` | List of Secrets containing extra env vars |
-| extraVolumes | list | ``[]`` | List of volumes to add to the deployment (evaluated as template). Requires setting `extraVolumeMounts` |
-| extraVolumeMounts | list | ``[]`` | List of volume mounts to add to the container (evaluated as template). Normally used with `extraVolumes` |
+| extraEnvVars | list | `[]` | Extra environment variables |
+| extraEnvVarsCMs | list | `[]` | List of ConfigMaps containing extra env vars |
+| extraEnvVarsSecrets | list | `[]` | List of Secrets containing extra env vars |
+| extraVolumes | list | `[]` | List of volumes to add to the deployment (evaluated as template). Requires setting `extraVolumeMounts` |
+| extraVolumeMounts | list | `[]` | List of volume mounts to add to the container (evaluated as template). Normally used with `extraVolumes` |
 
 ### Security Context: Pod
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| podSecurityContext.enabled | bool | ``true`` | Enable pod Security Context |
-| podSecurityContext.fsGroup | int | ``1001`` | Sets the GID that Kubernetes will apply to mounted volumes and created files so processes in the pod can share group-owned access |
+| podSecurityContext.enabled | bool | `true` | Enable pod Security Context |
+| podSecurityContext.fsGroup | int | `1001` | Sets the GID that Kubernetes will apply to mounted volumes and created files so processes in the pod can share group-owned access |
 
 ### Security Context: Container
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| containerSecurityContext.enabled | bool | ``true`` | Enable container Security Context |
-| containerSecurityContext.runAsUser | int | ``1001`` | UID the container processes run as (overrides container image default) |
-| containerSecurityContext.runAsNonRoot | bool | ``true`` | Boolean that requires the container to run as a non-root UID (prevents starting if UID 0) |
-| containerSecurityContext.readOnlyRootFilesystem | bool | ``true`` | Mounts the container root filesystem read-only to prevent in-place writes or tampering |
-| containerSecurityContext.capabilities | object | ``{"drop":["ALL"]}`` | Fine-grained Linux kernel privileges to add or drop for the container |
+| containerSecurityContext.enabled | bool | `true` | Enable container Security Context |
+| containerSecurityContext.runAsUser | int | `1001` | UID the container processes run as (overrides container image default) |
+| containerSecurityContext.runAsNonRoot | bool | `true` | Boolean that requires the container to run as a non-root UID (prevents starting if UID 0) |
+| containerSecurityContext.readOnlyRootFilesystem | bool | `true` | Mounts the container root filesystem read-only to prevent in-place writes or tampering |
+| containerSecurityContext.capabilities | object | `{"drop":["ALL"]}` | Fine-grained Linux kernel privileges to add or drop for the container |
 
 ### Resources
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| resources | object | ``{"limits":{"memory":"500Mi"},"requests":{"cpu":"100m","memory":"500Mi"}}`` | Container requests and limits for different resources like CPU or memory |
+| resources | object | `{"limits":{"memory":"500Mi"},"requests":{"cpu":"100m","memory":"500Mi"}}` | Container requests and limits for different resources like CPU or memory |
 
 ### Probes: Startup
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| startupProbe.enabled | bool | ``false`` | Enable startup probe |
-| startupProbe.httpGet.path | string | ``"/"`` | HTTP GET path for startup probe |
-| startupProbe.httpGet.port | string | ``"{{ .Values.service.http.targetPort }}"`` | HTTP GET port for startup probe. Evaluated as a template |
-| startupProbe.initialDelaySeconds | int | ``5`` | Longer initial wait to accommodate slow-starting apps |
-| startupProbe.periodSeconds | int | ``10`` | Often set longer to avoid frequent checks while starting |
-| startupProbe.timeoutSeconds | int | ``3`` | Can be longer to allow slow initialization responses |
-| startupProbe.failureThreshold | int | ``5`` | Consecutive failures during startup before killing the container (instead of immediate restarts) |
-| startupProbe.successThreshold | int | ``1`` | Number of consecutive successes required to consider startup complete and enable liveness/readiness |
+| startupProbe.enabled | bool | `false` | Enable startup probe |
+| startupProbe.httpGet.path | string | `"/"` | HTTP GET path for startup probe |
+| startupProbe.httpGet.port | string | `"{{ .Values.service.http.targetPort }}"` | HTTP GET port for startup probe. Evaluated as a template |
+| startupProbe.initialDelaySeconds | int | `5` | Longer initial wait to accommodate slow-starting apps |
+| startupProbe.periodSeconds | int | `10` | Often set longer to avoid frequent checks while starting |
+| startupProbe.timeoutSeconds | int | `3` | Can be longer to allow slow initialization responses |
+| startupProbe.failureThreshold | int | `5` | Consecutive failures during startup before killing the container (instead of immediate restarts) |
+| startupProbe.successThreshold | int | `1` | Number of consecutive successes required to consider startup complete and enable liveness/readiness |
 
 ### Probes: Readiness
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| readinessProbe.enabled | bool | ``true`` | Enable readiness probe |
-| readinessProbe.httpGet.path | string | ``"/"`` | HTTP GET path for readiness probe |
-| readinessProbe.httpGet.port | string | ``"{{ .Values.service.http.targetPort }}"`` | HTTP GET port for readiness probe. Evaluated as a template |
-| readinessProbe.initialDelaySeconds | int | ``10`` | Delay before first check |
-| readinessProbe.periodSeconds | int | ``5`` | Regular check interval during normal operation |
-| readinessProbe.timeoutSeconds | int | ``3`` | Short timeout to detect unresponsive containers for readiness |
-| readinessProbe.failureThreshold | int | ``3`` | Consecutive failures before marking the container Unready (no restart) |
-| readinessProbe.successThreshold | int | ``1`` | Number of consecutive successes required to mark the container Ready after failures |
+| readinessProbe.enabled | bool | `true` | Enable readiness probe |
+| readinessProbe.httpGet.path | string | `"/"` | HTTP GET path for readiness probe |
+| readinessProbe.httpGet.port | string | `"{{ .Values.service.http.targetPort }}"` | HTTP GET port for readiness probe. Evaluated as a template |
+| readinessProbe.initialDelaySeconds | int | `10` | Delay before first check |
+| readinessProbe.periodSeconds | int | `5` | Regular check interval during normal operation |
+| readinessProbe.timeoutSeconds | int | `3` | Short timeout to detect unresponsive containers for readiness |
+| readinessProbe.failureThreshold | int | `3` | Consecutive failures before marking the container Unready (no restart) |
+| readinessProbe.successThreshold | int | `1` | Number of consecutive successes required to mark the container Ready after failures |
 
 ### Probes: Liveness
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| livenessProbe.enabled | bool | ``true`` | Enable liveness probe |
-| livenessProbe.httpGet.path | string | ``"/"`` | HTTP GET path for liveness probe |
-| livenessProbe.httpGet.port | string | ``"{{ .Values.service.http.targetPort }}"`` | HTTP GET port for liveness probe. Evaluated as a template |
-| livenessProbe.initialDelaySeconds | int | ``30`` | Delay before first check |
-| livenessProbe.periodSeconds | int | ``10`` | Regular check interval during normal operation |
-| livenessProbe.timeoutSeconds | int | ``5`` | Short timeout to detect hung containers quickly |
-| livenessProbe.failureThreshold | int | ``3`` | Consecutive failures before restarting the container |
-| livenessProbe.successThreshold | int | ``1`` | Typically 1 (usually ignored) |
+| livenessProbe.enabled | bool | `true` | Enable liveness probe |
+| livenessProbe.httpGet.path | string | `"/"` | HTTP GET path for liveness probe |
+| livenessProbe.httpGet.port | string | `"{{ .Values.service.http.targetPort }}"` | HTTP GET port for liveness probe. Evaluated as a template |
+| livenessProbe.initialDelaySeconds | int | `30` | Delay before first check |
+| livenessProbe.periodSeconds | int | `10` | Regular check interval during normal operation |
+| livenessProbe.timeoutSeconds | int | `5` | Short timeout to detect hung containers quickly |
+| livenessProbe.failureThreshold | int | `3` | Consecutive failures before restarting the container |
+| livenessProbe.successThreshold | int | `1` | Typically 1 (usually ignored) |
 
 ### Service Account
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| serviceAccount | object | ``{"annotations":{},"automountServiceAccountToken":false,"imagePullSecretNames":[],"name":""}`` | Service account configuration |
-| serviceAccount.name | string | ``""`` | Service account name |
-| serviceAccount.annotations | object | ``{}`` | Service account annotations |
-| serviceAccount.imagePullSecretNames | list | ``[]`` | Names of Secrets containing credentials to pull images from registries |
-| serviceAccount.automountServiceAccountToken | bool | ``false`` | Automatically mount service account token |
+| serviceAccount | object | `{"annotations":{},"automountServiceAccountToken":false,"imagePullSecretNames":[],"name":""}` | Service account configuration |
+| serviceAccount.name | string | `""` | Service account name |
+| serviceAccount.annotations | object | `{}` | Service account annotations |
+| serviceAccount.imagePullSecretNames | list | `[]` | Names of Secrets containing credentials to pull images from registries |
+| serviceAccount.automountServiceAccountToken | bool | `false` | Automatically mount service account token |
 
 ### Ingress
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| ingress.enabled | bool | ``false`` | Enable ingress for Portal Web |
-| ingress.path | string | ``""`` | Path for the main ingress rule. When empty, falls back to `global.ingress.path` |
-| ingress.defaultPathType | string | ``""`` | Default path type for the Ingress. When empty, falls back to `global.ingress.defaultPathType` |
-| ingress.defaultBackend | object | ``{}`` | Configure the default service for the ingress (evaluated as template) Important: make sure only one defaultBackend is defined across the k8s cluster: if the ingress doesn't reconcile successfully, 'describe ingress <name>' will report problems |
-| ingress.extraHosts | list | ``[]`` | Additional hosts you want to include. Evaluated as a template |
-| ingress.annotations | object | ``{}`` | Ingress annotations specific to your load balancer. Evaluated as a template |
-| ingress.extraLabels | object | ``{}`` | Additional labels for the ingress object. Evaluated as a template |
-| ingress.ingressClassName | string | ``""`` | Name of the ingress class (replaces the deprecated annotation `kubernetes.io/ingress.class`). When empty, falls back to `global.ingress.ingressClassName` |
-| ingress.tls | list | ``[]`` | TLS configuration. Evaluated as a template |
+| ingress.enabled | bool | `false` | Enable ingress for Portal Web |
+| ingress.path | string | `""` | Path for the main ingress rule. When empty, falls back to `global.ingress.path` |
+| ingress.defaultPathType | string | `""` | Default path type for the Ingress. When empty, falls back to `global.ingress.defaultPathType` |
+| ingress.defaultBackend | object | `{}` | Configure the default service for the ingress (evaluated as template) Important: make sure only one defaultBackend is defined across the k8s cluster: if the ingress doesn't reconcile successfully, 'describe ingress <name>' will report problems |
+| ingress.extraHosts | list | `[]` | Additional hosts you want to include. Evaluated as a template |
+| ingress.annotations | object | `{}` | Ingress annotations specific to your load balancer. Evaluated as a template |
+| ingress.extraLabels | object | `{}` | Additional labels for the ingress object. Evaluated as a template |
+| ingress.ingressClassName | string | `""` | Name of the ingress class (replaces the deprecated annotation `kubernetes.io/ingress.class`). When empty, falls back to `global.ingress.ingressClassName` |
+| ingress.tls | list | `[]` | TLS configuration. Evaluated as a template |
 
 ### Extra Deploy
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| extraDeploy | list | ``[]`` | Array of extra objects to deploy with the release |
+| extraDeploy | list | `[]` | Array of extra objects to deploy with the release |
 
 ### Common Metadata
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| commonAnnotations | object | ``{}`` | Annotations to add to all deployed objects |
-| commonLabels | object | ``{}`` | Labels to add to all deployed objects |
-| secretLabels | object | ``{}`` | Additional labels for the Secret objects. Evaluated as a template |
-| secretAnnotations | object | ``{}`` | Additional annotations for the Secret objects. Evaluated as a template |
-| configMapLabels | object | ``{}`` | Additional labels for the ConfigMap objects. Evaluated as a template |
-| configMapAnnotations | object | ``{}`` | Additional annotations for the ConfigMap objects. Evaluated as a template |
+| commonAnnotations | object | `{}` | Annotations to add to all deployed objects |
+| commonLabels | object | `{}` | Labels to add to all deployed objects |
+| secretLabels | object | `{}` | Additional labels for the Secret objects. Evaluated as a template |
+| secretAnnotations | object | `{}` | Additional annotations for the Secret objects. Evaluated as a template |
+| configMapLabels | object | `{}` | Additional labels for the ConfigMap objects. Evaluated as a template |
+| configMapAnnotations | object | `{}` | Additional annotations for the ConfigMap objects. Evaluated as a template |
 
 ## Licensing
 

--- a/charts/platform/charts/portal-web/README.md.gotmpl
+++ b/charts/platform/charts/portal-web/README.md.gotmpl
@@ -79,7 +79,7 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 {{- range .SectionItems }}
-| {{ .Key }} | {{ .Type }} | {{ if .Default }}`{{ .Default }}`{{ else }}`{{ .AutoDefault }}`{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
+| {{ .Key }} | {{ .Type }} | {{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
 {{- end }}
 {{- end }}
 
@@ -90,7 +90,7 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 {{- range . }}
-| {{ .Key }} | {{ .Type }} | {{ if .Default }}`{{ .Default }}`{{ else }}`{{ .AutoDefault }}`{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
+| {{ .Key }} | {{ .Type }} | {{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
 {{- end }}
 {{- end }}
 

--- a/charts/platform/charts/studios/README.md
+++ b/charts/platform/charts/studios/README.md
@@ -88,257 +88,257 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| global.platformExternalDomain | string | ``"example.com"`` | Domain where Seqera Platform listens |
-| global.platformServiceAddress | string | ``""`` | Seqera Platform Service name: can be the internal Kubernetes hostname or an external ingress hostname. Evaluated as a template. Required when deploying this subchart standalone. When deploying as part of the parent `platform` umbrella chart, this value is inherited from the parent chart's `global` section |
-| global.platformServicePort | int | ``nil`` | Seqera Platform Service port. Required when deploying this subchart standalone. When deploying as part of the parent `platform` umbrella chart, this value is inherited from the parent chart's `global` section |
+| global.platformExternalDomain | string | `"example.com"` | Domain where Seqera Platform listens |
+| global.platformServiceAddress | string | `""` | Seqera Platform Service name: can be the internal Kubernetes hostname or an external ingress hostname. Evaluated as a template. Required when deploying this subchart standalone. When deploying as part of the parent `platform` umbrella chart, this value is inherited from the parent chart's `global` section |
+| global.platformServicePort | int | `nil` | Seqera Platform Service port. Required when deploying this subchart standalone. When deploying as part of the parent `platform` umbrella chart, this value is inherited from the parent chart's `global` section |
 
 ### Global: Studios
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| global.studiosDomain | string | ``"{{ printf \"studios.%s\" .Values.global.platformExternalDomain }}"`` | Domain where the Studios service listens. Make sure the TLS certificate covers this and its wildcard subdomains. Evaluated as a template |
-| global.studiosConnectionUrl | string | ``"{{ printf \"https://connect.%s\" (tpl .Values.global.studiosDomain $) }}"`` | Base URL for Studios connections: can be any value, since each session will use a unique subdomain under `.global.studiosDomain` anyway to connect. Evaluated as a template |
+| global.studiosDomain | string | `"{{ printf \"studios.%s\" .Values.global.platformExternalDomain }}"` | Domain where the Studios service listens. Make sure the TLS certificate covers this and its wildcard subdomains. Evaluated as a template |
+| global.studiosConnectionUrl | string | `"{{ printf \"https://connect.%s\" (tpl .Values.global.studiosDomain $) }}"` | Base URL for Studios connections: can be any value, since each session will use a unique subdomain under `.global.studiosDomain` anyway to connect. Evaluated as a template |
 
 ### Global: Ingress
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| global.ingress.enabled | bool | ``false`` | Enable Ingress for this chart. OR'd with the chart's local `ingress.enabled` so setting this once at the parent enables all subchart Ingresses. |
-| global.ingress.path | string | ``"/"`` | Default path applied to ingress rules when `ingress.path` is not set. AWS ALB users should override to `/*`. |
-| global.ingress.defaultPathType | string | ``"Prefix"`` | Default path type applied to ingress rules when `ingress.defaultPathType` is not set. `Prefix` works for nginx, traefik, AWS ALB, and most modern controllers. |
-| global.ingress.ingressClassName | string | ``""`` | Default ingress class name applied when `ingress.ingressClassName` is not set |
-| global.ingress.annotations | object | ``{}`` | Annotations merged into the Ingress. Local `ingress.annotations` wins on key collision. Evaluated as a template |
-| global.ingress.extraLabels | object | ``{}`` | Extra labels merged into the Ingress. Local `ingress.extraLabels` wins on key collision. Evaluated as a template |
-| global.ingress.tls | list | ``[]`` | TLS entries concatenated with the local `ingress.tls`. Evaluated as a template |
+| global.ingress.enabled | bool | `false` | Enable Ingress for this chart. OR'd with the chart's local `ingress.enabled` so setting this once at the parent enables all subchart Ingresses. |
+| global.ingress.path | string | `"/"` | Default path applied to ingress rules when `ingress.path` is not set. AWS ALB users should override to `/*`. |
+| global.ingress.defaultPathType | string | `"Prefix"` | Default path type applied to ingress rules when `ingress.defaultPathType` is not set. `Prefix` works for nginx, traefik, AWS ALB, and most modern controllers. |
+| global.ingress.ingressClassName | string | `""` | Default ingress class name applied when `ingress.ingressClassName` is not set |
+| global.ingress.annotations | object | `{}` | Annotations merged into the Ingress. Local `ingress.annotations` wins on key collision. Evaluated as a template |
+| global.ingress.extraLabels | object | `{}` | Extra labels merged into the Ingress. Local `ingress.extraLabels` wins on key collision. Evaluated as a template |
+| global.ingress.tls | list | `[]` | TLS entries concatenated with the local `ingress.tls`. Evaluated as a template |
 
 ### Global: Image Credentials
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| global.imageCredentials | list | ``[]`` | Optional credentials to log in and fetch images from a private registry. These credentials are shared with all the subcharts automatically |
-| global.imageCredentialsSecrets | list | ``[]`` | Optional list of existing Secrets containing image pull credentials to use for pulling images from private registries. These Secrets are shared with all the subcharts automatically |
+| global.imageCredentials | list | `[]` | Optional credentials to log in and fetch images from a private registry. These credentials are shared with all the subcharts automatically |
+| global.imageCredentialsSecrets | list | `[]` | Optional list of existing Secrets containing image pull credentials to use for pulling images from private registries. These Secrets are shared with all the subcharts automatically |
 
 ### Redis
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| redis.host | string | ``""`` | Redis hostname |
-| redis.port | int | ``6379`` | Redis port |
-| redis.database | int | ``0`` | Redis database number |
-| redis.password | string | ``""`` | Redis password if the installation requires it |
-| redis.existingSecretName | string | ``""`` | Name of an existing Secret containing credentials for Redis, as an alternative to the password field. Note: the Secret must already exist in the same namespace at the time of deployment |
-| redis.existingSecretKey | string | ``"CONNECT_REDIS_PASSWORD"`` | Key in the existing Secret containing the password for Redis |
-| redis.enableTls | bool | ``false`` | Enable TLS when connecting to Redis |
-| redis.prefix | string | ``"connect:session"`` | Key prefix to use when storing Studios sessions in Redis |
+| redis.host | string | `""` | Redis hostname |
+| redis.port | int | `6379` | Redis port |
+| redis.database | int | `0` | Redis database number |
+| redis.password | string | `""` | Redis password if the installation requires it |
+| redis.existingSecretName | string | `""` | Name of an existing Secret containing credentials for Redis, as an alternative to the password field. Note: the Secret must already exist in the same namespace at the time of deployment |
+| redis.existingSecretKey | string | `"CONNECT_REDIS_PASSWORD"` | Key in the existing Secret containing the password for Redis |
+| redis.enableTls | bool | `false` | Enable TLS when connecting to Redis |
+| redis.prefix | string | `"connect:session"` | Key prefix to use when storing Studios sessions in Redis |
 
 ### Proxy: Image
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| proxy.image.registry | string | ``""`` | Proxy container image registry |
-| proxy.image.repository | string | ``"enterprise/studios/proxy"`` | Proxy container image repository |
-| proxy.image.tag | string | ``"{{ .chart.AppVersion }}"`` | Proxy container image tag |
-| proxy.image.digest | string | ``""`` | Proxy container image digest in the format `sha256:1234abcdef` |
-| proxy.image.pullPolicy | string | ``"IfNotPresent"`` | imagePullPolicy for the Proxy container Ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images |
-| proxy.image.pullSecrets | list | ``[]`` | List of imagePullSecrets Secrets must be created in the same namespace, for example using the .extraDeploy array Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ |
+| proxy.image.registry | string | `""` | Proxy container image registry |
+| proxy.image.repository | string | `"enterprise/studios/proxy"` | Proxy container image repository |
+| proxy.image.tag | string | `"{{ .chart.AppVersion }}"` | Proxy container image tag |
+| proxy.image.digest | string | `""` | Proxy container image digest in the format `sha256:1234abcdef` |
+| proxy.image.pullPolicy | string | `"IfNotPresent"` | imagePullPolicy for the Proxy container Ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images |
+| proxy.image.pullSecrets | list | `[]` | List of imagePullSecrets Secrets must be created in the same namespace, for example using the .extraDeploy array Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ |
 
 ### Proxy: OIDC
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| proxy.oidcClientRegistrationToken | string | ``""`` | Initial access token to share with Seqera Platform to restrict registration requests to only authorized OIDC clients. The token can be provided as a string of random chars or as an external k8s Secret: in the latter case, a key can also be provided. If neither a string nor a Secret is provided, the chart will generate a random token WARNING: Always explicitly set this value or use an existing secret when using Kustomize. Auto-generated random values are incompatible with Kustomize. When upgrading releases via Kustomize, Helm cannot query the cluster to check if a secret already exists, causing it to regenerate a new random value on each upgrade |
-| proxy.oidcClientRegistrationTokenSecretName | string | ``""`` | Name of an existing Secret containing the OIDC client registration token as an alternative to the oidcClientRegistrationToken field. Note: the Secret must already exist in the same namespace at the time of deployment |
-| proxy.oidcClientRegistrationTokenSecretKey | string | ``"CONNECT_OIDC_CLIENT_REGISTRATION_TOKEN"`` | Key in the existing Secret containing the OIDC client registration token |
+| proxy.oidcClientRegistrationToken | string | `""` | Initial access token to share with Seqera Platform to restrict registration requests to only authorized OIDC clients. The token can be provided as a string of random chars or as an external k8s Secret: in the latter case, a key can also be provided. If neither a string nor a Secret is provided, the chart will generate a random token WARNING: Always explicitly set this value or use an existing secret when using Kustomize. Auto-generated random values are incompatible with Kustomize. When upgrading releases via Kustomize, Helm cannot query the cluster to check if a secret already exists, causing it to regenerate a new random value on each upgrade |
+| proxy.oidcClientRegistrationTokenSecretName | string | `""` | Name of an existing Secret containing the OIDC client registration token as an alternative to the oidcClientRegistrationToken field. Note: the Secret must already exist in the same namespace at the time of deployment |
+| proxy.oidcClientRegistrationTokenSecretKey | string | `"CONNECT_OIDC_CLIENT_REGISTRATION_TOKEN"` | Key in the existing Secret containing the OIDC client registration token |
 
 ### Proxy
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| proxy.localCacheTTL | string | ``"2m"`` | TTL for local cache of Redis keys used for resiliency against Redis failures |
+| proxy.localCacheTTL | string | `"2m"` | TTL for local cache of Redis keys used for resiliency against Redis failures |
 
 ### Proxy: Service
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| proxy.service.type | string | ``"ClusterIP"`` | Proxy Service type. Note: ingresses using AWS ALB require the service to be NodePort |
-| proxy.service.http.name | string | ``"http"`` | Service name to use |
-| proxy.service.http.port | int | ``80`` | Service port |
-| proxy.service.http.targetPort | int | ``8081`` | Port on the pod/container that the Service forwards traffic to (can be a number or named port, distinct from the Service's external port) |
-| proxy.service.http.nodePort | string | ``nil`` | Service node port, only used when service.type is Nodeport or LoadBalancer Choose port between 30000-32767, unless the cluster was configured differently than default |
-| proxy.service.extraServices | list | ``[]`` | Other services that should live in the Service object https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service |
-| proxy.service.extraOptions | object | ``{}`` | Extra Service options to place under .spec (for example, clusterIP, loadBalancerIP, externalTrafficPolicy, externalIPs). Evaluated as a template |
-| proxy.serviceLabels | object | ``{}`` | Additional labels for the Service objects. Evaluated as a template |
-| proxy.serviceAnnotations | object | ``{}`` | Additional annotations for the Service objects. Evaluated as a template |
+| proxy.service.type | string | `"ClusterIP"` | Proxy Service type. Note: ingresses using AWS ALB require the service to be NodePort |
+| proxy.service.http.name | string | `"http"` | Service name to use |
+| proxy.service.http.port | int | `80` | Service port |
+| proxy.service.http.targetPort | int | `8081` | Port on the pod/container that the Service forwards traffic to (can be a number or named port, distinct from the Service's external port) |
+| proxy.service.http.nodePort | string | `nil` | Service node port, only used when service.type is Nodeport or LoadBalancer Choose port between 30000-32767, unless the cluster was configured differently than default |
+| proxy.service.extraServices | list | `[]` | Other services that should live in the Service object https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service |
+| proxy.service.extraOptions | object | `{}` | Extra Service options to place under .spec (for example, clusterIP, loadBalancerIP, externalTrafficPolicy, externalIPs). Evaluated as a template |
+| proxy.serviceLabels | object | `{}` | Additional labels for the Service objects. Evaluated as a template |
+| proxy.serviceAnnotations | object | `{}` | Additional annotations for the Service objects. Evaluated as a template |
 
 ### Proxy: Pod
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| proxy.initContainers | list | ``[]`` | Additional init containers for the proxy pod. Evaluated as a template |
-| proxy.command | list | ``[]`` | Override default container command (useful when using custom images) |
-| proxy.args | list | ``[]`` | Override default container args (useful when using custom images) |
-| proxy.podLabels | object | ``{}`` | Additional labels for the proxy pod. Evaluated as a template |
-| proxy.podAnnotations | object | ``{}`` | Additional annotations for the proxy pod. Evaluated as a template |
-| proxy.extraVolumes | list | ``[]`` | List of volumes to add to the deployment (evaluated as template). Requires setting `extraVolumeMounts` |
-| proxy.extraVolumeMounts | list | ``[]`` | List of volume mounts to add to the container (evaluated as template). Normally used with `extraVolumes` |
-| proxy.extraOptionsSpec | object | ``{"replicas":2}`` | Extra options to place under .spec (e.g. replicas, strategy, revisionHistoryLimit, etc). Evaluated as a template |
-| proxy.extraOptionsTemplateSpec | object | ``{}`` | Extra options to place under .spec.template.spec (e.g. nodeSelector, affinity, restartPolicy, etc). Evaluated as a template |
+| proxy.initContainers | list | `[]` | Additional init containers for the proxy pod. Evaluated as a template |
+| proxy.command | list | `[]` | Override default container command (useful when using custom images) |
+| proxy.args | list | `[]` | Override default container args (useful when using custom images) |
+| proxy.podLabels | object | `{}` | Additional labels for the proxy pod. Evaluated as a template |
+| proxy.podAnnotations | object | `{}` | Additional annotations for the proxy pod. Evaluated as a template |
+| proxy.extraVolumes | list | `[]` | List of volumes to add to the deployment (evaluated as template). Requires setting `extraVolumeMounts` |
+| proxy.extraVolumeMounts | list | `[]` | List of volume mounts to add to the container (evaluated as template). Normally used with `extraVolumes` |
+| proxy.extraOptionsSpec | object | `{"replicas":2}` | Extra options to place under .spec (e.g. replicas, strategy, revisionHistoryLimit, etc). Evaluated as a template |
+| proxy.extraOptionsTemplateSpec | object | `{}` | Extra options to place under .spec.template.spec (e.g. nodeSelector, affinity, restartPolicy, etc). Evaluated as a template |
 
 ### Proxy: Environment
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| proxy.extraEnvVars | list | ``[]`` | Extra environment variables to set on the proxy pod |
-| proxy.extraEnvVarsCMs | list | ``[]`` | List of ConfigMaps containing extra env vars |
-| proxy.extraEnvVarsSecrets | list | ``[]`` | List of Secrets containing extra env vars |
+| proxy.extraEnvVars | list | `[]` | Extra environment variables to set on the proxy pod |
+| proxy.extraEnvVarsCMs | list | `[]` | List of ConfigMaps containing extra env vars |
+| proxy.extraEnvVarsSecrets | list | `[]` | List of Secrets containing extra env vars |
 
 ### Proxy: Security Context
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| proxy.podSecurityContext.enabled | bool | ``true`` | Enable pod Security Context |
-| proxy.podSecurityContext.fsGroup | int | ``65532`` | Sets the GID that Kubernetes will apply to mounted volumes and created files so processes in the pod can share group-owned access |
-| proxy.containerSecurityContext.enabled | bool | ``true`` | Enable container Security Context |
-| proxy.containerSecurityContext.runAsUser | int | ``65532`` | UID the container processes run as (overrides container image default) |
-| proxy.containerSecurityContext.runAsGroup | int | ``65532`` | GID the container processes run as (overrides container image default) |
-| proxy.containerSecurityContext.runAsNonRoot | bool | ``true`` | Boolean that requires the container to run as a non-root UID (prevents starting if UID 0) |
-| proxy.containerSecurityContext.readOnlyRootFilesystem | bool | ``false`` | Mounts the container root filesystem read-only to prevent in-place writes or tampering |
-| proxy.containerSecurityContext.capabilities | object | ``{"add":["NET_BIND_SERVICE"],"drop":["ALL"]}`` | Fine-grained Linux kernel privileges to add or drop for the container |
+| proxy.podSecurityContext.enabled | bool | `true` | Enable pod Security Context |
+| proxy.podSecurityContext.fsGroup | int | `65532` | Sets the GID that Kubernetes will apply to mounted volumes and created files so processes in the pod can share group-owned access |
+| proxy.containerSecurityContext.enabled | bool | `true` | Enable container Security Context |
+| proxy.containerSecurityContext.runAsUser | int | `65532` | UID the container processes run as (overrides container image default) |
+| proxy.containerSecurityContext.runAsGroup | int | `65532` | GID the container processes run as (overrides container image default) |
+| proxy.containerSecurityContext.runAsNonRoot | bool | `true` | Boolean that requires the container to run as a non-root UID (prevents starting if UID 0) |
+| proxy.containerSecurityContext.readOnlyRootFilesystem | bool | `false` | Mounts the container root filesystem read-only to prevent in-place writes or tampering |
+| proxy.containerSecurityContext.capabilities | object | `{"add":["NET_BIND_SERVICE"],"drop":["ALL"]}` | Fine-grained Linux kernel privileges to add or drop for the container |
 
 ### Proxy: Resources
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| proxy.resources | object | ``{}`` | Container requests and limits for different resources like CPU or memory |
+| proxy.resources | object | `{}` | Container requests and limits for different resources like CPU or memory |
 
 ### Server: Image
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| server.image.registry | string | ``""`` | Server container image registry |
-| server.image.repository | string | ``"enterprise/studios/server"`` | Server container image repository |
-| server.image.tag | string | ``"{{ .chart.AppVersion }}"`` | Server container image tag |
-| server.image.digest | string | ``""`` | Server container image digest in the format `sha256:1234abcdef` |
-| server.image.pullPolicy | string | ``"IfNotPresent"`` | imagePullPolicy for the Server container Ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images |
-| server.image.pullSecrets | list | ``[]`` | List of imagePullSecrets Secrets must be created in the same namespace, for example using the .extraDeploy array Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ |
+| server.image.registry | string | `""` | Server container image registry |
+| server.image.repository | string | `"enterprise/studios/server"` | Server container image repository |
+| server.image.tag | string | `"{{ .chart.AppVersion }}"` | Server container image tag |
+| server.image.digest | string | `""` | Server container image digest in the format `sha256:1234abcdef` |
+| server.image.pullPolicy | string | `"IfNotPresent"` | imagePullPolicy for the Server container Ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images |
+| server.image.pullSecrets | list | `[]` | List of imagePullSecrets Secrets must be created in the same namespace, for example using the .extraDeploy array Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ |
 
 ### Server
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| server.tunnelPort | int | ``7070`` | Port that proxy contacts the server at to create a new tunnel |
-| server.listenerPort | int | ``7777`` | Port where the server listens for connections from the Studios clients |
-| server.logLevel | string | ``"info"`` | Server log level, one of: `trace`, `debug`, `info`, `warn`, `error`, `fatal` |
+| server.tunnelPort | int | `7070` | Port that proxy contacts the server at to create a new tunnel |
+| server.listenerPort | int | `7777` | Port where the server listens for connections from the Studios clients |
+| server.logLevel | string | `"info"` | Server log level, one of: `trace`, `debug`, `info`, `warn`, `error`, `fatal` |
 
 ### Server: Service
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| server.service.type | string | ``"ClusterIP"`` | Server Service type. There should be no need to expose the Studios Server service outside of the cluster, since traffic goes through the proxy |
-| server.service.extraServices | list | ``[]`` | Other services that should live in the Service object https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service |
-| server.service.extraOptions | object | ``{"clusterIP":"None"}`` | Extra Service options to place under .spec (for example, clusterIP, loadBalancerIP, externalTrafficPolicy, externalIPs). Evaluated as a template |
-| server.serviceLabels | object | ``{}`` | Additional labels for the Service objects. Evaluated as a template |
-| server.serviceAnnotations | object | ``{}`` | Additional annotations for the Service objects. Evaluated as a template |
+| server.service.type | string | `"ClusterIP"` | Server Service type. There should be no need to expose the Studios Server service outside of the cluster, since traffic goes through the proxy |
+| server.service.extraServices | list | `[]` | Other services that should live in the Service object https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service |
+| server.service.extraOptions | object | `{"clusterIP":"None"}` | Extra Service options to place under .spec (for example, clusterIP, loadBalancerIP, externalTrafficPolicy, externalIPs). Evaluated as a template |
+| server.serviceLabels | object | `{}` | Additional labels for the Service objects. Evaluated as a template |
+| server.serviceAnnotations | object | `{}` | Additional annotations for the Service objects. Evaluated as a template |
 
 ### Server: Pod
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| server.initContainers | list | ``[]`` | Additional init containers for the server pod. Evaluated as a template |
-| server.command | list | ``[]`` | Override default container command (useful when using custom images) |
-| server.args | list | ``[]`` | Override default container args (useful when using custom images) |
-| server.podLabels | object | ``{}`` | Additional labels for the server pod. Evaluated as a template |
-| server.podAnnotations | object | ``{}`` | Additional annotations for the server pod. Evaluated as a template |
-| server.extraVolumes | list | ``[]`` | List of volumes to add to the deployment (evaluated as template). Requires setting `extraVolumeMounts` |
-| server.extraVolumeMounts | list | ``[]`` | List of volume mounts to add to the container (evaluated as template). Normally used with `extraVolumes` |
-| server.extraOptionsSpec | object | ``{"replicas":2}`` | Extra options to place under .spec (e.g. replicas, strategy, revisionHistoryLimit, etc). Evaluated as a template |
-| server.extraOptionsTemplateSpec | object | ``{}`` | Extra options to place under .spec.template.spec (e.g. nodeSelector, affinity, restartPolicy, etc). Evaluated as a template |
+| server.initContainers | list | `[]` | Additional init containers for the server pod. Evaluated as a template |
+| server.command | list | `[]` | Override default container command (useful when using custom images) |
+| server.args | list | `[]` | Override default container args (useful when using custom images) |
+| server.podLabels | object | `{}` | Additional labels for the server pod. Evaluated as a template |
+| server.podAnnotations | object | `{}` | Additional annotations for the server pod. Evaluated as a template |
+| server.extraVolumes | list | `[]` | List of volumes to add to the deployment (evaluated as template). Requires setting `extraVolumeMounts` |
+| server.extraVolumeMounts | list | `[]` | List of volume mounts to add to the container (evaluated as template). Normally used with `extraVolumes` |
+| server.extraOptionsSpec | object | `{"replicas":2}` | Extra options to place under .spec (e.g. replicas, strategy, revisionHistoryLimit, etc). Evaluated as a template |
+| server.extraOptionsTemplateSpec | object | `{}` | Extra options to place under .spec.template.spec (e.g. nodeSelector, affinity, restartPolicy, etc). Evaluated as a template |
 
 ### Server: Environment
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| server.extraEnvVars | list | ``[]`` | Extra environment variables to set on the server pod |
-| server.extraEnvVarsCMs | list | ``[]`` | List of ConfigMaps containing extra env vars |
-| server.extraEnvVarsSecrets | list | ``[]`` | List of Secrets containing extra env vars |
+| server.extraEnvVars | list | `[]` | Extra environment variables to set on the server pod |
+| server.extraEnvVarsCMs | list | `[]` | List of ConfigMaps containing extra env vars |
+| server.extraEnvVarsSecrets | list | `[]` | List of Secrets containing extra env vars |
 
 ### Server: Security Context
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| server.podSecurityContext.enabled | bool | ``true`` | Enable pod Security Context |
-| server.podSecurityContext.fsGroup | int | ``65532`` | Sets the GID that Kubernetes will apply to mounted volumes and created files so processes in the pod can share group-owned access |
-| server.containerSecurityContext.enabled | bool | ``true`` | Enable container Security Context |
-| server.containerSecurityContext.runAsUser | int | ``65532`` | UID the container processes run as (overrides container image default) |
-| server.containerSecurityContext.runAsGroup | int | ``65532`` | GID the container processes run as (overrides container image default) |
-| server.containerSecurityContext.runAsNonRoot | bool | ``true`` | Boolean that requires the container to run as a non-root UID (prevents starting if UID 0) |
-| server.containerSecurityContext.readOnlyRootFilesystem | bool | ``false`` | Mounts the container root filesystem read-only to prevent in-place writes or tampering |
-| server.containerSecurityContext.capabilities | object | ``{"add":["NET_BIND_SERVICE"],"drop":["ALL"]}`` | Fine-grained Linux kernel privileges to add or drop for the container |
+| server.podSecurityContext.enabled | bool | `true` | Enable pod Security Context |
+| server.podSecurityContext.fsGroup | int | `65532` | Sets the GID that Kubernetes will apply to mounted volumes and created files so processes in the pod can share group-owned access |
+| server.containerSecurityContext.enabled | bool | `true` | Enable container Security Context |
+| server.containerSecurityContext.runAsUser | int | `65532` | UID the container processes run as (overrides container image default) |
+| server.containerSecurityContext.runAsGroup | int | `65532` | GID the container processes run as (overrides container image default) |
+| server.containerSecurityContext.runAsNonRoot | bool | `true` | Boolean that requires the container to run as a non-root UID (prevents starting if UID 0) |
+| server.containerSecurityContext.readOnlyRootFilesystem | bool | `false` | Mounts the container root filesystem read-only to prevent in-place writes or tampering |
+| server.containerSecurityContext.capabilities | object | `{"add":["NET_BIND_SERVICE"],"drop":["ALL"]}` | Fine-grained Linux kernel privileges to add or drop for the container |
 
 ### Server: Resources
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| server.resources | object | ``{}`` | Container requests and limits for different resources like CPU or memory |
+| server.resources | object | `{}` | Container requests and limits for different resources like CPU or memory |
 
 ### Init Container Dependencies
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| initContainerDependencies.enabled | bool | ``true`` | Enable init containers that coordinate startup dependencies (for example, wait for Seqera Platform readiness before starting, etc) |
+| initContainerDependencies.enabled | bool | `true` | Enable init containers that coordinate startup dependencies (for example, wait for Seqera Platform readiness before starting, etc) |
 
 ### Init Container Dependencies: Wait for Platform
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| initContainerDependencies.waitForPlatform.enabled | bool | ``true`` | Enable wait for Seqera Platform init container before starting the proxy |
-| initContainerDependencies.waitForPlatform.image.registry | string | ``""`` | Wait for Platform init container image registry |
-| initContainerDependencies.waitForPlatform.image.repository | string | ``"curlimages/curl"`` | Wait for Platform init container image repository |
-| initContainerDependencies.waitForPlatform.image.tag | string | ``"latest"`` | Wait for Platform init container image tag |
-| initContainerDependencies.waitForPlatform.image.digest | string | ``""`` | Wait for Platform init container image digest in the format `sha256:1234abcdef` |
-| initContainerDependencies.waitForPlatform.image.pullPolicy | string | ``"IfNotPresent"`` | imagePullPolicy for the wait for Platform init container |
-| initContainerDependencies.waitForPlatform.securityContext.runAsUser | int | ``101`` | UID the container processes run as (overrides container image default) |
-| initContainerDependencies.waitForPlatform.securityContext.runAsNonRoot | bool | ``true`` | Require the container to run as a non-root UID (prevents starting if UID 0) |
-| initContainerDependencies.waitForPlatform.securityContext.readOnlyRootFilesystem | bool | ``true`` | Mount the container root filesystem read-only to prevent in-place writes or tampering |
-| initContainerDependencies.waitForPlatform.securityContext.capabilities | object | ``{"drop":["ALL"]}`` | Fine-grained Linux kernel privileges to add or drop for the container |
-| initContainerDependencies.waitForPlatform.resources | object | ``{"limits":{"memory":"100Mi"},"requests":{"cpu":"0.1","memory":"50Mi"}}`` | Container requests and limits for different resources like CPU or memory |
-| initContainerDependencies.waitForPlatform.extraEnvVars | list | ``[]`` | Additional environment variables for the init container |
-| initContainerDependencies.waitForPlatform.extraVolumeMounts | list | ``[]`` | Additional volume mounts for the init container (e.g. to mount a CA certificate) |
+| initContainerDependencies.waitForPlatform.enabled | bool | `true` | Enable wait for Seqera Platform init container before starting the proxy |
+| initContainerDependencies.waitForPlatform.image.registry | string | `""` | Wait for Platform init container image registry |
+| initContainerDependencies.waitForPlatform.image.repository | string | `"curlimages/curl"` | Wait for Platform init container image repository |
+| initContainerDependencies.waitForPlatform.image.tag | string | `"latest"` | Wait for Platform init container image tag |
+| initContainerDependencies.waitForPlatform.image.digest | string | `""` | Wait for Platform init container image digest in the format `sha256:1234abcdef` |
+| initContainerDependencies.waitForPlatform.image.pullPolicy | string | `"IfNotPresent"` | imagePullPolicy for the wait for Platform init container |
+| initContainerDependencies.waitForPlatform.securityContext.runAsUser | int | `101` | UID the container processes run as (overrides container image default) |
+| initContainerDependencies.waitForPlatform.securityContext.runAsNonRoot | bool | `true` | Require the container to run as a non-root UID (prevents starting if UID 0) |
+| initContainerDependencies.waitForPlatform.securityContext.readOnlyRootFilesystem | bool | `true` | Mount the container root filesystem read-only to prevent in-place writes or tampering |
+| initContainerDependencies.waitForPlatform.securityContext.capabilities | object | `{"drop":["ALL"]}` | Fine-grained Linux kernel privileges to add or drop for the container |
+| initContainerDependencies.waitForPlatform.resources | object | `{"limits":{"memory":"100Mi"},"requests":{"cpu":"0.1","memory":"50Mi"}}` | Container requests and limits for different resources like CPU or memory |
+| initContainerDependencies.waitForPlatform.extraEnvVars | list | `[]` | Additional environment variables for the init container |
+| initContainerDependencies.waitForPlatform.extraVolumeMounts | list | `[]` | Additional volume mounts for the init container (e.g. to mount a CA certificate) |
 
 ### Service Account
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| serviceAccount.name | string | ``""`` | Name of an existing ServiceAccount. If not set, a new ServiceAccount is generated based on the release name |
-| serviceAccount.annotations | object | ``{}`` | Additional annotations for the ServiceAccount to generate |
-| serviceAccount.imagePullSecretNames | list | ``[]`` | Names of Secrets containing credentials to pull images from registries |
-| serviceAccount.automountServiceAccountToken | bool | ``true`` | Automount service account token when the ServiceAccount is generated |
+| serviceAccount.name | string | `""` | Name of an existing ServiceAccount. If not set, a new ServiceAccount is generated based on the release name |
+| serviceAccount.annotations | object | `{}` | Additional annotations for the ServiceAccount to generate |
+| serviceAccount.imagePullSecretNames | list | `[]` | Names of Secrets containing credentials to pull images from registries |
+| serviceAccount.automountServiceAccountToken | bool | `true` | Automount service account token when the ServiceAccount is generated |
 
 ### Ingress
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| ingress.enabled | bool | ``false`` | Enable ingress for Studios Proxy |
-| ingress.path | string | ``""`` | Path for the main ingress rule. When empty, falls back to `global.ingress.path` |
-| ingress.defaultPathType | string | ``""`` | Default path type for the Ingress. When empty, falls back to `global.ingress.defaultPathType` |
-| ingress.defaultBackend | object | ``{}`` | Configure the default service for the ingress (evaluated as template) Important: make sure only one defaultBackend is defined across the k8s cluster: if the ingress doesn't reconcile successfully, 'describe ingress <name>' will report problems |
-| ingress.extraHosts | list | ``[]`` | Additional hosts you want to include. Evaluated as a template |
-| ingress.annotations | object | ``{}`` | Ingress annotations specific to your load balancer. Evaluated as a template |
-| ingress.extraLabels | object | ``{}`` | Additional labels for the ingress object. Evaluated as a template |
-| ingress.ingressClassName | string | ``""`` | Name of the ingress class (replaces the deprecated annotation `kubernetes.io/ingress.class`). When empty, falls back to `global.ingress.ingressClassName` |
-| ingress.tls | list | ``[]`` | TLS configuration. Evaluated as a template |
+| ingress.enabled | bool | `false` | Enable ingress for Studios Proxy |
+| ingress.path | string | `""` | Path for the main ingress rule. When empty, falls back to `global.ingress.path` |
+| ingress.defaultPathType | string | `""` | Default path type for the Ingress. When empty, falls back to `global.ingress.defaultPathType` |
+| ingress.defaultBackend | object | `{}` | Configure the default service for the ingress (evaluated as template) Important: make sure only one defaultBackend is defined across the k8s cluster: if the ingress doesn't reconcile successfully, 'describe ingress <name>' will report problems |
+| ingress.extraHosts | list | `[]` | Additional hosts you want to include. Evaluated as a template |
+| ingress.annotations | object | `{}` | Ingress annotations specific to your load balancer. Evaluated as a template |
+| ingress.extraLabels | object | `{}` | Additional labels for the ingress object. Evaluated as a template |
+| ingress.ingressClassName | string | `""` | Name of the ingress class (replaces the deprecated annotation `kubernetes.io/ingress.class`). When empty, falls back to `global.ingress.ingressClassName` |
+| ingress.tls | list | `[]` | TLS configuration. Evaluated as a template |
 
 ### Common
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| extraDeploy | list | ``[]`` | Array of extra objects to deploy with the release |
-| commonAnnotations | object | ``{}`` | Annotations to add to all deployed objects |
-| commonLabels | object | ``{}`` | Labels to add to all deployed objects |
-| secretLabels | object | ``{}`` | Additional labels for the Secret objects. Evaluated as a template |
-| secretAnnotations | object | ``{}`` | Additional annotations for the Secret objects. Evaluated as a template |
-| configMapLabels | object | ``{}`` | Additional labels for the ConfigMap objects. Evaluated as a template |
-| configMapAnnotations | object | ``{}`` | Additional annotations for the ConfigMap objects. Evaluated as a template |
+| extraDeploy | list | `[]` | Array of extra objects to deploy with the release |
+| commonAnnotations | object | `{}` | Annotations to add to all deployed objects |
+| commonLabels | object | `{}` | Labels to add to all deployed objects |
+| secretLabels | object | `{}` | Additional labels for the Secret objects. Evaluated as a template |
+| secretAnnotations | object | `{}` | Additional annotations for the Secret objects. Evaluated as a template |
+| configMapLabels | object | `{}` | Additional labels for the ConfigMap objects. Evaluated as a template |
+| configMapAnnotations | object | `{}` | Additional annotations for the ConfigMap objects. Evaluated as a template |
 
 ## Licensing
 

--- a/charts/platform/charts/studios/README.md.gotmpl
+++ b/charts/platform/charts/studios/README.md.gotmpl
@@ -85,7 +85,7 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 {{- range .SectionItems }}
-| {{ .Key }} | {{ .Type }} | {{ if .Default }}`{{ .Default }}`{{ else }}`{{ .AutoDefault }}`{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
+| {{ .Key }} | {{ .Type }} | {{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
 {{- end }}
 {{- end }}
 
@@ -96,7 +96,7 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 {{- range . }}
-| {{ .Key }} | {{ .Type }} | {{ if .Default }}`{{ .Default }}`{{ else }}`{{ .AutoDefault }}`{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
+| {{ .Key }} | {{ .Type }} | {{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
 {{- end }}
 {{- end }}
 

--- a/charts/platform/charts/wave/README.md
+++ b/charts/platform/charts/wave/README.md
@@ -83,249 +83,249 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| global.platformExternalDomain | string | ``"example.com"`` | Domain where Seqera Platform listens |
-| global.waveDomain | string | ``"{{ printf \"wave.%s\" .Values.global.platformExternalDomain }}"`` | Domain where Wave listens. Evaluated as a template |
+| global.platformExternalDomain | string | `"example.com"` | Domain where Seqera Platform listens |
+| global.waveDomain | string | `"{{ printf \"wave.%s\" .Values.global.platformExternalDomain }}"` | Domain where Wave listens. Evaluated as a template |
 
 ### Global: Ingress
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| global.ingress.enabled | bool | ``false`` | Enable Ingress for this chart. OR'd with the chart's local `ingress.enabled` so setting this once at the parent enables all subchart Ingresses. |
-| global.ingress.path | string | ``"/"`` | Default path applied to ingress rules when `ingress.path` is not set. AWS ALB users should override to `/*`. |
-| global.ingress.defaultPathType | string | ``"Prefix"`` | Default path type applied to ingress rules when `ingress.defaultPathType` is not set. `Prefix` works for nginx, traefik, AWS ALB, and most modern controllers. |
-| global.ingress.ingressClassName | string | ``""`` | Default ingress class name applied when `ingress.ingressClassName` is not set |
-| global.ingress.annotations | object | ``{}`` | Annotations merged into the Ingress. Local `ingress.annotations` wins on key collision. Evaluated as a template |
-| global.ingress.extraLabels | object | ``{}`` | Extra labels merged into the Ingress. Local `ingress.extraLabels` wins on key collision. Evaluated as a template |
-| global.ingress.tls | list | ``[]`` | TLS entries concatenated with the local `ingress.tls`. Evaluated as a template |
+| global.ingress.enabled | bool | `false` | Enable Ingress for this chart. OR'd with the chart's local `ingress.enabled` so setting this once at the parent enables all subchart Ingresses. |
+| global.ingress.path | string | `"/"` | Default path applied to ingress rules when `ingress.path` is not set. AWS ALB users should override to `/*`. |
+| global.ingress.defaultPathType | string | `"Prefix"` | Default path type applied to ingress rules when `ingress.defaultPathType` is not set. `Prefix` works for nginx, traefik, AWS ALB, and most modern controllers. |
+| global.ingress.ingressClassName | string | `""` | Default ingress class name applied when `ingress.ingressClassName` is not set |
+| global.ingress.annotations | object | `{}` | Annotations merged into the Ingress. Local `ingress.annotations` wins on key collision. Evaluated as a template |
+| global.ingress.extraLabels | object | `{}` | Extra labels merged into the Ingress. Local `ingress.extraLabels` wins on key collision. Evaluated as a template |
+| global.ingress.tls | list | `[]` | TLS entries concatenated with the local `ingress.tls`. Evaluated as a template |
 
 ### Global: Image Credentials
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| global.imageCredentials | list | ``[]`` | Optional credentials to log in and fetch images from a private registry. These credentials are shared with all the subcharts automatically |
-| global.imageCredentialsSecrets | list | ``[]`` | Optional list of existing Secrets containing image pull credentials to use for pulling images from private registries. These Secrets are shared with all the subcharts automatically |
+| global.imageCredentials | list | `[]` | Optional credentials to log in and fetch images from a private registry. These credentials are shared with all the subcharts automatically |
+| global.imageCredentialsSecrets | list | `[]` | Optional list of existing Secrets containing image pull credentials to use for pulling images from private registries. These Secrets are shared with all the subcharts automatically |
 
 ### Application
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| micronautEnvironments | list | ``["postgres","redis","lite"]`` | List of Micronaut environments to enable |
+| micronautEnvironments | list | `["postgres","redis","lite"]` | List of Micronaut environments to enable |
 
 ### Database
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| database.host | string | ``""`` | PostgreSQL database hostname |
-| database.port | int | ``5432`` | PostgreSQL database port |
-| database.name | string | ``""`` | PostgreSQL database name |
-| database.username | string | ``""`` | PostgreSQL database username |
-| database.password | string | ``""`` | PostgreSQL database password |
-| database.existingSecretName | string | ``""`` | Name of an existing Secret containing credentials for the PostgreSQL database, as an alternative to the password field. Note: the Secret must already exist in the  same namespace at the time of deployment |
-| database.existingSecretKey | string | ``"WAVE_DB_PASSWORD"`` | Key in the existing Secret containing the password for the PostgreSQL database |
-| database.enableTls | bool | ``false`` | Enable TLS for the PostgreSQL database connection |
+| database.host | string | `""` | PostgreSQL database hostname |
+| database.port | int | `5432` | PostgreSQL database port |
+| database.name | string | `""` | PostgreSQL database name |
+| database.username | string | `""` | PostgreSQL database username |
+| database.password | string | `""` | PostgreSQL database password |
+| database.existingSecretName | string | `""` | Name of an existing Secret containing credentials for the PostgreSQL database, as an alternative to the password field. Note: the Secret must already exist in the  same namespace at the time of deployment |
+| database.existingSecretKey | string | `"WAVE_DB_PASSWORD"` | Key in the existing Secret containing the password for the PostgreSQL database |
+| database.enableTls | bool | `false` | Enable TLS for the PostgreSQL database connection |
 
 ### Redis
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| redis.host | string | ``""`` | Redis hostname |
-| redis.port | int | ``6379`` | Redis port |
-| redis.enableTls | bool | ``false`` | Enable TLS when connecting to Redis |
-| redis.password | string | ``""`` | Redis password |
-| redis.existingSecretName | string | ``""`` | Name of an existing Secret containing the Redis password, as an alternative to the password field. Note: the Secret must already exist in the same namespace at the time of deployment |
-| redis.existingSecretKey | string | ``"REDIS_PASSWORD"`` | Key in the existing Secret containing the Redis password |
+| redis.host | string | `""` | Redis hostname |
+| redis.port | int | `6379` | Redis port |
+| redis.enableTls | bool | `false` | Enable TLS when connecting to Redis |
+| redis.password | string | `""` | Redis password |
+| redis.existingSecretName | string | `""` | Name of an existing Secret containing the Redis password, as an alternative to the password field. Note: the Secret must already exist in the same namespace at the time of deployment |
+| redis.existingSecretKey | string | `"REDIS_PASSWORD"` | Key in the existing Secret containing the Redis password |
 
 ### Image
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| image.registry | string | ``""`` | Container image registry |
-| image.repository | string | ``"enterprise/wave/server"`` | Container image repository |
-| image.tag | string | ``"{{ .chart.AppVersion }}"`` | Container image tag |
-| image.digest | string | ``""`` | Container image digest in the format `sha256:1234abcdef` |
-| image.pullPolicy | string | ``"IfNotPresent"`` | imagePullPolicy for the container Ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images |
-| image.pullSecrets | list | ``[]`` | List of imagePullSecrets Secrets must be created in the same namespace, for example using the .extraDeploy array Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ |
+| image.registry | string | `""` | Container image registry |
+| image.repository | string | `"enterprise/wave/server"` | Container image repository |
+| image.tag | string | `"{{ .chart.AppVersion }}"` | Container image tag |
+| image.digest | string | `""` | Container image digest in the format `sha256:1234abcdef` |
+| image.pullPolicy | string | `"IfNotPresent"` | imagePullPolicy for the container Ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images |
+| image.pullSecrets | list | `[]` | List of imagePullSecrets Secrets must be created in the same namespace, for example using the .extraDeploy array Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ |
 
 ### Service
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| service | object | ``{"extraOptions":{},"extraServices":[],"http":{"name":"http","nodePort":null,"port":9090,"targetPort":9090},"type":"ClusterIP"}`` | Service configuration |
-| service.type | string | ``"ClusterIP"`` | Service type. Note: ingresses using AWS ALB require the service to be NodePort |
-| service.http.name | string | ``"http"`` | Service name to use |
-| service.http.port | int | ``9090`` | Service port |
-| service.http.targetPort | int | ``9090`` | Port on the pod/container that the Service forwards traffic to (can be a number or named port, distinct from the Service's external port) |
-| service.http.nodePort | string | ``nil`` | Service node port, only used when service.type is Nodeport or LoadBalancer Choose port between 30000-32767, unless the cluster was configured differently than default |
-| service.extraServices | list | ``[]`` | Other services that should live in the Service object https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service |
-| service.extraOptions | object | ``{}`` | Extra Service options to place under .spec (for example, clusterIP, loadBalancerIP, externalTrafficPolicy, externalIPs). Evaluated as a template |
+| service | object | `{"extraOptions":{},"extraServices":[],"http":{"name":"http","nodePort":null,"port":9090,"targetPort":9090},"type":"ClusterIP"}` | Service configuration |
+| service.type | string | `"ClusterIP"` | Service type. Note: ingresses using AWS ALB require the service to be NodePort |
+| service.http.name | string | `"http"` | Service name to use |
+| service.http.port | int | `9090` | Service port |
+| service.http.targetPort | int | `9090` | Port on the pod/container that the Service forwards traffic to (can be a number or named port, distinct from the Service's external port) |
+| service.http.nodePort | string | `nil` | Service node port, only used when service.type is Nodeport or LoadBalancer Choose port between 30000-32767, unless the cluster was configured differently than default |
+| service.extraServices | list | `[]` | Other services that should live in the Service object https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service |
+| service.extraOptions | object | `{}` | Extra Service options to place under .spec (for example, clusterIP, loadBalancerIP, externalTrafficPolicy, externalIPs). Evaluated as a template |
 
 ### Deployment
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| initContainers | list | ``[]`` | Additional init containers for the pod. Evaluated as a template |
-| command | list | ``[]`` | Override default container command (useful when using custom images) |
-| args | list | ``[]`` | Override default container args (useful when using custom images) |
-| workingDir | string | ``"/work"`` | Working directory for the main container process. Evaluated as a template |
-| podLabels | object | ``{}`` | Additional labels for the pod. Evaluated as a template |
-| podAnnotations | object | ``{}`` | Additional annotations for the pod. Evaluated as a template |
-| extraOptionsSpec | object | ``{}`` | Extra options to place under .spec (e.g. replicas, strategy, revisionHistoryLimit, etc). Evaluated as a template |
-| extraOptionsTemplateSpec | object | ``{}`` | Extra options to place under .spec.template.spec (e.g. nodeSelector, affinity, restartPolicy, etc). Evaluated as a template |
+| initContainers | list | `[]` | Additional init containers for the pod. Evaluated as a template |
+| command | list | `[]` | Override default container command (useful when using custom images) |
+| args | list | `[]` | Override default container args (useful when using custom images) |
+| workingDir | string | `"/work"` | Working directory for the main container process. Evaluated as a template |
+| podLabels | object | `{}` | Additional labels for the pod. Evaluated as a template |
+| podAnnotations | object | `{}` | Additional annotations for the pod. Evaluated as a template |
+| extraOptionsSpec | object | `{}` | Extra options to place under .spec (e.g. replicas, strategy, revisionHistoryLimit, etc). Evaluated as a template |
+| extraOptionsTemplateSpec | object | `{}` | Extra options to place under .spec.template.spec (e.g. nodeSelector, affinity, restartPolicy, etc). Evaluated as a template |
 
 ### Deployment: Environment
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| extraEnvVars | list | ``[]`` | Extra environment variables |
-| extraEnvVarsCMs | list | ``[]`` | List of ConfigMaps containing extra env vars |
-| extraEnvVarsSecrets | list | ``[]`` | List of Secrets containing extra env vars |
+| extraEnvVars | list | `[]` | Extra environment variables |
+| extraEnvVarsCMs | list | `[]` | List of ConfigMaps containing extra env vars |
+| extraEnvVarsSecrets | list | `[]` | List of Secrets containing extra env vars |
 
 ### Deployment: Volumes
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| extraVolumes | list | ``[]`` | List of volumes to add to the deployment (evaluated as template). Requires setting `extraVolumeMounts` |
-| extraVolumeMounts | list | ``[]`` | List of volume mounts to add to the container (evaluated as template). Normally used with `extraVolumes` |
+| extraVolumes | list | `[]` | List of volumes to add to the deployment (evaluated as template). Requires setting `extraVolumeMounts` |
+| extraVolumeMounts | list | `[]` | List of volume mounts to add to the container (evaluated as template). Normally used with `extraVolumes` |
 
 ### Security Context
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| podSecurityContext.enabled | bool | ``true`` | Enable pod Security Context |
-| podSecurityContext.fsGroup | int | ``101`` | Sets the GID that Kubernetes will apply to mounted volumes and created files so processes in the pod can share group-owned access |
-| containerSecurityContext.enabled | bool | ``true`` | Enable container Security Context |
-| containerSecurityContext.runAsUser | int | ``101`` | UID the container processes run as (overrides container image default) |
-| containerSecurityContext.runAsNonRoot | bool | ``true`` | Boolean that requires the container to run as a non-root UID (prevents starting if UID 0) |
-| containerSecurityContext.readOnlyRootFilesystem | bool | ``true`` | Mounts the container root filesystem read-only to prevent in-place writes or tampering |
-| containerSecurityContext.capabilities | object | ``{"drop":["ALL"]}`` | Fine-grained Linux kernel privileges to add or drop for the container |
+| podSecurityContext.enabled | bool | `true` | Enable pod Security Context |
+| podSecurityContext.fsGroup | int | `101` | Sets the GID that Kubernetes will apply to mounted volumes and created files so processes in the pod can share group-owned access |
+| containerSecurityContext.enabled | bool | `true` | Enable container Security Context |
+| containerSecurityContext.runAsUser | int | `101` | UID the container processes run as (overrides container image default) |
+| containerSecurityContext.runAsNonRoot | bool | `true` | Boolean that requires the container to run as a non-root UID (prevents starting if UID 0) |
+| containerSecurityContext.readOnlyRootFilesystem | bool | `true` | Mounts the container root filesystem read-only to prevent in-place writes or tampering |
+| containerSecurityContext.capabilities | object | `{"drop":["ALL"]}` | Fine-grained Linux kernel privileges to add or drop for the container |
 
 ### Resources
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| resources | object | ``{}`` | Container requests and limits for different resources like CPU or memory |
+| resources | object | `{}` | Container requests and limits for different resources like CPU or memory |
 
 ### Init Container Dependencies
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| initContainerDependencies.enabled | bool | ``true`` | Enable init containers that coordinate startup dependencies |
+| initContainerDependencies.enabled | bool | `true` | Enable init containers that coordinate startup dependencies |
 
 ### Init Container Dependencies: Wait for Redis
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| initContainerDependencies.waitForRedis.enabled | bool | ``true`` | Enable wait for Redis init container before starting the main container |
-| initContainerDependencies.waitForRedis.image.registry | string | ``""`` | Override default wait for Redis init container image |
-| initContainerDependencies.waitForRedis.image.repository | string | ``"redis"`` | Init container image repository |
-| initContainerDependencies.waitForRedis.image.tag | string | ``"7-alpine"`` | Init container image tag |
-| initContainerDependencies.waitForRedis.image.digest | string | ``""`` | Init container image digest in the format `sha256:1234abcdef` |
-| initContainerDependencies.waitForRedis.image.pullPolicy | string | ``"IfNotPresent"`` | imagePullPolicy for the init container |
-| initContainerDependencies.waitForRedis.securityContext.runAsUser | int | ``101`` | UID the container processes run as (overrides container image default) |
-| initContainerDependencies.waitForRedis.securityContext.runAsNonRoot | bool | ``true`` | Require the container to run as a non-root UID (prevents starting if UID is 0) |
-| initContainerDependencies.waitForRedis.securityContext.readOnlyRootFilesystem | bool | ``true`` | Mount the container root filesystem read-only to prevent in-place writes or tampering |
-| initContainerDependencies.waitForRedis.securityContext.capabilities | object | ``{"drop":["ALL"]}`` | Fine-grained Linux kernel privileges to add or drop for the container |
-| initContainerDependencies.waitForRedis.resources | object | ``{"limits":{"memory":"100Mi"},"requests":{"cpu":"0.5","memory":"50Mi"}}`` | Container requests and limits for different resources like CPU or memory |
-| initContainerDependencies.waitForRedis.extraEnvVars | list | ``[]`` | Additional environment variables for the init container |
-| initContainerDependencies.waitForRedis.extraVolumeMounts | list | ``[]`` | Additional volume mounts for the init container (e.g. to mount a CA certificate) |
+| initContainerDependencies.waitForRedis.enabled | bool | `true` | Enable wait for Redis init container before starting the main container |
+| initContainerDependencies.waitForRedis.image.registry | string | `""` | Override default wait for Redis init container image |
+| initContainerDependencies.waitForRedis.image.repository | string | `"redis"` | Init container image repository |
+| initContainerDependencies.waitForRedis.image.tag | string | `"7-alpine"` | Init container image tag |
+| initContainerDependencies.waitForRedis.image.digest | string | `""` | Init container image digest in the format `sha256:1234abcdef` |
+| initContainerDependencies.waitForRedis.image.pullPolicy | string | `"IfNotPresent"` | imagePullPolicy for the init container |
+| initContainerDependencies.waitForRedis.securityContext.runAsUser | int | `101` | UID the container processes run as (overrides container image default) |
+| initContainerDependencies.waitForRedis.securityContext.runAsNonRoot | bool | `true` | Require the container to run as a non-root UID (prevents starting if UID is 0) |
+| initContainerDependencies.waitForRedis.securityContext.readOnlyRootFilesystem | bool | `true` | Mount the container root filesystem read-only to prevent in-place writes or tampering |
+| initContainerDependencies.waitForRedis.securityContext.capabilities | object | `{"drop":["ALL"]}` | Fine-grained Linux kernel privileges to add or drop for the container |
+| initContainerDependencies.waitForRedis.resources | object | `{"limits":{"memory":"100Mi"},"requests":{"cpu":"0.5","memory":"50Mi"}}` | Container requests and limits for different resources like CPU or memory |
+| initContainerDependencies.waitForRedis.extraEnvVars | list | `[]` | Additional environment variables for the init container |
+| initContainerDependencies.waitForRedis.extraVolumeMounts | list | `[]` | Additional volume mounts for the init container (e.g. to mount a CA certificate) |
 
 ### Init Container Dependencies: Wait for PostgreSQL
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| initContainerDependencies.waitForPostgres.enabled | bool | ``true`` | Enable wait for PostgreSQL init container before starting the main container |
-| initContainerDependencies.waitForPostgres.image.registry | string | ``""`` | Override default wait for PostgreSQL init container image |
-| initContainerDependencies.waitForPostgres.image.repository | string | ``"postgres"`` | Init container image repository |
-| initContainerDependencies.waitForPostgres.image.tag | string | ``"16-alpine"`` | Init container image tag |
-| initContainerDependencies.waitForPostgres.image.digest | string | ``""`` | Init container image digest in the format `sha256:1234abcdef` |
-| initContainerDependencies.waitForPostgres.image.pullPolicy | string | ``"IfNotPresent"`` | imagePullPolicy for the init container |
-| initContainerDependencies.waitForPostgres.securityContext.runAsUser | int | ``101`` | UID the container processes run as (overrides container image default) |
-| initContainerDependencies.waitForPostgres.securityContext.runAsNonRoot | bool | ``true`` | Require the container to run as a non-root UID (prevents starting if UID is 0) |
-| initContainerDependencies.waitForPostgres.securityContext.readOnlyRootFilesystem | bool | ``true`` | Mount the container root filesystem read-only to prevent in-place writes or tampering |
-| initContainerDependencies.waitForPostgres.securityContext.capabilities | object | ``{"drop":["ALL"]}`` | Fine-grained Linux kernel privileges to add or drop for the container |
-| initContainerDependencies.waitForPostgres.resources | object | ``{"limits":{"memory":"100Mi"},"requests":{"cpu":"0.5","memory":"50Mi"}}`` | Container requests and limits for different resources like CPU or memory |
-| initContainerDependencies.waitForPostgres.extraEnvVars | list | ``[]`` | Additional environment variables for the init container. The special variable `MYSQL_EXTRA_ARGS` is appended verbatim to the `mysql` readiness check command, and can be used to pass TLS flags when connecting to managed MySQL services such as AWS RDS or Azure Database for MySQL that require certificate verification. Pair with `extraVolumeMounts` to mount the CA certificate into the container. Example (TLS with CA certificate mounted from a volume): extraEnvVars:   - name: MYSQL_EXTRA_ARGS     value: "--ssl-ca=/certs/ca.pem --ssl-mode=VERIFY_IDENTITY" |
-| initContainerDependencies.waitForPostgres.extraVolumeMounts | list | ``[]`` | Additional volume mounts for the init container. Use this to mount CA certificates (e.g. from a Secret or ConfigMap populated by an extraInitContainer) so that `MYSQL_EXTRA_ARGS` can reference them. |
+| initContainerDependencies.waitForPostgres.enabled | bool | `true` | Enable wait for PostgreSQL init container before starting the main container |
+| initContainerDependencies.waitForPostgres.image.registry | string | `""` | Override default wait for PostgreSQL init container image |
+| initContainerDependencies.waitForPostgres.image.repository | string | `"postgres"` | Init container image repository |
+| initContainerDependencies.waitForPostgres.image.tag | string | `"16-alpine"` | Init container image tag |
+| initContainerDependencies.waitForPostgres.image.digest | string | `""` | Init container image digest in the format `sha256:1234abcdef` |
+| initContainerDependencies.waitForPostgres.image.pullPolicy | string | `"IfNotPresent"` | imagePullPolicy for the init container |
+| initContainerDependencies.waitForPostgres.securityContext.runAsUser | int | `101` | UID the container processes run as (overrides container image default) |
+| initContainerDependencies.waitForPostgres.securityContext.runAsNonRoot | bool | `true` | Require the container to run as a non-root UID (prevents starting if UID is 0) |
+| initContainerDependencies.waitForPostgres.securityContext.readOnlyRootFilesystem | bool | `true` | Mount the container root filesystem read-only to prevent in-place writes or tampering |
+| initContainerDependencies.waitForPostgres.securityContext.capabilities | object | `{"drop":["ALL"]}` | Fine-grained Linux kernel privileges to add or drop for the container |
+| initContainerDependencies.waitForPostgres.resources | object | `{"limits":{"memory":"100Mi"},"requests":{"cpu":"0.5","memory":"50Mi"}}` | Container requests and limits for different resources like CPU or memory |
+| initContainerDependencies.waitForPostgres.extraEnvVars | list | `[]` | Additional environment variables for the init container. The special variable `MYSQL_EXTRA_ARGS` is appended verbatim to the `mysql` readiness check command, and can be used to pass TLS flags when connecting to managed MySQL services such as AWS RDS or Azure Database for MySQL that require certificate verification. Pair with `extraVolumeMounts` to mount the CA certificate into the container. Example (TLS with CA certificate mounted from a volume): extraEnvVars:   - name: MYSQL_EXTRA_ARGS     value: "--ssl-ca=/certs/ca.pem --ssl-mode=VERIFY_IDENTITY" |
+| initContainerDependencies.waitForPostgres.extraVolumeMounts | list | `[]` | Additional volume mounts for the init container. Use this to mount CA certificates (e.g. from a Secret or ConfigMap populated by an extraInitContainer) so that `MYSQL_EXTRA_ARGS` can reference them. |
 
 ### Probes: Startup
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| startupProbe.enabled | bool | ``false`` | Enable startup probe |
-| startupProbe.httpGet.path | string | ``"/health"`` | HTTP GET path for startup probe |
-| startupProbe.httpGet.port | string | ``"{{ .Values.service.http.targetPort }}"`` | HTTP GET port for startup probe. Evaluated as a template |
-| startupProbe.initialDelaySeconds | int | ``5`` | Longer initial wait to accommodate slow-starting apps |
-| startupProbe.periodSeconds | int | ``10`` | Often set longer to avoid frequent checks while starting |
-| startupProbe.timeoutSeconds | int | ``3`` | Can be longer to allow slow initialization responses |
-| startupProbe.failureThreshold | int | ``5`` | Consecutive failures during startup before killing the container (instead of immediate restarts) |
-| startupProbe.successThreshold | int | ``1`` | Number of consecutive successes required to consider startup complete and enable liveness/readiness |
+| startupProbe.enabled | bool | `false` | Enable startup probe |
+| startupProbe.httpGet.path | string | `"/health"` | HTTP GET path for startup probe |
+| startupProbe.httpGet.port | string | `"{{ .Values.service.http.targetPort }}"` | HTTP GET port for startup probe. Evaluated as a template |
+| startupProbe.initialDelaySeconds | int | `5` | Longer initial wait to accommodate slow-starting apps |
+| startupProbe.periodSeconds | int | `10` | Often set longer to avoid frequent checks while starting |
+| startupProbe.timeoutSeconds | int | `3` | Can be longer to allow slow initialization responses |
+| startupProbe.failureThreshold | int | `5` | Consecutive failures during startup before killing the container (instead of immediate restarts) |
+| startupProbe.successThreshold | int | `1` | Number of consecutive successes required to consider startup complete and enable liveness/readiness |
 
 ### Probes: Readiness
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| readinessProbe.enabled | bool | ``true`` | Enable readiness probe |
-| readinessProbe.httpGet.path | string | ``"/health"`` | HTTP GET path for readiness probe |
-| readinessProbe.httpGet.port | string | ``"{{ .Values.service.http.targetPort }}"`` | HTTP GET port for readiness probe. Evaluated as a template |
-| readinessProbe.initialDelaySeconds | int | ``5`` | Delay before first check (normal start timing) |
-| readinessProbe.periodSeconds | int | ``5`` | Regular check interval during normal operation |
-| readinessProbe.timeoutSeconds | int | ``3`` | Short timeout to detect unresponsive containers for readiness |
-| readinessProbe.failureThreshold | int | ``5`` | Consecutive failures before marking the container Unready (no restart) |
-| readinessProbe.successThreshold | int | ``1`` | Number of consecutive successes required to mark the container Ready after failures |
+| readinessProbe.enabled | bool | `true` | Enable readiness probe |
+| readinessProbe.httpGet.path | string | `"/health"` | HTTP GET path for readiness probe |
+| readinessProbe.httpGet.port | string | `"{{ .Values.service.http.targetPort }}"` | HTTP GET port for readiness probe. Evaluated as a template |
+| readinessProbe.initialDelaySeconds | int | `5` | Delay before first check (normal start timing) |
+| readinessProbe.periodSeconds | int | `5` | Regular check interval during normal operation |
+| readinessProbe.timeoutSeconds | int | `3` | Short timeout to detect unresponsive containers for readiness |
+| readinessProbe.failureThreshold | int | `5` | Consecutive failures before marking the container Unready (no restart) |
+| readinessProbe.successThreshold | int | `1` | Number of consecutive successes required to mark the container Ready after failures |
 
 ### Probes: Liveness
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| livenessProbe.enabled | bool | ``true`` | Enable liveness probe |
-| livenessProbe.httpGet.path | string | ``"/health"`` | HTTP GET path for liveness probe |
-| livenessProbe.httpGet.port | string | ``"{{ .Values.service.http.targetPort }}"`` | HTTP GET port for liveness probe. Evaluated as a template |
-| livenessProbe.initialDelaySeconds | int | ``5`` | Delay before first check (normal start timing) |
-| livenessProbe.periodSeconds | int | ``10`` | Regular check interval during normal operation |
-| livenessProbe.timeoutSeconds | int | ``3`` | Short timeout to detect hung containers quickly |
-| livenessProbe.failureThreshold | int | ``10`` | Consecutive failures before restarting the container |
-| livenessProbe.successThreshold | int | ``1`` | Typically 1 (usually ignored) |
+| livenessProbe.enabled | bool | `true` | Enable liveness probe |
+| livenessProbe.httpGet.path | string | `"/health"` | HTTP GET path for liveness probe |
+| livenessProbe.httpGet.port | string | `"{{ .Values.service.http.targetPort }}"` | HTTP GET port for liveness probe. Evaluated as a template |
+| livenessProbe.initialDelaySeconds | int | `5` | Delay before first check (normal start timing) |
+| livenessProbe.periodSeconds | int | `10` | Regular check interval during normal operation |
+| livenessProbe.timeoutSeconds | int | `3` | Short timeout to detect hung containers quickly |
+| livenessProbe.failureThreshold | int | `10` | Consecutive failures before restarting the container |
+| livenessProbe.successThreshold | int | `1` | Typically 1 (usually ignored) |
 
 ### Service Account
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| serviceAccount | object | ``{"annotations":{},"automountServiceAccountToken":true,"imagePullSecretNames":[],"name":""}`` | Service account configuration |
-| serviceAccount.name | string | ``""`` | Service account name |
-| serviceAccount.annotations | object | ``{}`` | Service account annotations |
-| serviceAccount.imagePullSecretNames | list | ``[]`` | Names of Secrets containing credentials to pull images from registries |
-| serviceAccount.automountServiceAccountToken | bool | ``true`` | Automatically mount service account token |
+| serviceAccount | object | `{"annotations":{},"automountServiceAccountToken":true,"imagePullSecretNames":[],"name":""}` | Service account configuration |
+| serviceAccount.name | string | `""` | Service account name |
+| serviceAccount.annotations | object | `{}` | Service account annotations |
+| serviceAccount.imagePullSecretNames | list | `[]` | Names of Secrets containing credentials to pull images from registries |
+| serviceAccount.automountServiceAccountToken | bool | `true` | Automatically mount service account token |
 
 ### Ingress
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| ingress.enabled | bool | ``false`` | Enable ingress for Wave |
-| ingress.path | string | ``""`` | Path for the main ingress rule. When empty, falls back to `global.ingress.path` |
-| ingress.defaultPathType | string | ``""`` | Default path type for the Ingress. When empty, falls back to `global.ingress.defaultPathType` |
-| ingress.defaultBackend | object | ``{}`` | Configure the default service for the ingress (evaluated as template) Important: make sure only one defaultBackend is defined across the k8s cluster: if the ingress doesn't reconcile successfully, 'describe ingress <name>' will report problems |
-| ingress.extraHosts | list | ``[]`` | Additional hosts you want to include. Evaluated as a template |
-| ingress.annotations | object | ``{}`` | Ingress annotations specific to your load balancer. Evaluated as a template |
-| ingress.extraLabels | object | ``{}`` | Additional labels for the ingress object. Evaluated as a template |
-| ingress.ingressClassName | string | ``""`` | Name of the ingress class (replaces the deprecated annotation `kubernetes.io/ingress.class`). When empty, falls back to `global.ingress.ingressClassName` |
-| ingress.tls | list | ``[]`` | TLS configuration. Evaluated as a template |
+| ingress.enabled | bool | `false` | Enable ingress for Wave |
+| ingress.path | string | `""` | Path for the main ingress rule. When empty, falls back to `global.ingress.path` |
+| ingress.defaultPathType | string | `""` | Default path type for the Ingress. When empty, falls back to `global.ingress.defaultPathType` |
+| ingress.defaultBackend | object | `{}` | Configure the default service for the ingress (evaluated as template) Important: make sure only one defaultBackend is defined across the k8s cluster: if the ingress doesn't reconcile successfully, 'describe ingress <name>' will report problems |
+| ingress.extraHosts | list | `[]` | Additional hosts you want to include. Evaluated as a template |
+| ingress.annotations | object | `{}` | Ingress annotations specific to your load balancer. Evaluated as a template |
+| ingress.extraLabels | object | `{}` | Additional labels for the ingress object. Evaluated as a template |
+| ingress.ingressClassName | string | `""` | Name of the ingress class (replaces the deprecated annotation `kubernetes.io/ingress.class`). When empty, falls back to `global.ingress.ingressClassName` |
+| ingress.tls | list | `[]` | TLS configuration. Evaluated as a template |
 
 ### Extra Deploy
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| extraDeploy | list | ``[]`` | Array of extra objects to deploy with the release |
+| extraDeploy | list | `[]` | Array of extra objects to deploy with the release |
 
 ### Common Metadata
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| commonAnnotations | object | ``{}`` | Annotations to add to all deployed objects |
-| commonLabels | object | ``{}`` | Labels to add to all deployed objects |
-| secretLabels | object | ``{}`` | Additional labels for the Secret objects. Evaluated as a template |
-| secretAnnotations | object | ``{}`` | Additional annotations for the Secret objects. Evaluated as a template |
-| configMapLabels | object | ``{}`` | Additional labels for the ConfigMap objects. Evaluated as a template |
-| configMapAnnotations | object | ``{}`` | Additional annotations for the ConfigMap objects. Evaluated as a template |
+| commonAnnotations | object | `{}` | Annotations to add to all deployed objects |
+| commonLabels | object | `{}` | Labels to add to all deployed objects |
+| secretLabels | object | `{}` | Additional labels for the Secret objects. Evaluated as a template |
+| secretAnnotations | object | `{}` | Additional annotations for the Secret objects. Evaluated as a template |
+| configMapLabels | object | `{}` | Additional labels for the ConfigMap objects. Evaluated as a template |
+| configMapAnnotations | object | `{}` | Additional annotations for the ConfigMap objects. Evaluated as a template |
 
 ## Licensing
 

--- a/charts/platform/charts/wave/README.md.gotmpl
+++ b/charts/platform/charts/wave/README.md.gotmpl
@@ -80,7 +80,7 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 {{- range .SectionItems }}
-| {{ .Key }} | {{ .Type }} | {{ if .Default }}`{{ .Default }}`{{ else }}`{{ .AutoDefault }}`{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
+| {{ .Key }} | {{ .Type }} | {{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
 {{- end }}
 {{- end }}
 
@@ -91,7 +91,7 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 {{- range . }}
-| {{ .Key }} | {{ .Type }} | {{ if .Default }}`{{ .Default }}`{{ else }}`{{ .AutoDefault }}`{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
+| {{ .Key }} | {{ .Type }} | {{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
 {{- end }}
 {{- end }}
 

--- a/charts/platform/values.schema.json
+++ b/charts/platform/values.schema.json
@@ -6448,10 +6448,10 @@
               "type": "string"
             },
             "port": {
-              "default": "",
+              "default": 587,
               "description": "SMTP server port",
               "title": "port",
-              "type": "string"
+              "type": "integer"
             },
             "user": {
               "default": "",

--- a/charts/platform/values.yaml
+++ b/charts/platform/values.yaml
@@ -329,7 +329,7 @@ platform:
     host: ""
     # -- SMTP server port
     # @section -- Platform: SMTP
-    port: ""
+    port: 587
     # -- SMTP server username
     # @section -- Platform: SMTP
     user: ""


### PR DESCRIPTION
- Set cron SMTP port to the default 587 to be explicit
- helm-docs already sets default values in double quotes when sensible
- This shouldn't trigger a new release once merged