### PR TITLE
feat: Downgrade default mysql shell used from 9 to 8.4

### DIFF
--- a/charts/platform/CHANGELOG.md
+++ b/charts/platform/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.36.0] - 2026-07-16
 
 ### Added
 
@@ -25,6 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `serviceAccount.create` (default `true`). Migration: if you set `serviceAccount.name` to reference
   an externally-managed ServiceAccount, also set `serviceAccount.create: false` to preserve the
   previous behaviour.
+- Downgrade the default `waitForMySQL` init container image tag from `9` to `8.4` in the `platform`
+  chart and the `agent-backend` and `pipeline-optimization` subcharts, so all `waitForMySQL` init
+  containers default to MySQL `8.4`.
 
 ## [0.35.1] - 2026-07-13
 

--- a/charts/platform/Chart.yaml
+++ b/charts/platform/Chart.yaml
@@ -38,7 +38,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.35.1
+version: 0.36.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/platform/README.md
+++ b/charts/platform/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart to deploy Seqera Platform (also referred to as Tower) on Kubernetes.
 
-![Version: 0.35.1](https://img.shields.io/badge/Version-0.35.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v26.1.3](https://img.shields.io/badge/AppVersion-v26.1.3-informational?style=flat-square)
+![Version: 0.36.0](https://img.shields.io/badge/Version-0.36.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v26.1.3](https://img.shields.io/badge/AppVersion-v26.1.3-informational?style=flat-square)
 
 Some basic familiarity with Helm is assumed. If you are new to Helm, please refer to the [Helm documentation](https://helm.sh/docs/).
 We recommend reading through the `values.yaml` file to understand the configuration options available for the chart. Each entry is documented with `# --` comments describing its purpose and usage. Other annotations are used to automatically generate the README files and can be ignored:
@@ -47,13 +47,13 @@ To install the chart:
 
 1. Download the default values file:
    ```console
-   helm show values oci://public.cr.seqera.io/charts/platform --version 0.35.1 > values.yaml
+   helm show values oci://public.cr.seqera.io/charts/platform --version 0.36.0 > values.yaml
    ```
 2. Edit `values.yaml` to match your environment. We recommend removing entries whose defaults you don't need to override — this keeps your configuration file focused and easier to maintain across upgrades.
 3. Install the chart with the release name `my-release`:
    ```console
    helm install my-release oci://public.cr.seqera.io/charts/platform \
-     --version 0.35.1 \
+     --version 0.36.0 \
      --namespace my-namespace \
      --create-namespace \
      -f values.yaml
@@ -69,7 +69,7 @@ Charts are also published to a traditional Helm repository. This can be useful i
 helm repo add seqeralabs https://seqeralabs.github.io/helm-charts
 helm repo update
 helm install my-release seqeralabs/platform \
-  --version 0.35.1 \
+  --version 0.36.0 \
   --namespace my-namespace \
   --create-namespace \
   -f values.yaml
@@ -578,7 +578,7 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | initContainerDependencies.waitForMySQL.enabled | bool | `true` | Enable wait for MySQL init container before starting backend and cron |
 | initContainerDependencies.waitForMySQL.image.registry | string | `""` | Override default wait for MySQL init container image |
 | initContainerDependencies.waitForMySQL.image.repository | string | `"mysql"` | Init container image repository |
-| initContainerDependencies.waitForMySQL.image.tag | string | `"9"` | Init container image tag |
+| initContainerDependencies.waitForMySQL.image.tag | string | `"8.4"` | Init container image tag |
 | initContainerDependencies.waitForMySQL.image.digest | string | `""` | Init container image digest in the format `sha256:1234abcdef` |
 | initContainerDependencies.waitForMySQL.image.pullPolicy | string | `"IfNotPresent"` | imagePullPolicy for the init container |
 | initContainerDependencies.waitForMySQL.securityContext.runAsUser | int | `101` | UID the container processes run as (overrides container image default) |

--- a/charts/platform/charts/agent-backend/CHANGELOG.md
+++ b/charts/platform/charts/agent-backend/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.2.0] - 2026-07-16
 
 ### Added
 
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Downgrade the default `waitForMySQL` init container image tag from `9` to `8.4` to match the
+  MySQL version used elsewhere in the chart.
 - **BREAKING**: `serviceAccount.name` no longer suppresses ServiceAccount creation. Previously,
   setting `serviceAccount.name` caused the chart to skip creating a ServiceAccount and reference an
   existing one instead. Creation is now gated solely on `serviceAccount.create` (default `true`).

--- a/charts/platform/charts/agent-backend/Chart.yaml
+++ b/charts/platform/charts/agent-backend/Chart.yaml
@@ -19,7 +19,7 @@ apiVersion: v2
 name: agent-backend
 description: Backend service for Seqera CLI AI capabilities
 type: application
-version: 1.1.0
+version: 1.2.0
 appVersion: "1.13.1"
 icon: https://raw.githubusercontent.com/seqeralabs/helm-charts/master/media/seqera-icon-light.svg
 maintainers:

--- a/charts/platform/charts/agent-backend/README.md
+++ b/charts/platform/charts/agent-backend/README.md
@@ -2,7 +2,7 @@
 
 Backend service for Seqera CLI AI capabilities
 
-![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.13.1](https://img.shields.io/badge/AppVersion-1.13.1-informational?style=flat-square)
+![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.13.1](https://img.shields.io/badge/AppVersion-1.13.1-informational?style=flat-square)
 
 Some basic familiarity with Helm is assumed. If you are new to Helm, please refer to the [Helm documentation](https://helm.sh/docs/).
 We recommend reading through the `values.yaml` file to understand the configuration options available for the chart. Each entry is documented with `# --` comments describing its purpose and usage. Other annotations are used to automatically generate the README files and can be ignored:
@@ -50,13 +50,13 @@ To install the chart:
 
 1. Download the default values file:
    ```console
-   helm show values oci://public.cr.seqera.io/charts/agent-backend --version 1.1.0 > values.yaml
+   helm show values oci://public.cr.seqera.io/charts/agent-backend --version 1.2.0 > values.yaml
    ```
 2. Edit `values.yaml` to match your environment. We recommend removing entries whose defaults you don't need to override — this keeps your configuration file focused and easier to maintain across upgrades.
 3. Install the chart with the release name `my-release`:
    ```console
    helm install my-release oci://public.cr.seqera.io/charts/agent-backend \
-     --version 1.1.0 \
+     --version 1.2.0 \
      --namespace my-namespace \
      --create-namespace \
      -f values.yaml
@@ -72,7 +72,7 @@ Charts are also published to a traditional Helm repository. This can be useful i
 helm repo add seqeralabs https://seqeralabs.github.io/helm-charts
 helm repo update
 helm install my-release seqeralabs/agent-backend \
-  --version 1.1.0 \
+  --version 1.2.0 \
   --namespace my-namespace \
   --create-namespace \
   -f values.yaml
@@ -309,7 +309,7 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | initContainerDependencies.waitForMySQL.enabled | bool | `true` | Enable wait for MySQL init container before starting the main container |
 | initContainerDependencies.waitForMySQL.image.registry | string | `""` | Override default wait for MySQL init container image |
 | initContainerDependencies.waitForMySQL.image.repository | string | `"mysql"` | Init container image repository |
-| initContainerDependencies.waitForMySQL.image.tag | string | `"9"` | Init container image tag |
+| initContainerDependencies.waitForMySQL.image.tag | string | `"8.4"` | Init container image tag |
 | initContainerDependencies.waitForMySQL.image.digest | string | `""` | Init container image digest in the format `sha256:1234abcdef` |
 | initContainerDependencies.waitForMySQL.image.pullPolicy | string | `"IfNotPresent"` | imagePullPolicy for the init container |
 | initContainerDependencies.waitForMySQL.securityContext.runAsUser | int | `101` | UID the container processes run as (overrides container image default) |

--- a/charts/platform/charts/agent-backend/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/platform/charts/agent-backend/tests/__snapshot__/deployment_test.yaml.snap
@@ -109,7 +109,7 @@ should render a Deployment with default values:
                     secretKeyRef:
                       key: AGENT_BACKEND_DB_PASSWORD
                       name: release-name-agent-backend
-              image: mysql:9
+              image: mysql:8.4
               imagePullPolicy: IfNotPresent
               name: wait-for-db
               resources:

--- a/charts/platform/charts/agent-backend/values.schema.json
+++ b/charts/platform/charts/agent-backend/values.schema.json
@@ -875,7 +875,7 @@
                   "type": "string"
                 },
                 "tag": {
-                  "default": "9",
+                  "default": "8.4",
                   "description": "Init container image tag",
                   "title": "tag",
                   "type": "string"

--- a/charts/platform/charts/agent-backend/values.yaml
+++ b/charts/platform/charts/agent-backend/values.yaml
@@ -543,7 +543,7 @@ initContainerDependencies:
       repository: mysql
       # -- Init container image tag
       # @section -- Init Container Dependencies: Wait For MySQL
-      tag: "9"
+      tag: "8.4"
       # -- Init container image digest in the format `sha256:1234abcdef`
       # @section -- Init Container Dependencies: Wait For MySQL
       digest: ""

--- a/charts/platform/charts/pipeline-optimization/CHANGELOG.md
+++ b/charts/platform/charts/pipeline-optimization/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.2.0] - 2026-07-16
 
 ### Added
 
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   created rather than only referenced.
 
 ### Changed
+
+- Downgrade the default `waitForMySQL` init container image tag from `9` to `8.4` to match the
+  MySQL version used elsewhere in the chart.
 
 - **BREAKING**: `serviceAccount.name` no longer suppresses ServiceAccount creation. Previously,
   setting `serviceAccount.name` caused the chart to skip creating a ServiceAccount and reference an

--- a/charts/platform/charts/pipeline-optimization/Chart.yaml
+++ b/charts/platform/charts/pipeline-optimization/Chart.yaml
@@ -23,7 +23,7 @@ maintainers:
     email: devops@seqera.io
     url: https://seqera.io
 type: application
-version: 2.1.0
+version: 2.2.0
 appVersion: "0.4.15"
 icon: https://raw.githubusercontent.com/seqeralabs/helm-charts/master/media/seqera-icon-light.svg
 annotations:

--- a/charts/platform/charts/pipeline-optimization/README.md
+++ b/charts/platform/charts/pipeline-optimization/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart to deploy the Seqera Pipeline Optimization service (referred to as Groundswell in Platform configuration files).
 
-![Version: 2.1.0](https://img.shields.io/badge/Version-2.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.15](https://img.shields.io/badge/AppVersion-0.4.15-informational?style=flat-square)
+![Version: 2.2.0](https://img.shields.io/badge/Version-2.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.15](https://img.shields.io/badge/AppVersion-0.4.15-informational?style=flat-square)
 
 Some basic familiarity with Helm is assumed. If you are new to Helm, please refer to the [Helm documentation](https://helm.sh/docs/).
 We recommend reading through the `values.yaml` file to understand the configuration options available for the chart. Each entry is documented with `# --` comments describing its purpose and usage. Other annotations are used to automatically generate the README files and can be ignored:
@@ -40,13 +40,13 @@ To install the chart:
 
 1. Download the default values file:
    ```console
-   helm show values oci://public.cr.seqera.io/charts/pipeline-optimization --version 2.1.0 > values.yaml
+   helm show values oci://public.cr.seqera.io/charts/pipeline-optimization --version 2.2.0 > values.yaml
    ```
 2. Edit `values.yaml` to match your environment. We recommend removing entries whose defaults you don't need to override — this keeps your configuration file focused and easier to maintain across upgrades.
 3. Install the chart with the release name `my-release`:
    ```console
    helm install my-release oci://public.cr.seqera.io/charts/pipeline-optimization \
-     --version 2.1.0 \
+     --version 2.2.0 \
      --namespace my-namespace \
      --create-namespace \
      -f values.yaml
@@ -62,7 +62,7 @@ Charts are also published to a traditional Helm repository. This can be useful i
 helm repo add seqeralabs https://seqeralabs.github.io/helm-charts
 helm repo update
 helm install my-release seqeralabs/pipeline-optimization \
-  --version 2.1.0 \
+  --version 2.2.0 \
   --namespace my-namespace \
   --create-namespace \
   -f values.yaml
@@ -279,7 +279,7 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | initContainerDependencies.waitForMySQL.enabled | bool | `true` | Enable wait for MySQL init container before starting pipeline optimization and cron |
 | initContainerDependencies.waitForMySQL.image.registry | string | `""` | Override default wait for MySQL init container image |
 | initContainerDependencies.waitForMySQL.image.repository | string | `"mysql"` | Init container image repository |
-| initContainerDependencies.waitForMySQL.image.tag | string | `"9"` | Init container image tag |
+| initContainerDependencies.waitForMySQL.image.tag | string | `"8.4"` | Init container image tag |
 | initContainerDependencies.waitForMySQL.image.digest | string | `""` | Init container image digest in the format `sha256:1234abcdef` |
 | initContainerDependencies.waitForMySQL.image.pullPolicy | string | `"IfNotPresent"` | imagePullPolicy for the init container |
 | initContainerDependencies.waitForMySQL.securityContext.runAsUser | int | `101` | UID the container processes run as (overrides container image default) |

--- a/charts/platform/charts/pipeline-optimization/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/platform/charts/pipeline-optimization/tests/__snapshot__/deployment_test.yaml.snap
@@ -75,7 +75,7 @@ should produce a Deployment resource with minimal values:
               secretKeyRef:
                 key: SWELL_DB_PASSWORD
                 name: release-name-pipeline-optimization
-        image: mysql:9
+        image: mysql:8.4
         imagePullPolicy: IfNotPresent
         name: wait-for-pipeline-optimization-db
         resources:
@@ -117,7 +117,7 @@ should produce a Deployment resource with minimal values:
               secretKeyRef:
                 key: TOWER_DB_PASSWORD
                 name: release-name-pipeline-optimization
-        image: mysql:9
+        image: mysql:8.4
         imagePullPolicy: IfNotPresent
         name: wait-for-platform-db
         resources:
@@ -279,7 +279,7 @@ should render the deployment with the correct checksums, labels and annotations:
                     secretKeyRef:
                       key: SWELL_DB_PASSWORD
                       name: release-name-pipeline-optimization
-              image: mysql:9
+              image: mysql:8.4
               imagePullPolicy: IfNotPresent
               name: wait-for-pipeline-optimization-db
               resources:
@@ -321,7 +321,7 @@ should render the deployment with the correct checksums, labels and annotations:
                     secretKeyRef:
                       key: TOWER_DB_PASSWORD
                       name: release-name-pipeline-optimization
-              image: mysql:9
+              image: mysql:8.4
               imagePullPolicy: IfNotPresent
               name: wait-for-platform-db
               resources:

--- a/charts/platform/charts/pipeline-optimization/values.schema.json
+++ b/charts/platform/charts/pipeline-optimization/values.schema.json
@@ -493,7 +493,7 @@
                   "type": "string"
                 },
                 "tag": {
-                  "default": "9",
+                  "default": "8.4",
                   "description": "Init container image tag",
                   "title": "tag",
                   "type": "string"

--- a/charts/platform/charts/pipeline-optimization/values.yaml
+++ b/charts/platform/charts/pipeline-optimization/values.yaml
@@ -483,7 +483,7 @@ initContainerDependencies:
       repository: mysql
       # -- Init container image tag
       # @section -- Init Container Dependencies: Wait For MySQL
-      tag: "9"
+      tag: "8.4"
       # -- Init container image digest in the format `sha256:1234abcdef`
       # @section -- Init Container Dependencies: Wait For MySQL
       digest: ""

--- a/charts/platform/tests/__snapshot__/deployment-backend_test.yaml.snap
+++ b/charts/platform/tests/__snapshot__/deployment-backend_test.yaml.snap
@@ -103,7 +103,7 @@ should produce a Deployment resource with minimal values:
               secretKeyRef:
                 key: TOWER_DB_PASSWORD
                 name: release-name-platform-backend
-        image: mysql:9
+        image: mysql:8.4
         imagePullPolicy: IfNotPresent
         name: wait-for-platform-db
         resources:
@@ -344,7 +344,7 @@ should render the backend deployment with the correct checksums, labels and anno
                     secretKeyRef:
                       key: db-password-key
                       name: unittest
-              image: mysql:9
+              image: mysql:8.4
               imagePullPolicy: IfNotPresent
               name: wait-for-platform-db
               resources:

--- a/charts/platform/tests/__snapshot__/deployment-cron_test.yaml.snap
+++ b/charts/platform/tests/__snapshot__/deployment-cron_test.yaml.snap
@@ -98,7 +98,7 @@ should produce a Deployment resource with minimal values:
               secretKeyRef:
                 key: TOWER_DB_PASSWORD
                 name: release-name-platform-backend
-        image: mysql:9
+        image: mysql:8.4
         imagePullPolicy: IfNotPresent
         name: wait-for-platform-db
         resources:
@@ -335,7 +335,7 @@ should render the cron deployment with the correct checksums, labels and annotat
                     secretKeyRef:
                       key: db-password-key
                       name: unittest
-              image: mysql:9
+              image: mysql:8.4
               imagePullPolicy: IfNotPresent
               name: wait-for-platform-db
               resources:

--- a/charts/platform/values.schema.json
+++ b/charts/platform/values.schema.json
@@ -784,7 +784,7 @@
                       "type": "string"
                     },
                     "tag": {
-                      "default": "9",
+                      "default": "8.4",
                       "description": "Init container image tag",
                       "title": "tag",
                       "type": "string"
@@ -3925,7 +3925,7 @@
                   "type": "string"
                 },
                 "tag": {
-                  "default": "9",
+                  "default": "8.4",
                   "description": "Init container image tag",
                   "title": "tag",
                   "type": "string"
@@ -5681,7 +5681,7 @@
                       "type": "string"
                     },
                     "tag": {
-                      "default": "9",
+                      "default": "8.4",
                       "description": "Init container image tag",
                       "title": "tag",
                       "type": "string"

--- a/charts/platform/values.yaml
+++ b/charts/platform/values.yaml
@@ -1386,7 +1386,7 @@ initContainerDependencies:
       repository: mysql
       # -- Init container image tag
       # @section -- Init Container Dependencies: Wait For MySQL
-      tag: "9"
+      tag: "8.4"
       # -- Init container image digest in the format `sha256:1234abcdef`
       # @section -- Init Container Dependencies: Wait For MySQL
       digest: ""


### PR DESCRIPTION
MySQL 9 isn't supported by Platform and other Seqera products. Using MySQL 9 for the initContainer that waits for the platform db to be ready is probably fine, but better to keep the versions aligned

This will trigger the release of three new charts which will include the `serviceAccount.create` change #187.