### PR TITLE
feat: Allow service accounts to be explicity disabled or named

### DIFF
--- a/charts/platform/CHANGELOG.md
+++ b/charts/platform/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Added `serviceAccount.create` (default `true`) to the `platform` chart and every subchart
+  (agent-backend, mcp, pipeline-optimization, portal-web, studios, wave) to control whether each
+  chart creates its ServiceAccount. When `true`, the ServiceAccount named by `serviceAccount.name`
+  is created (or a generated `<release>-<chart>-sa` name when unset), so a custom ServiceAccount
+  name can now be created rather than only referenced.
+- Added `docs/service-accounts.md` documenting every ServiceAccount created by the chart, how the
+  names are generated per release, and the `serviceAccount.create` / `serviceAccount.name` controls.
+
+### Changed
+
+- **BREAKING**: `serviceAccount.name` no longer suppresses ServiceAccount creation in the `platform`
+  chart or any subchart. Previously, setting `serviceAccount.name` caused the chart to skip creating
+  a ServiceAccount and reference an existing one instead. Creation is now gated solely on
+  `serviceAccount.create` (default `true`). Migration: if you set `serviceAccount.name` to reference
+  an externally-managed ServiceAccount, also set `serviceAccount.create: false` to preserve the
+  previous behaviour.
+
 ## [0.35.1] - 2026-07-13
 
 ### Changed

--- a/charts/platform/README.md
+++ b/charts/platform/README.md
@@ -629,7 +629,8 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| serviceAccount.name | string | `""` | Name of an existing ServiceAccount. If not set, a new ServiceAccount is generated based on the release name |
+| serviceAccount.create | bool | `true` | Whether to create a ServiceAccount. When `true`, the ServiceAccount named by `serviceAccount.name` is created (a `<release>-<chart>-sa` name is generated when it is unset). Set to `false` to use an existing, externally-managed ServiceAccount referenced by `serviceAccount.name`. |
+| serviceAccount.name | string | `""` | Name of the ServiceAccount used by this chart's workloads. When empty, a name is generated from the release name. Applies whether the ServiceAccount is created by this chart (`create: true`) or managed externally (`create: false`). |
 | serviceAccount.annotations | object | `{}` | Additional annotations for the ServiceAccount to generate |
 | serviceAccount.imagePullSecretNames | list | `[]` | Names of Secrets containing credentials to pull images from registries |
 | serviceAccount.automountServiceAccountToken | bool | `false` | Automount service account token when the service account is generated |

--- a/charts/platform/charts/agent-backend/CHANGELOG.md
+++ b/charts/platform/charts/agent-backend/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Added `serviceAccount.create` (default `true`) to control whether the chart creates its
+  ServiceAccount. When `true`, the ServiceAccount named by `serviceAccount.name` is created (or a
+  generated `<release>-<chart>-sa` name when unset), so a custom ServiceAccount name can now be
+  created rather than only referenced.
+
+### Changed
+
+- **BREAKING**: `serviceAccount.name` no longer suppresses ServiceAccount creation. Previously,
+  setting `serviceAccount.name` caused the chart to skip creating a ServiceAccount and reference an
+  existing one instead. Creation is now gated solely on `serviceAccount.create` (default `true`).
+  Migration: if you set `serviceAccount.name` to reference an externally-managed ServiceAccount,
+  also set `serviceAccount.create: false` to preserve the previous behaviour.
+
 ## [1.1.0] - 2026-07-07
 
 ### Changed

--- a/charts/platform/charts/agent-backend/README.md
+++ b/charts/platform/charts/agent-backend/README.md
@@ -363,8 +363,9 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| serviceAccount | object | `{"annotations":{},"automountServiceAccountToken":true,"imagePullSecretNames":[],"name":""}` | Service account configuration |
-| serviceAccount.name | string | `""` | Service account name |
+| serviceAccount | object | `{"annotations":{},"automountServiceAccountToken":true,"create":true,"imagePullSecretNames":[],"name":""}` | Service account configuration |
+| serviceAccount.create | bool | `true` | Whether to create a ServiceAccount. When `true`, the ServiceAccount named by `serviceAccount.name` is created (a `<release>-<chart>-sa` name is generated when it is unset). Set to `false` to use an existing, externally-managed ServiceAccount referenced by `serviceAccount.name`. |
+| serviceAccount.name | string | `""` | Name of the ServiceAccount used by this chart's workloads. When empty, a name is generated from the release name. Applies whether the ServiceAccount is created by this chart (`create: true`) or managed externally (`create: false`). |
 | serviceAccount.annotations | object | `{}` | Service account annotations |
 | serviceAccount.imagePullSecretNames | list | `[]` | Names of Secrets containing credentials to pull images from registries |
 | serviceAccount.automountServiceAccountToken | bool | `true` | Automatically mount service account token |

--- a/charts/platform/charts/agent-backend/templates/_helpers.tpl
+++ b/charts/platform/charts/agent-backend/templates/_helpers.tpl
@@ -21,7 +21,11 @@
 Create the name of the service account to use
 */}}
 {{- define "agent-backend.serviceAccountName" -}}
+  {{- if .Values.serviceAccount.create -}}
 {{- default (printf "%s-sa" (include "common.names.fullname" .)) .Values.serviceAccount.name -}}
+  {{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+  {{- end -}}
 {{- end }}
 
 {{/*

--- a/charts/platform/charts/agent-backend/templates/serviceaccount.yaml
+++ b/charts/platform/charts/agent-backend/templates/serviceaccount.yaml
@@ -17,7 +17,7 @@
  limitations under the License.
 */}}
 
-{{- if not .Values.serviceAccount.name }}
+{{- if .Values.serviceAccount.create }}
   {{- $commonLabels := include "common.labels.standard" (dict "customLabels" .Values.commonLabels "context" $) | fromYaml -}}
   {{- $labels := include "common.tplvalues.render" (dict "value" $commonLabels "context" $) -}}
   {{- $mergedAnnotations := include "common.tplvalues.merge" (dict "values" (list .Values.serviceAccount.annotations .Values.commonAnnotations) "context" .) -}}

--- a/charts/platform/charts/agent-backend/tests/deployment_test.yaml
+++ b/charts/platform/charts/agent-backend/tests/deployment_test.yaml
@@ -645,3 +645,32 @@ tests:
           content:
             name: REDISCLI_TLS
             value: "1"
+
+  - it: should use the default ServiceAccount when serviceAccount.create is false and no name is set
+    template: deployment.yaml
+    set:
+      global.platformServiceAddress: '{{ printf "%s-platform-backend" .Release.Name | lower }}'
+      global.platformServicePort: 8080
+      database.password: test-db-password
+      anthropic.apiKey: test-anthropic-key
+      tokenEncryptionKey: test-token-encryption-key
+      serviceAccount.create: false
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: default
+
+  - it: should use the provided ServiceAccount name when serviceAccount.create is false
+    template: deployment.yaml
+    set:
+      global.platformServiceAddress: '{{ printf "%s-platform-backend" .Release.Name | lower }}'
+      global.platformServicePort: 8080
+      database.password: test-db-password
+      anthropic.apiKey: test-anthropic-key
+      tokenEncryptionKey: test-token-encryption-key
+      serviceAccount.create: false
+      serviceAccount.name: my-custom-sa
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: my-custom-sa

--- a/charts/platform/charts/agent-backend/tests/serviceaccount_test.yaml
+++ b/charts/platform/charts/agent-backend/tests/serviceaccount_test.yaml
@@ -32,13 +32,33 @@ tests:
           of: ServiceAccount
       - matchSnapshot: {}
 
-  - it: should NOT render when serviceAccount.name is set
+  - it: should NOT render when serviceAccount.create is false
     template: serviceaccount.yaml
     set:
+      serviceAccount.create: false
+    asserts:
+      - hasDocuments:
+          count: 0  # ServiceAccount should not render when create is false
+
+  - it: should NOT render when create is false even if a name is set
+    template: serviceaccount.yaml
+    set:
+      serviceAccount.create: false
       serviceAccount.name: existing-sa
     asserts:
       - hasDocuments:
-          count: 0  # ServiceAccount should not render when name is provided
+          count: 0
+
+  - it: should render with a custom name when create is true and name is set
+    template: serviceaccount.yaml
+    set:
+      serviceAccount.name: custom-sa
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: custom-sa
 
   - it: should include imagePullSecrets from global.imageCredentials
     template: serviceaccount.yaml

--- a/charts/platform/charts/agent-backend/values.schema.json
+++ b/charts/platform/charts/agent-backend/values.schema.json
@@ -1566,6 +1566,12 @@
             "string"
           ]
         },
+        "create": {
+          "default": true,
+          "description": "Whether to create a ServiceAccount. When `true`, the ServiceAccount named by\n`serviceAccount.name` is created (a `\u003crelease\u003e-\u003cchart\u003e-sa` name is generated when it is unset).\nSet to `false` to use an existing, externally-managed ServiceAccount referenced by\n`serviceAccount.name`.",
+          "title": "create",
+          "type": "boolean"
+        },
         "imagePullSecretNames": {
           "description": "Names of Secrets containing credentials to pull images from registries",
           "items": {
@@ -1576,12 +1582,13 @@
         },
         "name": {
           "default": "",
-          "description": "Service account name",
+          "description": "Name of the ServiceAccount used by this chart's workloads. When empty, a name is generated\nfrom the release name. Applies whether the ServiceAccount is created by this chart\n(`create: true`) or managed externally (`create: false`).",
           "title": "name",
           "type": "string"
         }
       },
       "required": [
+        "create",
         "name",
         "annotations",
         "imagePullSecretNames"

--- a/charts/platform/charts/agent-backend/values.yaml
+++ b/charts/platform/charts/agent-backend/values.yaml
@@ -682,7 +682,15 @@ livenessProbe:
 # -- Service account configuration
 # @section -- Service Account
 serviceAccount:
-  # -- Service account name
+  # -- Whether to create a ServiceAccount. When `true`, the ServiceAccount named by
+  # `serviceAccount.name` is created (a `<release>-<chart>-sa` name is generated when it is unset).
+  # Set to `false` to use an existing, externally-managed ServiceAccount referenced by
+  # `serviceAccount.name`.
+  # @section -- Service Account
+  create: true
+  # -- Name of the ServiceAccount used by this chart's workloads. When empty, a name is generated
+  # from the release name. Applies whether the ServiceAccount is created by this chart
+  # (`create: true`) or managed externally (`create: false`).
   # @section -- Service Account
   name: ""
   # -- Service account annotations

--- a/charts/platform/charts/mcp/CHANGELOG.md
+++ b/charts/platform/charts/mcp/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Added `serviceAccount.create` (default `true`) to control whether the chart creates its
+  ServiceAccount. When `true`, the ServiceAccount named by `serviceAccount.name` is created (or a
+  generated `<release>-<chart>-sa` name when unset), so a custom ServiceAccount name can now be
+  created rather than only referenced.
+
+### Changed
+
+- **BREAKING**: `serviceAccount.name` no longer suppresses ServiceAccount creation. Previously,
+  setting `serviceAccount.name` caused the chart to skip creating a ServiceAccount and reference an
+  existing one instead. Creation is now gated solely on `serviceAccount.create` (default `true`).
+  Migration: if you set `serviceAccount.name` to reference an externally-managed ServiceAccount,
+  also set `serviceAccount.create: false` to preserve the previous behaviour.
+
 ## [0.5.0] - 2026-07-07
 
 ### Changed

--- a/charts/platform/charts/mcp/README.md
+++ b/charts/platform/charts/mcp/README.md
@@ -279,8 +279,9 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| serviceAccount | object | `{"annotations":{},"automountServiceAccountToken":true,"imagePullSecretNames":[],"name":""}` | Service account configuration |
-| serviceAccount.name | string | `""` | Service account name |
+| serviceAccount | object | `{"annotations":{},"automountServiceAccountToken":true,"create":true,"imagePullSecretNames":[],"name":""}` | Service account configuration |
+| serviceAccount.create | bool | `true` | Whether to create a ServiceAccount. When `true`, the ServiceAccount named by `serviceAccount.name` is created (a `<release>-<chart>-sa` name is generated when it is unset). Set to `false` to use an existing, externally-managed ServiceAccount referenced by `serviceAccount.name`. |
+| serviceAccount.name | string | `""` | Name of the ServiceAccount used by this chart's workloads. When empty, a name is generated from the release name. Applies whether the ServiceAccount is created by this chart (`create: true`) or managed externally (`create: false`). |
 | serviceAccount.annotations | object | `{}` | Service account annotations |
 | serviceAccount.imagePullSecretNames | list | `[]` | Names of Secrets containing credentials to pull images from registries |
 | serviceAccount.automountServiceAccountToken | bool | `true` | Automatically mount service account token |

--- a/charts/platform/charts/mcp/templates/_helpers.tpl
+++ b/charts/platform/charts/mcp/templates/_helpers.tpl
@@ -21,7 +21,11 @@
 Create the name of the service account to use
 */}}
 {{- define "mcp.serviceAccountName" -}}
+  {{- if .Values.serviceAccount.create -}}
 {{- default (printf "%s-sa" (include "common.names.fullname" .)) .Values.serviceAccount.name -}}
+  {{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+  {{- end -}}
 {{- end }}
 
 {{/*

--- a/charts/platform/charts/mcp/templates/serviceaccount.yaml
+++ b/charts/platform/charts/mcp/templates/serviceaccount.yaml
@@ -17,7 +17,7 @@
  limitations under the License.
 */}}
 
-{{- if not .Values.serviceAccount.name }}
+{{- if .Values.serviceAccount.create }}
   {{- $commonLabels := include "common.labels.standard" (dict "customLabels" .Values.commonLabels "context" $) | fromYaml -}}
   {{- $labels := include "common.tplvalues.render" (dict "value" $commonLabels "context" $) -}}
   {{- $mergedAnnotations := include "common.tplvalues.merge" (dict "values" (list .Values.serviceAccount.annotations .Values.commonAnnotations) "context" .) -}}

--- a/charts/platform/charts/mcp/tests/deployment_test.yaml
+++ b/charts/platform/charts/mcp/tests/deployment_test.yaml
@@ -484,3 +484,26 @@ tests:
           content:
             name: PLATFORM_PORT
             value: "8080"
+
+  - it: should use the default ServiceAccount when serviceAccount.create is false and no name is set
+    template: deployment.yaml
+    set:
+      global.platformServiceAddress: '{{ printf "%s-platform-backend" .Release.Name | lower }}'
+      global.platformServicePort: 8080
+      serviceAccount.create: false
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: default
+
+  - it: should use the provided ServiceAccount name when serviceAccount.create is false
+    template: deployment.yaml
+    set:
+      global.platformServiceAddress: '{{ printf "%s-platform-backend" .Release.Name | lower }}'
+      global.platformServicePort: 8080
+      serviceAccount.create: false
+      serviceAccount.name: my-custom-sa
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: my-custom-sa

--- a/charts/platform/charts/mcp/tests/serviceaccount_test.yaml
+++ b/charts/platform/charts/mcp/tests/serviceaccount_test.yaml
@@ -32,13 +32,33 @@ tests:
           of: ServiceAccount
       - matchSnapshot: {}
 
-  - it: should NOT render when serviceAccount.name is set
+  - it: should NOT render when serviceAccount.create is false
     template: serviceaccount.yaml
     set:
+      serviceAccount.create: false
+    asserts:
+      - hasDocuments:
+          count: 0  # ServiceAccount should not render when create is false
+
+  - it: should NOT render when create is false even if a name is set
+    template: serviceaccount.yaml
+    set:
+      serviceAccount.create: false
       serviceAccount.name: existing-sa
     asserts:
       - hasDocuments:
-          count: 0  # ServiceAccount should not render when name is provided
+          count: 0
+
+  - it: should render with a custom name when create is true and name is set
+    template: serviceaccount.yaml
+    set:
+      serviceAccount.name: custom-sa
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: custom-sa
 
   - it: should include imagePullSecrets from global.imageCredentials
     template: serviceaccount.yaml

--- a/charts/platform/charts/mcp/values.schema.json
+++ b/charts/platform/charts/mcp/values.schema.json
@@ -1002,6 +1002,12 @@
             "string"
           ]
         },
+        "create": {
+          "default": true,
+          "description": "Whether to create a ServiceAccount. When `true`, the ServiceAccount named by\n`serviceAccount.name` is created (a `\u003crelease\u003e-\u003cchart\u003e-sa` name is generated when it is unset).\nSet to `false` to use an existing, externally-managed ServiceAccount referenced by\n`serviceAccount.name`.",
+          "title": "create",
+          "type": "boolean"
+        },
         "imagePullSecretNames": {
           "description": "Names of Secrets containing credentials to pull images from registries",
           "items": {
@@ -1012,12 +1018,13 @@
         },
         "name": {
           "default": "",
-          "description": "Service account name",
+          "description": "Name of the ServiceAccount used by this chart's workloads. When empty, a name is generated\nfrom the release name. Applies whether the ServiceAccount is created by this chart\n(`create: true`) or managed externally (`create: false`).",
           "title": "name",
           "type": "string"
         }
       },
       "required": [
+        "create",
         "name",
         "annotations",
         "imagePullSecretNames"

--- a/charts/platform/charts/mcp/values.yaml
+++ b/charts/platform/charts/mcp/values.yaml
@@ -480,7 +480,15 @@ livenessProbe:
 # -- Service account configuration
 # @section -- Service account
 serviceAccount:
-  # -- Service account name
+  # -- Whether to create a ServiceAccount. When `true`, the ServiceAccount named by
+  # `serviceAccount.name` is created (a `<release>-<chart>-sa` name is generated when it is unset).
+  # Set to `false` to use an existing, externally-managed ServiceAccount referenced by
+  # `serviceAccount.name`.
+  # @section -- Service account
+  create: true
+  # -- Name of the ServiceAccount used by this chart's workloads. When empty, a name is generated
+  # from the release name. Applies whether the ServiceAccount is created by this chart
+  # (`create: true`) or managed externally (`create: false`).
   # @section -- Service account
   name: ""
   # -- Service account annotations

--- a/charts/platform/charts/pipeline-optimization/CHANGELOG.md
+++ b/charts/platform/charts/pipeline-optimization/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Added `serviceAccount.create` (default `true`) to control whether the chart creates its
+  ServiceAccount. When `true`, the ServiceAccount named by `serviceAccount.name` is created (or a
+  generated `<release>-<chart>-sa` name when unset), so a custom ServiceAccount name can now be
+  created rather than only referenced.
+
+### Changed
+
+- **BREAKING**: `serviceAccount.name` no longer suppresses ServiceAccount creation. Previously,
+  setting `serviceAccount.name` caused the chart to skip creating a ServiceAccount and reference an
+  existing one instead. Creation is now gated solely on `serviceAccount.create` (default `true`).
+  Migration: if you set `serviceAccount.name` to reference an externally-managed ServiceAccount,
+  also set `serviceAccount.create: false` to preserve the previous behaviour.
+
 ## [2.1.0] - 2026-07-07
 
 ### Changed

--- a/charts/platform/charts/pipeline-optimization/README.md
+++ b/charts/platform/charts/pipeline-optimization/README.md
@@ -300,7 +300,8 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| serviceAccount.name | string | `""` | Name of an existing ServiceAccount. If not set, a new ServiceAccount is generated based on the release name |
+| serviceAccount.create | bool | `true` | Whether to create a ServiceAccount. When `true`, the ServiceAccount named by `serviceAccount.name` is created (a `<release>-<chart>-sa` name is generated when it is unset). Set to `false` to use an existing, externally-managed ServiceAccount referenced by `serviceAccount.name`. |
+| serviceAccount.name | string | `""` | Name of the ServiceAccount used by this chart's workloads. When empty, a name is generated from the release name. Applies whether the ServiceAccount is created by this chart (`create: true`) or managed externally (`create: false`). |
 | serviceAccount.annotations | object | `{}` | Additional annotations for the Platform ServiceAccount to generate |
 | serviceAccount.imagePullSecretNames | list | `[]` | Names of Secrets containing credentials to pull images from registries |
 | serviceAccount.automountServiceAccountToken | bool | `false` | Automount service account token when the server service account is generated |

--- a/charts/platform/charts/pipeline-optimization/templates/_helpers.tpl
+++ b/charts/platform/charts/pipeline-optimization/templates/_helpers.tpl
@@ -71,5 +71,9 @@ Return the name of the secret containing the Platform database password.
 Custom service account name.
 */}}
 {{- define "pipeline-optimization.serviceAccountName" -}}
+  {{- if .Values.serviceAccount.create -}}
 {{- default (printf "%s-sa" (include "common.names.fullname" .)) .Values.serviceAccount.name -}}
+  {{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+  {{- end -}}
 {{- end -}}

--- a/charts/platform/charts/pipeline-optimization/templates/serviceaccount.yaml
+++ b/charts/platform/charts/pipeline-optimization/templates/serviceaccount.yaml
@@ -17,7 +17,7 @@
  limitations under the License.
 */}}
 
-{{ if not .Values.serviceAccount.name }}
+{{ if .Values.serviceAccount.create }}
   {{- $commonLabels := include "common.labels.standard" (dict "customLabels" .Values.commonLabels "context" $) | fromYaml -}}
   {{- $labels := include "common.tplvalues.render" (dict "value" $commonLabels "context" $) -}}
   {{- $mergedAnnotations := include "common.tplvalues.merge" (dict "values" (list .Values.serviceAccount.annotations .Values.commonAnnotations) "context" .) -}}

--- a/charts/platform/charts/pipeline-optimization/tests/deployment_test.yaml
+++ b/charts/platform/charts/pipeline-optimization/tests/deployment_test.yaml
@@ -665,3 +665,22 @@ tests:
       - equal:
           path: spec.template.metadata.labels.another-label
           value: another-value
+
+  - it: should use the default ServiceAccount when serviceAccount.create is false and no name is set
+    template: deployment.yaml
+    set:
+      serviceAccount.create: false
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: default
+
+  - it: should use the provided ServiceAccount name when serviceAccount.create is false
+    template: deployment.yaml
+    set:
+      serviceAccount.create: false
+      serviceAccount.name: my-custom-sa
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: my-custom-sa

--- a/charts/platform/charts/pipeline-optimization/tests/serviceaccount_test.yaml
+++ b/charts/platform/charts/pipeline-optimization/tests/serviceaccount_test.yaml
@@ -41,13 +41,33 @@ tests:
           value: false
       - matchSnapshot: {}
 
-  - it: should not render a serviceaccount if user provides an existing service account by name
+  - it: should not render a serviceaccount when create is false
+    set:
+      serviceAccount:
+        create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render a serviceaccount when create is false even if a name is provided
+    set:
+      serviceAccount:
+        create: false
+        name: existing-service-account
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render a serviceaccount with a custom name when create is true and name is set
     set:
       serviceAccount:
         name: custom-service-account
     asserts:
-      - hasDocuments:
-          count: 0
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: custom-service-account
 
   - it: should use custom namespace when specified
     set:

--- a/charts/platform/charts/pipeline-optimization/values.schema.json
+++ b/charts/platform/charts/pipeline-optimization/values.schema.json
@@ -1020,6 +1020,12 @@
             "string"
           ]
         },
+        "create": {
+          "default": true,
+          "description": "Whether to create a ServiceAccount. When `true`, the ServiceAccount named by\n`serviceAccount.name` is created (a `\u003crelease\u003e-\u003cchart\u003e-sa` name is generated when it is unset).\nSet to `false` to use an existing, externally-managed ServiceAccount referenced by\n`serviceAccount.name`.",
+          "title": "create",
+          "type": "boolean"
+        },
         "imagePullSecretNames": {
           "description": "Names of Secrets containing credentials to pull images from registries",
           "items": {
@@ -1030,12 +1036,13 @@
         },
         "name": {
           "default": "",
-          "description": "Name of an existing ServiceAccount. If not set, a new ServiceAccount is generated based on\nthe release name",
+          "description": "Name of the ServiceAccount used by this chart's workloads. When empty, a name is generated\nfrom the release name. Applies whether the ServiceAccount is created by this chart\n(`create: true`) or managed externally (`create: false`).",
           "title": "name",
           "type": "string"
         }
       },
       "required": [
+        "create",
         "name",
         "annotations",
         "imagePullSecretNames"

--- a/charts/platform/charts/pipeline-optimization/values.yaml
+++ b/charts/platform/charts/pipeline-optimization/values.yaml
@@ -546,8 +546,15 @@ extraDeploy: []
 #     ...
 
 serviceAccount:
-  # -- Name of an existing ServiceAccount. If not set, a new ServiceAccount is generated based on
-  # the release name
+  # -- Whether to create a ServiceAccount. When `true`, the ServiceAccount named by
+  # `serviceAccount.name` is created (a `<release>-<chart>-sa` name is generated when it is unset).
+  # Set to `false` to use an existing, externally-managed ServiceAccount referenced by
+  # `serviceAccount.name`.
+  # @section -- Service Account
+  create: true
+  # -- Name of the ServiceAccount used by this chart's workloads. When empty, a name is generated
+  # from the release name. Applies whether the ServiceAccount is created by this chart
+  # (`create: true`) or managed externally (`create: false`).
   # @section -- Service Account
   name: ""
   # -- Additional annotations for the Platform ServiceAccount to generate

--- a/charts/platform/charts/portal-web/CHANGELOG.md
+++ b/charts/platform/charts/portal-web/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this chart will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Added
+
+- Added `serviceAccount.create` (default `true`) to control whether the chart creates its
+  ServiceAccount. When `true`, the ServiceAccount named by `serviceAccount.name` is created (or a
+  generated `<release>-<chart>-sa` name when unset), so a custom ServiceAccount name can now be
+  created rather than only referenced.
+
+### Changed
+
+- **BREAKING**: `serviceAccount.name` no longer suppresses ServiceAccount creation. Previously,
+  setting `serviceAccount.name` caused the chart to skip creating a ServiceAccount and reference an
+  existing one instead. Creation is now gated solely on `serviceAccount.create` (default `true`).
+  Migration: if you set `serviceAccount.name` to reference an externally-managed ServiceAccount,
+  also set `serviceAccount.create: false` to preserve the previous behaviour.
+
 ## [0.4.0] - 2026-07-07
 
 ### Changed

--- a/charts/platform/charts/portal-web/README.md
+++ b/charts/platform/charts/portal-web/README.md
@@ -220,8 +220,9 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| serviceAccount | object | `{"annotations":{},"automountServiceAccountToken":false,"imagePullSecretNames":[],"name":""}` | Service account configuration |
-| serviceAccount.name | string | `""` | Service account name |
+| serviceAccount | object | `{"annotations":{},"automountServiceAccountToken":false,"create":true,"imagePullSecretNames":[],"name":""}` | Service account configuration |
+| serviceAccount.create | bool | `true` | Whether to create a ServiceAccount. When `true`, the ServiceAccount named by `serviceAccount.name` is created (a `<release>-<chart>-sa` name is generated when it is unset). Set to `false` to use an existing, externally-managed ServiceAccount referenced by `serviceAccount.name`. |
+| serviceAccount.name | string | `""` | Name of the ServiceAccount used by this chart's workloads. When empty, a name is generated from the release name. Applies whether the ServiceAccount is created by this chart (`create: true`) or managed externally (`create: false`). |
 | serviceAccount.annotations | object | `{}` | Service account annotations |
 | serviceAccount.imagePullSecretNames | list | `[]` | Names of Secrets containing credentials to pull images from registries |
 | serviceAccount.automountServiceAccountToken | bool | `false` | Automatically mount service account token |

--- a/charts/platform/charts/portal-web/templates/_helpers.tpl
+++ b/charts/platform/charts/portal-web/templates/_helpers.tpl
@@ -21,7 +21,11 @@
 Create the name of the service account to use
 */}}
 {{- define "portal-web.serviceAccountName" -}}
+  {{- if .Values.serviceAccount.create -}}
 {{- default (printf "%s-sa" (include "common.names.fullname" .)) .Values.serviceAccount.name -}}
+  {{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+  {{- end -}}
 {{- end }}
 
 {{/*

--- a/charts/platform/charts/portal-web/templates/serviceaccount.yaml
+++ b/charts/platform/charts/portal-web/templates/serviceaccount.yaml
@@ -17,7 +17,7 @@
  limitations under the License.
 */}}
 
-{{- if not .Values.serviceAccount.name }}
+{{- if .Values.serviceAccount.create }}
   {{- $commonLabels := include "common.labels.standard" (dict "customLabels" .Values.commonLabels "context" $) | fromYaml -}}
   {{- $labels := include "common.tplvalues.render" (dict "value" $commonLabels "context" $) -}}
   {{- $mergedAnnotations := include "common.tplvalues.merge" (dict "values" (list .Values.serviceAccount.annotations .Values.commonAnnotations) "context" .) -}}

--- a/charts/platform/charts/portal-web/tests/_helpers_test.yaml
+++ b/charts/platform/charts/portal-web/tests/_helpers_test.yaml
@@ -52,3 +52,22 @@ tests:
       - equal:
           path: spec.template.spec.serviceAccountName
           value: my-custom-sa
+
+  - it: should use the default ServiceAccount when serviceAccount.create is false and no name is set
+    template: deployment.yaml
+    set:
+      serviceAccount.create: false
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: default
+
+  - it: should use the provided ServiceAccount name when serviceAccount.create is false
+    template: deployment.yaml
+    set:
+      serviceAccount.create: false
+      serviceAccount.name: my-custom-sa
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: my-custom-sa

--- a/charts/platform/charts/portal-web/tests/serviceaccount_test.yaml
+++ b/charts/platform/charts/portal-web/tests/serviceaccount_test.yaml
@@ -32,13 +32,33 @@ tests:
           of: ServiceAccount
       - matchSnapshot: {}
 
-  - it: should NOT render when serviceAccount.name is set
+  - it: should NOT render when serviceAccount.create is false
     template: serviceaccount.yaml
     set:
+      serviceAccount.create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should NOT render when create is false even if a name is set
+    template: serviceaccount.yaml
+    set:
+      serviceAccount.create: false
       serviceAccount.name: existing-sa
     asserts:
       - hasDocuments:
           count: 0
+
+  - it: should render with a custom name when create is true and name is set
+    template: serviceaccount.yaml
+    set:
+      serviceAccount.name: custom-sa
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: custom-sa
 
   - it: should default automountServiceAccountToken to false
     template: serviceaccount.yaml

--- a/charts/platform/charts/portal-web/values.schema.json
+++ b/charts/platform/charts/portal-web/values.schema.json
@@ -778,6 +778,12 @@
             "string"
           ]
         },
+        "create": {
+          "default": true,
+          "description": "Whether to create a ServiceAccount. When `true`, the ServiceAccount named by\n`serviceAccount.name` is created (a `\u003crelease\u003e-\u003cchart\u003e-sa` name is generated when it is unset).\nSet to `false` to use an existing, externally-managed ServiceAccount referenced by\n`serviceAccount.name`.",
+          "title": "create",
+          "type": "boolean"
+        },
         "imagePullSecretNames": {
           "description": "Names of Secrets containing credentials to pull images from registries",
           "items": {
@@ -788,12 +794,13 @@
         },
         "name": {
           "default": "",
-          "description": "Service account name",
+          "description": "Name of the ServiceAccount used by this chart's workloads. When empty, a name is generated\nfrom the release name. Applies whether the ServiceAccount is created by this chart\n(`create: true`) or managed externally (`create: false`).",
           "title": "name",
           "type": "string"
         }
       },
       "required": [
+        "create",
         "name",
         "annotations",
         "imagePullSecretNames"

--- a/charts/platform/charts/portal-web/values.yaml
+++ b/charts/platform/charts/portal-web/values.yaml
@@ -366,7 +366,15 @@ livenessProbe:
 # -- Service account configuration
 # @section -- Service Account
 serviceAccount:
-  # -- Service account name
+  # -- Whether to create a ServiceAccount. When `true`, the ServiceAccount named by
+  # `serviceAccount.name` is created (a `<release>-<chart>-sa` name is generated when it is unset).
+  # Set to `false` to use an existing, externally-managed ServiceAccount referenced by
+  # `serviceAccount.name`.
+  # @section -- Service Account
+  create: true
+  # -- Name of the ServiceAccount used by this chart's workloads. When empty, a name is generated
+  # from the release name. Applies whether the ServiceAccount is created by this chart
+  # (`create: true`) or managed externally (`create: false`).
   # @section -- Service Account
   name: ""
   # -- Service account annotations

--- a/charts/platform/charts/studios/CHANGELOG.md
+++ b/charts/platform/charts/studios/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Added `serviceAccount.create` (default `true`) to control whether the chart creates its
+  ServiceAccount. When `true`, the ServiceAccount named by `serviceAccount.name` is created (or a
+  generated `<release>-<chart>-sa` name when unset), so a custom ServiceAccount name can now be
+  created rather than only referenced.
+
+### Changed
+
+- **BREAKING**: `serviceAccount.name` no longer suppresses ServiceAccount creation. Previously,
+  setting `serviceAccount.name` caused the chart to skip creating a ServiceAccount and reference an
+  existing one instead. Creation is now gated solely on `serviceAccount.create` (default `true`).
+  Migration: if you set `serviceAccount.name` to reference an externally-managed ServiceAccount,
+  also set `serviceAccount.create: false` to preserve the previous behaviour.
+
 ## [1.5.0] - 2026-07-07
 
 ### Changed

--- a/charts/platform/charts/studios/README.md
+++ b/charts/platform/charts/studios/README.md
@@ -309,7 +309,8 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| serviceAccount.name | string | `""` | Name of an existing ServiceAccount. If not set, a new ServiceAccount is generated based on the release name |
+| serviceAccount.create | bool | `true` | Whether to create a ServiceAccount. When `true`, the ServiceAccount named by `serviceAccount.name` is created (a `<release>-<chart>-sa` name is generated when it is unset). Set to `false` to use an existing, externally-managed ServiceAccount referenced by `serviceAccount.name`. |
+| serviceAccount.name | string | `""` | Name of the ServiceAccount used by this chart's workloads. When empty, a name is generated from the release name. Applies whether the ServiceAccount is created by this chart (`create: true`) or managed externally (`create: false`). |
 | serviceAccount.annotations | object | `{}` | Additional annotations for the ServiceAccount to generate |
 | serviceAccount.imagePullSecretNames | list | `[]` | Names of Secrets containing credentials to pull images from registries |
 | serviceAccount.automountServiceAccountToken | bool | `true` | Automount service account token when the ServiceAccount is generated |

--- a/charts/platform/charts/studios/templates/_helpers.tpl
+++ b/charts/platform/charts/studios/templates/_helpers.tpl
@@ -21,7 +21,11 @@
 by the Seqera Platform Terraform module.
 */}}
 {{- define "studios.serviceAccountName" -}}
+  {{- if .Values.serviceAccount.create -}}
 {{- default (printf "%s-sa" (include "common.names.fullname" .)) .Values.serviceAccount.name -}}
+  {{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+  {{- end -}}
 {{- end -}}
 
 {{/* Return the hostname of the redis server.

--- a/charts/platform/charts/studios/templates/serviceaccount.yaml
+++ b/charts/platform/charts/studios/templates/serviceaccount.yaml
@@ -17,7 +17,7 @@
  limitations under the License.
 */}}
 
-{{ if not .Values.serviceAccount.name }}
+{{ if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/platform/charts/studios/tests/serviceaccount_test.yaml
+++ b/charts/platform/charts/studios/tests/serviceaccount_test.yaml
@@ -29,13 +29,33 @@ tests:
       - hasDocuments:
           count: 1
 
-  - it: should not create a ServiceAccount if the user specifies one
+  - it: should not create a ServiceAccount when create is false
     set:
       serviceAccount:
+        create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not create a ServiceAccount when create is false even if a name is provided
+    set:
+      serviceAccount:
+        create: false
         name: existing-sa
     asserts:
       - hasDocuments:
           count: 0
+
+  - it: should create a ServiceAccount with a custom name when create is true and name is set
+    set:
+      serviceAccount:
+        name: custom-sa
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: custom-sa
 
   - it: should setup a serviceaccount unless the user provides one
     asserts:

--- a/charts/platform/charts/studios/tests/statefulset-server_test.yaml
+++ b/charts/platform/charts/studios/tests/statefulset-server_test.yaml
@@ -575,3 +575,30 @@ tests:
       value:
         whenDeleted: Retain
         whenScaled: Delete
+
+- it: should use the default ServiceAccount when serviceAccount.create is false and no name is set
+  template: statefulset-server.yaml
+  set:
+    proxy:
+      oidcClientRegistrationToken: my-oidc-token
+      oidcClientRegistrationTokenSecretName: ""
+    serviceAccount:
+      create: false
+  asserts:
+  - equal:
+      path: spec.template.spec.serviceAccountName
+      value: default
+
+- it: should use the provided ServiceAccount name when serviceAccount.create is false
+  template: statefulset-server.yaml
+  set:
+    proxy:
+      oidcClientRegistrationToken: my-oidc-token
+      oidcClientRegistrationTokenSecretName: ""
+    serviceAccount:
+      create: false
+      name: my-custom-sa
+  asserts:
+  - equal:
+      path: spec.template.spec.serviceAccountName
+      value: my-custom-sa

--- a/charts/platform/charts/studios/values.schema.json
+++ b/charts/platform/charts/studios/values.schema.json
@@ -1300,6 +1300,12 @@
             "string"
           ]
         },
+        "create": {
+          "default": true,
+          "description": "Whether to create a ServiceAccount. When `true`, the ServiceAccount named by\n`serviceAccount.name` is created (a `\u003crelease\u003e-\u003cchart\u003e-sa` name is generated when it is unset).\nSet to `false` to use an existing, externally-managed ServiceAccount referenced by\n`serviceAccount.name`.",
+          "title": "create",
+          "type": "boolean"
+        },
         "imagePullSecretNames": {
           "description": "Names of Secrets containing credentials to pull images from registries",
           "items": {
@@ -1310,12 +1316,13 @@
         },
         "name": {
           "default": "",
-          "description": "Name of an existing ServiceAccount. If not set, a new ServiceAccount is generated based on\nthe release name",
+          "description": "Name of the ServiceAccount used by this chart's workloads. When empty, a name is generated\nfrom the release name. Applies whether the ServiceAccount is created by this chart\n(`create: true`) or managed externally (`create: false`).",
           "title": "name",
           "type": "string"
         }
       },
       "required": [
+        "create",
         "name",
         "annotations",
         "imagePullSecretNames"

--- a/charts/platform/charts/studios/values.yaml
+++ b/charts/platform/charts/studios/values.yaml
@@ -594,8 +594,15 @@ initContainerDependencies:
     extraVolumeMounts: []
 
 serviceAccount:
-  # -- Name of an existing ServiceAccount. If not set, a new ServiceAccount is generated based on
-  # the release name
+  # -- Whether to create a ServiceAccount. When `true`, the ServiceAccount named by
+  # `serviceAccount.name` is created (a `<release>-<chart>-sa` name is generated when it is unset).
+  # Set to `false` to use an existing, externally-managed ServiceAccount referenced by
+  # `serviceAccount.name`.
+  # @section -- Service Account
+  create: true
+  # -- Name of the ServiceAccount used by this chart's workloads. When empty, a name is generated
+  # from the release name. Applies whether the ServiceAccount is created by this chart
+  # (`create: true`) or managed externally (`create: false`).
   # @section -- Service Account
   name: ""
   # -- Additional annotations for the ServiceAccount to generate

--- a/charts/platform/charts/wave/CHANGELOG.md
+++ b/charts/platform/charts/wave/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Added `serviceAccount.create` (default `true`) to control whether the chart creates its
+  ServiceAccount. When `true`, the ServiceAccount named by `serviceAccount.name` is created (or a
+  generated `<release>-<chart>-sa` name when unset), so a custom ServiceAccount name can now be
+  created rather than only referenced.
+
+### Changed
+
+- **BREAKING**: `serviceAccount.name` no longer suppresses ServiceAccount creation. Previously,
+  setting `serviceAccount.name` caused the chart to skip creating a ServiceAccount and reference an
+  existing one instead. Creation is now gated solely on `serviceAccount.create` (default `true`).
+  Migration: if you set `serviceAccount.name` to reference an externally-managed ServiceAccount,
+  also set `serviceAccount.create: false` to preserve the previous behaviour.
+
 ## [0.3.0] - 2026-07-07
 
 ### Changed

--- a/charts/platform/charts/wave/README.md
+++ b/charts/platform/charts/wave/README.md
@@ -290,8 +290,9 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| serviceAccount | object | `{"annotations":{},"automountServiceAccountToken":true,"imagePullSecretNames":[],"name":""}` | Service account configuration |
-| serviceAccount.name | string | `""` | Service account name |
+| serviceAccount | object | `{"annotations":{},"automountServiceAccountToken":true,"create":true,"imagePullSecretNames":[],"name":""}` | Service account configuration |
+| serviceAccount.create | bool | `true` | Whether to create a ServiceAccount. When `true`, the ServiceAccount named by `serviceAccount.name` is created (a `<release>-<chart>-sa` name is generated when it is unset). Set to `false` to use an existing, externally-managed ServiceAccount referenced by `serviceAccount.name`. |
+| serviceAccount.name | string | `""` | Name of the ServiceAccount used by this chart's workloads. When empty, a name is generated from the release name. Applies whether the ServiceAccount is created by this chart (`create: true`) or managed externally (`create: false`). |
 | serviceAccount.annotations | object | `{}` | Service account annotations |
 | serviceAccount.imagePullSecretNames | list | `[]` | Names of Secrets containing credentials to pull images from registries |
 | serviceAccount.automountServiceAccountToken | bool | `true` | Automatically mount service account token |

--- a/charts/platform/charts/wave/templates/_helpers.tpl
+++ b/charts/platform/charts/wave/templates/_helpers.tpl
@@ -21,7 +21,11 @@
 Create the name of the service account to use
 */}}
 {{- define "wave.serviceAccountName" -}}
+  {{- if .Values.serviceAccount.create -}}
 {{- default (printf "%s-sa" (include "common.names.fullname" .)) .Values.serviceAccount.name -}}
+  {{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+  {{- end -}}
 {{- end }}
 
 {{/*

--- a/charts/platform/charts/wave/templates/serviceaccount.yaml
+++ b/charts/platform/charts/wave/templates/serviceaccount.yaml
@@ -17,7 +17,7 @@
  limitations under the License.
 */}}
 
-{{- if not .Values.serviceAccount.name }}
+{{- if .Values.serviceAccount.create }}
   {{- $commonLabels := include "common.labels.standard" (dict "customLabels" .Values.commonLabels "context" $) | fromYaml -}}
   {{- $labels := include "common.tplvalues.render" (dict "value" $commonLabels "context" $) -}}
   {{- $mergedAnnotations := include "common.tplvalues.merge" (dict "values" (list .Values.serviceAccount.annotations .Values.commonAnnotations) "context" .) -}}

--- a/charts/platform/charts/wave/tests/deployment_test.yaml
+++ b/charts/platform/charts/wave/tests/deployment_test.yaml
@@ -930,3 +930,32 @@ tests:
             - name: ca-certs
               mountPath: /certs
               readOnly: true
+
+  - it: should use the default ServiceAccount when serviceAccount.create is false and no name is set
+    template: deployment.yaml
+    set:
+      database.host: db.example.com
+      database.name: wavedb
+      database.username: wave
+      database.password: test-db-password
+      redis.host: redis.example.com
+      serviceAccount.create: false
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: default
+
+  - it: should use the provided ServiceAccount name when serviceAccount.create is false
+    template: deployment.yaml
+    set:
+      database.host: db.example.com
+      database.name: wavedb
+      database.username: wave
+      database.password: test-db-password
+      redis.host: redis.example.com
+      serviceAccount.create: false
+      serviceAccount.name: my-custom-sa
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: my-custom-sa

--- a/charts/platform/charts/wave/tests/serviceaccount_test.yaml
+++ b/charts/platform/charts/wave/tests/serviceaccount_test.yaml
@@ -32,13 +32,33 @@ tests:
           of: ServiceAccount
       - matchSnapshot: {}
 
-  - it: should NOT render when serviceAccount.name is set
+  - it: should NOT render when serviceAccount.create is false
     template: serviceaccount.yaml
     set:
+      serviceAccount.create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should NOT render when create is false even if a name is set
+    template: serviceaccount.yaml
+    set:
+      serviceAccount.create: false
       serviceAccount.name: existing-sa
     asserts:
       - hasDocuments:
           count: 0
+
+  - it: should render with a custom name when create is true and name is set
+    template: serviceaccount.yaml
+    set:
+      serviceAccount.name: custom-sa
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: custom-sa
 
   - it: should include imagePullSecrets from global.imageCredentials
     template: serviceaccount.yaml

--- a/charts/platform/charts/wave/values.schema.json
+++ b/charts/platform/charts/wave/values.schema.json
@@ -1211,6 +1211,12 @@
             "string"
           ]
         },
+        "create": {
+          "default": true,
+          "description": "Whether to create a ServiceAccount. When `true`, the ServiceAccount named by\n`serviceAccount.name` is created (a `\u003crelease\u003e-\u003cchart\u003e-sa` name is generated when it is unset).\nSet to `false` to use an existing, externally-managed ServiceAccount referenced by\n`serviceAccount.name`.",
+          "title": "create",
+          "type": "boolean"
+        },
         "imagePullSecretNames": {
           "description": "Names of Secrets containing credentials to pull images from registries",
           "items": {
@@ -1221,12 +1227,13 @@
         },
         "name": {
           "default": "",
-          "description": "Service account name",
+          "description": "Name of the ServiceAccount used by this chart's workloads. When empty, a name is generated\nfrom the release name. Applies whether the ServiceAccount is created by this chart\n(`create: true`) or managed externally (`create: false`).",
           "title": "name",
           "type": "string"
         }
       },
       "required": [
+        "create",
         "name",
         "annotations",
         "imagePullSecretNames"

--- a/charts/platform/charts/wave/values.yaml
+++ b/charts/platform/charts/wave/values.yaml
@@ -533,7 +533,15 @@ livenessProbe:
 # -- Service account configuration
 # @section -- Service Account
 serviceAccount:
-  # -- Service account name
+  # -- Whether to create a ServiceAccount. When `true`, the ServiceAccount named by
+  # `serviceAccount.name` is created (a `<release>-<chart>-sa` name is generated when it is unset).
+  # Set to `false` to use an existing, externally-managed ServiceAccount referenced by
+  # `serviceAccount.name`.
+  # @section -- Service Account
+  create: true
+  # -- Name of the ServiceAccount used by this chart's workloads. When empty, a name is generated
+  # from the release name. Applies whether the ServiceAccount is created by this chart
+  # (`create: true`) or managed externally (`create: false`).
   # @section -- Service Account
   name: ""
   # -- Service account annotations

--- a/charts/platform/docs/service-accounts.md
+++ b/charts/platform/docs/service-accounts.md
@@ -1,0 +1,152 @@
+<!--
+ Copyright (c) 2025 - 2026 Seqera Labs
+ All rights reserved.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
+# ServiceAccounts
+
+This document lists every Kubernetes `ServiceAccount` the Seqera Platform chart (and its subcharts)
+can create, explains how their names are derived, how naming changes between releases, and how to
+control creation and naming with the `serviceAccount.*` values.
+
+## Summary
+
+Each chart and subchart owns **exactly one** `ServiceAccount`, rendered from its own
+`templates/serviceaccount.yaml`. Workloads never define ServiceAccounts inline — they only
+reference one via `serviceAccountName`. A subchart's ServiceAccount is only created when that
+subchart is enabled (via its `*.enabled` condition in the parent `Chart.yaml`).
+
+| Chart / subchart        | Enabled by                       | Generated ServiceAccount name¹    | Workloads that use it                          |
+| ----------------------- | -------------------------------- | --------------------------------- | ---------------------------------------------- |
+| `platform` (parent)     | always                           | `<release>-platform-sa`           | backend, cron, frontend Deployments            |
+| `studios`               | `studios.enabled`                | `<release>-studios-sa`            | server StatefulSet, proxy Deployment           |
+| `wave`                  | `wave.enabled`                   | `<release>-wave-sa`               | wave Deployment                                |
+| `mcp`                   | `mcp.enabled`                    | `<release>-mcp-sa`                | mcp Deployment                                 |
+| `agent-backend`         | `agent-backend.enabled`          | `<release>-agent-backend-sa`      | agent-backend Deployment                       |
+| `portal-web`            | `portal-web.enabled`             | `<release>-portal-web-sa`         | portal-web Deployment                          |
+| `pipeline-optimization` | `pipeline-optimization.enabled`  | `<release>-pipeline-optimization-sa` | pipeline-optimization Deployment            |
+
+¹ Default name when `serviceAccount.name` is unset. See [How names are generated](#how-names-are-generated).
+
+For a release named `tower` with every subchart enabled, the full set of created ServiceAccounts is:
+
+```
+tower-platform-sa
+tower-studios-sa
+tower-wave-sa
+tower-mcp-sa
+tower-agent-backend-sa
+tower-portal-web-sa
+tower-pipeline-optimization-sa
+```
+
+## How names are generated
+
+Every chart uses the same helper (`<chart>.serviceAccountName`):
+
+```gotemplate
+{{- define "platform.serviceAccountName" -}}
+{{- default (printf "%s-sa" (include "common.names.fullname" .)) .Values.serviceAccount.name -}}
+{{- end -}}
+```
+
+The precedence is:
+
+1. **`serviceAccount.name`** — if set, it is used verbatim as the ServiceAccount name.
+2. Otherwise **`<common.names.fullname>-sa`**.
+
+`common.names.fullname` (from the Bitnami common library) resolves to:
+
+- `fullnameOverride` if set, else
+- `<Release.Name>-<nameOverride | Chart.Name>`, collapsing to just `<Release.Name>` when the
+  release name already contains the chart name.
+
+Because the default incorporates `Release.Name`, **the generated names differ per release**, so
+multiple releases can coexist in the same namespace without colliding. In a subchart, `Chart.Name`
+is the subchart's own name (e.g. `studios`) while `Release.Name` is the shared parent release, which
+is why each subchart gets its own distinct `<release>-<subchart>-sa`.
+
+The same helper is used both to name the created ServiceAccount **and** to set `serviceAccountName`
+on the chart's workloads, so the two always stay in sync.
+
+## Controlling creation and naming
+
+Two values drive the behaviour, and they are independent:
+
+| Value                    | Default | Purpose                                                                 |
+| ------------------------ | ------- | ----------------------------------------------------------------------- |
+| `serviceAccount.create`  | `true`  | Whether this chart creates the ServiceAccount.                          |
+| `serviceAccount.name`    | `""`    | The name to use (created and/or referenced). Generated when empty.      |
+
+Behaviour matrix:
+
+| `create` | `name`      | Result                                                                                |
+| -------- | ----------- | ------------------------------------------------------------------------------------- |
+| `true`   | `""`        | Chart creates `<release>-<chart>-sa`; workloads reference it. **(default)**           |
+| `true`   | `my-sa`     | Chart creates a ServiceAccount named `my-sa`; workloads reference `my-sa`.            |
+| `false`  | `""`        | Nothing created; workloads reference the namespace's `default` ServiceAccount.         |
+| `false`  | `my-sa`     | Nothing created; workloads reference `my-sa` (must already exist / be managed elsewhere). |
+
+> **Note:** when `create: false` and no `name` is given, workloads fall back to the namespace's
+> built-in `default` ServiceAccount rather than a generated `<release>-<chart>-sa` name. This avoids
+> referencing a ServiceAccount that nothing creates (which Kubernetes would reject at pod admission).
+> Set `serviceAccount.name` if you want workloads to use a specific pre-existing ServiceAccount.
+
+### Examples
+
+Create the ServiceAccount with a custom name:
+
+```yaml
+serviceAccount:
+  create: true
+  name: platform-sa
+```
+
+Use an existing, externally-managed ServiceAccount (chart creates nothing):
+
+```yaml
+serviceAccount:
+  create: false
+  name: my-preexisting-sa
+```
+
+Each subchart has its own `serviceAccount` block, so overrides are scoped per component, e.g.:
+
+```yaml
+serviceAccount:            # parent (platform) ServiceAccount
+  name: platform-sa
+
+studios:
+  serviceAccount:          # studios subchart ServiceAccount
+    create: false
+    name: shared-studios-sa
+```
+
+## Migration (breaking change)
+
+Previously, setting `serviceAccount.name` **also suppressed** ServiceAccount creation — it was the
+only way to point workloads at an existing ServiceAccount. Creation is now gated solely on
+`serviceAccount.create` (default `true`).
+
+If you set `serviceAccount.name` to reference an externally-managed ServiceAccount, add
+`serviceAccount.create: false` (in the relevant chart / subchart block) so the chart does not try to
+create it and conflict with the existing resource:
+
+```yaml
+serviceAccount:
+  create: false           # add this line
+  name: my-preexisting-sa
+```
+
+## Related settings
+
+- **`serviceAccount.annotations`** — merged with `commonAnnotations` onto the created ServiceAccount.
+  Commonly used for cloud IAM binding, e.g. IRSA (`eks.amazonaws.com/role-arn`) or GKE Workload
+  Identity (`iam.gke.io/gcp-service-account`). Only applied when the chart creates the ServiceAccount.
+- **`serviceAccount.automountServiceAccountToken`** — controls token automounting on the created
+  ServiceAccount. Defaults vary by chart: `false` for `platform`, `portal-web`, and
+  `pipeline-optimization`; `true` for `studios`, `mcp`, `wave`, and `agent-backend`.
+- **`serviceAccount.imagePullSecretNames`** — extra image pull secrets attached to the ServiceAccount,
+  in addition to any generated from `global.imageCredentials` and `global.imageCredentialsSecrets`.

--- a/charts/platform/templates/_helpers.tpl
+++ b/charts/platform/templates/_helpers.tpl
@@ -22,7 +22,11 @@ Let the user specify a ServiceAccount name, or default to the same Service Accou
 by the Platform Terraform provider.
 */}}
 {{- define "platform.serviceAccountName" -}}
+  {{- if .Values.serviceAccount.create -}}
 {{- default (printf "%s-sa" (include "common.names.fullname" .)) .Values.serviceAccount.name -}}
+  {{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+  {{- end -}}
 {{- end -}}
 
 {{/*

--- a/charts/platform/templates/serviceaccount.yaml
+++ b/charts/platform/templates/serviceaccount.yaml
@@ -17,7 +17,7 @@
  limitations under the License.
 */}}
 
-{{ if not .Values.serviceAccount.name }}
+{{ if .Values.serviceAccount.create }}
   {{- $commonLabels := include "common.labels.standard" (dict "customLabels" .Values.commonLabels "context" $) | fromYaml -}}
   {{- $labels := include "common.tplvalues.render" (dict "value" $commonLabels "context" $) -}}
   {{- $mergedAnnotations := include "common.tplvalues.merge" (dict "values" (list .Values.serviceAccount.annotations .Values.commonAnnotations) "context" .) -}}

--- a/charts/platform/tests/deployment-backend_test.yaml
+++ b/charts/platform/tests/deployment-backend_test.yaml
@@ -1106,3 +1106,24 @@ tests:
       content:
         name: REDISCLI_TLS
         value: "1"
+
+- it: should use the default ServiceAccount when serviceAccount.create is false and no name is set
+  template: deployment-backend.yaml
+  set:
+    serviceAccount:
+      create: false
+  asserts:
+  - equal:
+      path: spec.template.spec.serviceAccountName
+      value: default
+
+- it: should use the provided ServiceAccount name when serviceAccount.create is false
+  template: deployment-backend.yaml
+  set:
+    serviceAccount:
+      create: false
+      name: my-custom-sa
+  asserts:
+  - equal:
+      path: spec.template.spec.serviceAccountName
+      value: my-custom-sa

--- a/charts/platform/tests/serviceaccount_test.yaml
+++ b/charts/platform/tests/serviceaccount_test.yaml
@@ -28,13 +28,33 @@ tests:
     asserts:
       - matchSnapshot: {}
 
-  - it: should not render a serviceaccount if user provides an existing service account by name
+  - it: should not render a serviceaccount when create is false
+    set:
+      serviceAccount:
+        create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render a serviceaccount when create is false even if a name is provided
+    set:
+      serviceAccount:
+        create: false
+        name: existing-service-account
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create a serviceaccount with a custom name when create is true and name is set
     set:
       serviceAccount:
         name: custom-service-account
     asserts:
-      - hasDocuments:
-          count: 0
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: custom-service-account
 
   - it: should render a serviceaccount with names of image pull secret created by Helm
     set:

--- a/charts/platform/values.schema.json
+++ b/charts/platform/values.schema.json
@@ -1372,6 +1372,12 @@
                 "string"
               ]
             },
+            "create": {
+              "default": true,
+              "description": "Whether to create a ServiceAccount. When `true`, the ServiceAccount named by\n`serviceAccount.name` is created (a `\u003crelease\u003e-\u003cchart\u003e-sa` name is generated when it is unset).\nSet to `false` to use an existing, externally-managed ServiceAccount referenced by\n`serviceAccount.name`.",
+              "title": "create",
+              "type": "boolean"
+            },
             "imagePullSecretNames": {
               "description": "Names of Secrets containing credentials to pull images from registries",
               "items": {
@@ -1382,7 +1388,7 @@
             },
             "name": {
               "default": "",
-              "description": "Service account name",
+              "description": "Name of the ServiceAccount used by this chart's workloads. When empty, a name is generated\nfrom the release name. Applies whether the ServiceAccount is created by this chart\n(`create: true`) or managed externally (`create: false`).",
               "title": "name",
               "type": "string"
             }
@@ -5122,6 +5128,12 @@
                 "string"
               ]
             },
+            "create": {
+              "default": true,
+              "description": "Whether to create a ServiceAccount. When `true`, the ServiceAccount named by\n`serviceAccount.name` is created (a `\u003crelease\u003e-\u003cchart\u003e-sa` name is generated when it is unset).\nSet to `false` to use an existing, externally-managed ServiceAccount referenced by\n`serviceAccount.name`.",
+              "title": "create",
+              "type": "boolean"
+            },
             "imagePullSecretNames": {
               "description": "Names of Secrets containing credentials to pull images from registries",
               "items": {
@@ -5132,7 +5144,7 @@
             },
             "name": {
               "default": "",
-              "description": "Service account name",
+              "description": "Name of the ServiceAccount used by this chart's workloads. When empty, a name is generated\nfrom the release name. Applies whether the ServiceAccount is created by this chart\n(`create: true`) or managed externally (`create: false`).",
               "title": "name",
               "type": "string"
             }
@@ -6123,6 +6135,12 @@
                 "string"
               ]
             },
+            "create": {
+              "default": true,
+              "description": "Whether to create a ServiceAccount. When `true`, the ServiceAccount named by\n`serviceAccount.name` is created (a `\u003crelease\u003e-\u003cchart\u003e-sa` name is generated when it is unset).\nSet to `false` to use an existing, externally-managed ServiceAccount referenced by\n`serviceAccount.name`.",
+              "title": "create",
+              "type": "boolean"
+            },
             "imagePullSecretNames": {
               "description": "Names of Secrets containing credentials to pull images from registries",
               "items": {
@@ -6133,7 +6151,7 @@
             },
             "name": {
               "default": "",
-              "description": "Name of an existing ServiceAccount. If not set, a new ServiceAccount is generated based on\nthe release name",
+              "description": "Name of the ServiceAccount used by this chart's workloads. When empty, a name is generated\nfrom the release name. Applies whether the ServiceAccount is created by this chart\n(`create: true`) or managed externally (`create: false`).",
               "title": "name",
               "type": "string"
             }
@@ -7469,6 +7487,12 @@
                 "string"
               ]
             },
+            "create": {
+              "default": true,
+              "description": "Whether to create a ServiceAccount. When `true`, the ServiceAccount named by\n`serviceAccount.name` is created (a `\u003crelease\u003e-\u003cchart\u003e-sa` name is generated when it is unset).\nSet to `false` to use an existing, externally-managed ServiceAccount referenced by\n`serviceAccount.name`.",
+              "title": "create",
+              "type": "boolean"
+            },
             "imagePullSecretNames": {
               "description": "Names of Secrets containing credentials to pull images from registries",
               "items": {
@@ -7479,7 +7503,7 @@
             },
             "name": {
               "default": "",
-              "description": "Service account name",
+              "description": "Name of the ServiceAccount used by this chart's workloads. When empty, a name is generated\nfrom the release name. Applies whether the ServiceAccount is created by this chart\n(`create: true`) or managed externally (`create: false`).",
               "title": "name",
               "type": "string"
             }
@@ -7631,6 +7655,12 @@
             "string"
           ]
         },
+        "create": {
+          "default": true,
+          "description": "Whether to create a ServiceAccount. When `true`, the ServiceAccount named by\n`serviceAccount.name` is created (a `\u003crelease\u003e-\u003cchart\u003e-sa` name is generated when it is unset).\nSet to `false` to use an existing, externally-managed ServiceAccount referenced by\n`serviceAccount.name`.",
+          "title": "create",
+          "type": "boolean"
+        },
         "imagePullSecretNames": {
           "description": "Names of Secrets containing credentials to pull images from registries",
           "items": {
@@ -7641,12 +7671,13 @@
         },
         "name": {
           "default": "",
-          "description": "Name of an existing ServiceAccount. If not set, a new ServiceAccount is generated based on\nthe release name",
+          "description": "Name of the ServiceAccount used by this chart's workloads. When empty, a name is generated\nfrom the release name. Applies whether the ServiceAccount is created by this chart\n(`create: true`) or managed externally (`create: false`).",
           "title": "name",
           "type": "string"
         }
       },
       "required": [
+        "create",
         "name",
         "annotations",
         "imagePullSecretNames"
@@ -8786,6 +8817,12 @@
                 "string"
               ]
             },
+            "create": {
+              "default": true,
+              "description": "Whether to create a ServiceAccount. When `true`, the ServiceAccount named by\n`serviceAccount.name` is created (a `\u003crelease\u003e-\u003cchart\u003e-sa` name is generated when it is unset).\nSet to `false` to use an existing, externally-managed ServiceAccount referenced by\n`serviceAccount.name`.",
+              "title": "create",
+              "type": "boolean"
+            },
             "imagePullSecretNames": {
               "description": "Names of Secrets containing credentials to pull images from registries",
               "items": {
@@ -8796,7 +8833,7 @@
             },
             "name": {
               "default": "",
-              "description": "Name of an existing ServiceAccount. If not set, a new ServiceAccount is generated based on\nthe release name",
+              "description": "Name of the ServiceAccount used by this chart's workloads. When empty, a name is generated\nfrom the release name. Applies whether the ServiceAccount is created by this chart\n(`create: true`) or managed externally (`create: false`).",
               "title": "name",
               "type": "string"
             }
@@ -9875,6 +9912,12 @@
                 "string"
               ]
             },
+            "create": {
+              "default": true,
+              "description": "Whether to create a ServiceAccount. When `true`, the ServiceAccount named by\n`serviceAccount.name` is created (a `\u003crelease\u003e-\u003cchart\u003e-sa` name is generated when it is unset).\nSet to `false` to use an existing, externally-managed ServiceAccount referenced by\n`serviceAccount.name`.",
+              "title": "create",
+              "type": "boolean"
+            },
             "imagePullSecretNames": {
               "description": "Names of Secrets containing credentials to pull images from registries",
               "items": {
@@ -9885,7 +9928,7 @@
             },
             "name": {
               "default": "",
-              "description": "Service account name",
+              "description": "Name of the ServiceAccount used by this chart's workloads. When empty, a name is generated\nfrom the release name. Applies whether the ServiceAccount is created by this chart\n(`create: true`) or managed externally (`create: false`).",
               "title": "name",
               "type": "string"
             }

--- a/charts/platform/values.yaml
+++ b/charts/platform/values.yaml
@@ -1546,8 +1546,15 @@ initContainerDependencies:
     extraVolumeMounts: []
 
 serviceAccount:
-  # -- Name of an existing ServiceAccount. If not set, a new ServiceAccount is generated based on
-  # the release name
+  # -- Whether to create a ServiceAccount. When `true`, the ServiceAccount named by
+  # `serviceAccount.name` is created (a `<release>-<chart>-sa` name is generated when it is unset).
+  # Set to `false` to use an existing, externally-managed ServiceAccount referenced by
+  # `serviceAccount.name`.
+  # @section -- Service Account
+  create: true
+  # -- Name of the ServiceAccount used by this chart's workloads. When empty, a name is generated
+  # from the release name. Applies whether the ServiceAccount is created by this chart
+  # (`create: true`) or managed externally (`create: false`).
   # @section -- Service Account
   name: ""
   # -- Additional annotations for the ServiceAccount to generate


### PR DESCRIPTION
The following allows the toggle of service account creation along with the creation of specifically named service accounts which can match existing infrastructure deployments. 

For example if the infrastructure team owns pod-identity bindings you can specify their use their naming conventions without having to manually define the kubernetes manifests and apply these independently. 

