### PR TITLE
feat(helm): support portName in ingress extraHosts

### DIFF
--- a/charts/platform/CHANGELOG.md
+++ b/charts/platform/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.38.0] - 2026-07-17
+
+### Added
+
+- Backend deployment now sets `TOWER_AI_BASE_URL` (to `https://<global.portalWebDomain>`) when the
+  `portal-web` subchart is enabled, and `TOWER_AGENT_BACKEND_URL` (to
+  `https://<global.agentBackendDomain>`) when the `agent-backend` subchart is enabled.
+
 ## [0.37.0] - 2026-07-17
 
 ### Added

--- a/charts/platform/CHANGELOG.md
+++ b/charts/platform/CHANGELOG.md
@@ -5,10 +5,13 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.38.0] - 2026-07-17
+## [0.37.0] - 2026-07-20
 
 ### Added
 
+- `ingress.extraHosts[].paths[].portName` as an alternative to `portNumber`, for referencing ALB
+  annotation-based actions (for example `portName: use-annotation`). Takes precedence over
+  `portNumber` when both are set.
 - Backend deployment now sets `TOWER_AI_BASE_URL` (to `https://<global.portalWebDomain>`) when the
   `portal-web` subchart is enabled, and `TOWER_AGENT_BACKEND_URL` (to
   `https://<global.agentBackendDomain>`) when the `agent-backend` subchart is enabled.
@@ -22,14 +25,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `REDIS_PASSWORD` (matching the chart-managed Secret) instead of `WAVE_REDIS_PASSWORD`; previously
   setting `redis.password` inline caused the Wave pod to fail to start with
   `CreateContainerConfigError`.
-
-## [0.37.0] - 2026-07-17
-
-### Added
-
-- `ingress.extraHosts[].paths[].portName` as an alternative to `portNumber`, for referencing ALB
-  annotation-based actions (for example `portName: use-annotation`). Takes precedence over
-  `portNumber` when both are set.
 
 ### Changed
 

--- a/charts/platform/CHANGELOG.md
+++ b/charts/platform/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.37.0] - 2026-07-17
+
+### Added
+
+- `ingress.extraHosts[].paths[].portName` as an alternative to `portNumber`, for referencing ALB
+  annotation-based actions (for example `portName: use-annotation`). Takes precedence over
+  `portNumber` when both are set.
+
+### Changed
+
+- Bumped subchart dependency versions to pick up the same `ingress.extraHosts` `portName` support:
+  `agent-backend` to `1.3.x`, `mcp` to `0.7.x`, `portal-web` to `0.6.x`, `studios` to `1.7.x`, and
+  `wave` to `0.5.x`.
+
 ## [0.36.1] - 2026-07-17
 
 ### Changed

--- a/charts/platform/CHANGELOG.md
+++ b/charts/platform/CHANGELOG.md
@@ -13,6 +13,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `portal-web` subchart is enabled, and `TOWER_AGENT_BACKEND_URL` (to
   `https://<global.agentBackendDomain>`) when the `agent-backend` subchart is enabled.
 
+### Fixed
+
+- Bumped the `wave` subchart dependency to `0.6.x`, which fixes `WAVE_SERVER_URL` to be derived from
+  `global.waveDomain` instead of `global.platformExternalDomain`, so it points at the Wave subdomain
+  used for container pulls.
+- Picked up the `wave` subchart fix for the Redis password Secret key, which now defaults to
+  `REDIS_PASSWORD` (matching the chart-managed Secret) instead of `WAVE_REDIS_PASSWORD`; previously
+  setting `redis.password` inline caused the Wave pod to fail to start with
+  `CreateContainerConfigError`.
+
 ## [0.37.0] - 2026-07-17
 
 ### Added

--- a/charts/platform/Chart.lock
+++ b/charts/platform/Chart.lock
@@ -13,7 +13,7 @@ dependencies:
   version: 1.7.0
 - name: wave
   repository: file://charts/wave
-  version: 0.6.0
+  version: 0.5.0
 - name: mcp
   repository: file://charts/mcp
   version: 0.7.0
@@ -23,5 +23,5 @@ dependencies:
 - name: portal-web
   repository: file://charts/portal-web
   version: 0.6.0
-digest: sha256:f2b5d3fa81e3cc87cdae278b7438356b2737d28f526224cca083a705907b2b84
-generated: "2026-07-20T13:17:07.132824151+02:00"
+digest: sha256:c5e2d2fdf3dead48a2185dac462343774b44157b15beab47564562cb42d21b1d
+generated: "2026-07-20T15:39:32.304798461+02:00"

--- a/charts/platform/Chart.lock
+++ b/charts/platform/Chart.lock
@@ -13,7 +13,7 @@ dependencies:
   version: 1.7.0
 - name: wave
   repository: file://charts/wave
-  version: 0.5.0
+  version: 0.6.0
 - name: mcp
   repository: file://charts/mcp
   version: 0.7.0
@@ -23,5 +23,5 @@ dependencies:
 - name: portal-web
   repository: file://charts/portal-web
   version: 0.6.0
-digest: sha256:c5e2d2fdf3dead48a2185dac462343774b44157b15beab47564562cb42d21b1d
-generated: "2026-07-17T18:33:04.245313+02:00"
+digest: sha256:f2b5d3fa81e3cc87cdae278b7438356b2737d28f526224cca083a705907b2b84
+generated: "2026-07-20T13:17:07.132824151+02:00"

--- a/charts/platform/Chart.lock
+++ b/charts/platform/Chart.lock
@@ -10,18 +10,18 @@ dependencies:
   version: 2.2.1
 - name: studios
   repository: file://charts/studios
-  version: 1.6.0
+  version: 1.7.0
 - name: wave
   repository: file://charts/wave
-  version: 0.4.0
+  version: 0.5.0
 - name: mcp
   repository: file://charts/mcp
-  version: 0.6.0
+  version: 0.7.0
 - name: agent-backend
   repository: file://charts/agent-backend
-  version: 1.2.1
+  version: 1.3.0
 - name: portal-web
   repository: file://charts/portal-web
-  version: 0.5.0
-digest: sha256:6dcb250da7297b41dd1c4febacb707979566fad612d442c6c96bce069498d4f5
-generated: "2026-07-17T11:32:27.808877596+02:00"
+  version: 0.6.0
+digest: sha256:c5e2d2fdf3dead48a2185dac462343774b44157b15beab47564562cb42d21b1d
+generated: "2026-07-17T18:33:04.245313+02:00"

--- a/charts/platform/Chart.yaml
+++ b/charts/platform/Chart.yaml
@@ -38,7 +38,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.36.1
+version: 0.37.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -81,13 +81,13 @@ dependencies:
       - studios
     condition: studios.enabled
   - name: wave
-    version: "0.4.x"
+    version: "0.5.x"
     repository: "file://charts/wave"
     tags:
       - wave
     condition: wave.enabled
   - name: mcp
-    version: "0.6.x"
+    version: "0.7.x"
     repository: "file://charts/mcp"
     tags:
       - mcp
@@ -99,7 +99,7 @@ dependencies:
       - agent-backend
     condition: agent-backend.enabled
   - name: portal-web
-    version: "0.5.x"
+    version: "0.6.x"
     repository: "file://charts/portal-web"
     tags:
       - portal-web

--- a/charts/platform/Chart.yaml
+++ b/charts/platform/Chart.yaml
@@ -38,7 +38,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.37.0
+version: 0.38.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/platform/Chart.yaml
+++ b/charts/platform/Chart.yaml
@@ -81,7 +81,7 @@ dependencies:
       - studios
     condition: studios.enabled
   - name: wave
-    version: "0.5.x"
+    version: "0.6.x"
     repository: "file://charts/wave"
     tags:
       - wave

--- a/charts/platform/Chart.yaml
+++ b/charts/platform/Chart.yaml
@@ -38,7 +38,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.38.0
+version: 0.37.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -81,7 +81,7 @@ dependencies:
       - studios
     condition: studios.enabled
   - name: wave
-    version: "0.6.x"
+    version: "0.5.x"
     repository: "file://charts/wave"
     tags:
       - wave

--- a/charts/platform/README.md
+++ b/charts/platform/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart to deploy Seqera Platform (also referred to as Tower) on Kubernetes.
 
-![Version: 0.36.1](https://img.shields.io/badge/Version-0.36.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v26.1.3](https://img.shields.io/badge/AppVersion-v26.1.3-informational?style=flat-square)
+![Version: 0.37.0](https://img.shields.io/badge/Version-0.37.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v26.1.3](https://img.shields.io/badge/AppVersion-v26.1.3-informational?style=flat-square)
 
 Some basic familiarity with Helm is assumed. If you are new to Helm, please refer to the [Helm documentation](https://helm.sh/docs/).
 We recommend reading through the `values.yaml` file to understand the configuration options available for the chart. Each entry is documented with `# --` comments describing its purpose and usage. Other annotations are used to automatically generate the README files and can be ignored:
@@ -48,13 +48,13 @@ To install the chart:
 
 1. Download the default values file:
    ```console
-   helm show values oci://public.cr.seqera.io/charts/platform --version 0.36.1 > values.yaml
+   helm show values oci://public.cr.seqera.io/charts/platform --version 0.37.0 > values.yaml
    ```
 2. Edit `values.yaml` to match your environment. We recommend removing entries whose defaults you don't need to override — this keeps your configuration file focused and easier to maintain across upgrades.
 3. Install the chart with the release name `my-release`:
    ```console
    helm install my-release oci://public.cr.seqera.io/charts/platform \
-     --version 0.36.1 \
+     --version 0.37.0 \
      --namespace my-namespace \
      --create-namespace \
      -f values.yaml
@@ -70,7 +70,7 @@ Charts are also published to a traditional Helm repository. This can be useful i
 helm repo add seqeralabs https://seqeralabs.github.io/helm-charts
 helm repo update
 helm install my-release seqeralabs/platform \
-  --version 0.36.1 \
+  --version 0.37.0 \
   --namespace my-namespace \
   --create-namespace \
   -f values.yaml
@@ -92,11 +92,11 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 |------------|------|---------|
 | file://../seqera-common | seqera-common | 3.x.x |
 | file://charts/agent-backend | agent-backend | 1.x.x |
-| file://charts/mcp | mcp | 0.6.x |
+| file://charts/mcp | mcp | 0.7.x |
 | file://charts/pipeline-optimization | pipeline-optimization | 2.x.x |
-| file://charts/portal-web | portal-web | 0.5.x |
+| file://charts/portal-web | portal-web | 0.6.x |
 | file://charts/studios | studios | 1.x.x |
-| file://charts/wave | wave | 0.4.x |
+| file://charts/wave | wave | 0.5.x |
 | oci://registry-1.docker.io/bitnamicharts | common | 2.x.x |
 
 ## Values
@@ -645,7 +645,7 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | ingress.contentPath | string | `""` | Path for the content domain ingress rule. When empty, falls back to `ingress.path` |
 | ingress.defaultPathType | string | `""` | Default path type for the Ingress. When empty, falls back to `global.ingress.defaultPathType` |
 | ingress.defaultBackend | object | `{}` | Configure the default service for the ingress (evaluated as template) Important: make sure only one defaultBackend is defined across the k8s cluster: if the ingress doesn't reconcile successfully, 'describe ingress <name>' will report problems |
-| ingress.extraHosts | list | `[]` | Additional hosts you want to include. Evaluated as a template |
+| ingress.extraHosts | list | `[]` | Additional hosts you want to include. Evaluated as a template. Each path's backend takes either `portNumber` or `portName` (e.g. `use-annotation` to reference an ALB action defined via `ingress.annotations`). |
 | ingress.annotations | object | `{}` | Ingress annotations specific to your load balancer. Evaluated as a template |
 | ingress.extraLabels | object | `{}` | Additional labels for the ingress object. Evaluated as a template |
 | ingress.ingressClassName | string | `""` | Name of the ingress class (replaces the deprecated annotation `kubernetes.io/ingress.class`). When empty, falls back to `global.ingress.ingressClassName` |

--- a/charts/platform/README.md
+++ b/charts/platform/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart to deploy Seqera Platform (also referred to as Tower) on Kubernetes.
 
-![Version: 0.38.0](https://img.shields.io/badge/Version-0.38.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v26.1.3](https://img.shields.io/badge/AppVersion-v26.1.3-informational?style=flat-square)
+![Version: 0.37.0](https://img.shields.io/badge/Version-0.37.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v26.1.3](https://img.shields.io/badge/AppVersion-v26.1.3-informational?style=flat-square)
 
 Some basic familiarity with Helm is assumed. If you are new to Helm, please refer to the [Helm documentation](https://helm.sh/docs/).
 We recommend reading through the `values.yaml` file to understand the configuration options available for the chart. Each entry is documented with `# --` comments describing its purpose and usage. Other annotations are used to automatically generate the README files and can be ignored:
@@ -48,13 +48,13 @@ To install the chart:
 
 1. Download the default values file:
    ```console
-   helm show values oci://public.cr.seqera.io/charts/platform --version 0.38.0 > values.yaml
+   helm show values oci://public.cr.seqera.io/charts/platform --version 0.37.0 > values.yaml
    ```
 2. Edit `values.yaml` to match your environment. We recommend removing entries whose defaults you don't need to override — this keeps your configuration file focused and easier to maintain across upgrades.
 3. Install the chart with the release name `my-release`:
    ```console
    helm install my-release oci://public.cr.seqera.io/charts/platform \
-     --version 0.38.0 \
+     --version 0.37.0 \
      --namespace my-namespace \
      --create-namespace \
      -f values.yaml
@@ -70,7 +70,7 @@ Charts are also published to a traditional Helm repository. This can be useful i
 helm repo add seqeralabs https://seqeralabs.github.io/helm-charts
 helm repo update
 helm install my-release seqeralabs/platform \
-  --version 0.38.0 \
+  --version 0.37.0 \
   --namespace my-namespace \
   --create-namespace \
   -f values.yaml
@@ -96,7 +96,7 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | file://charts/pipeline-optimization | pipeline-optimization | 2.x.x |
 | file://charts/portal-web | portal-web | 0.6.x |
 | file://charts/studios | studios | 1.x.x |
-| file://charts/wave | wave | 0.6.x |
+| file://charts/wave | wave | 0.5.x |
 | oci://registry-1.docker.io/bitnamicharts | common | 2.x.x |
 
 ## Values

--- a/charts/platform/README.md
+++ b/charts/platform/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart to deploy Seqera Platform (also referred to as Tower) on Kubernetes.
 
-![Version: 0.37.0](https://img.shields.io/badge/Version-0.37.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v26.1.3](https://img.shields.io/badge/AppVersion-v26.1.3-informational?style=flat-square)
+![Version: 0.38.0](https://img.shields.io/badge/Version-0.38.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v26.1.3](https://img.shields.io/badge/AppVersion-v26.1.3-informational?style=flat-square)
 
 Some basic familiarity with Helm is assumed. If you are new to Helm, please refer to the [Helm documentation](https://helm.sh/docs/).
 We recommend reading through the `values.yaml` file to understand the configuration options available for the chart. Each entry is documented with `# --` comments describing its purpose and usage. Other annotations are used to automatically generate the README files and can be ignored:
@@ -48,13 +48,13 @@ To install the chart:
 
 1. Download the default values file:
    ```console
-   helm show values oci://public.cr.seqera.io/charts/platform --version 0.37.0 > values.yaml
+   helm show values oci://public.cr.seqera.io/charts/platform --version 0.38.0 > values.yaml
    ```
 2. Edit `values.yaml` to match your environment. We recommend removing entries whose defaults you don't need to override — this keeps your configuration file focused and easier to maintain across upgrades.
 3. Install the chart with the release name `my-release`:
    ```console
    helm install my-release oci://public.cr.seqera.io/charts/platform \
-     --version 0.37.0 \
+     --version 0.38.0 \
      --namespace my-namespace \
      --create-namespace \
      -f values.yaml
@@ -70,7 +70,7 @@ Charts are also published to a traditional Helm repository. This can be useful i
 helm repo add seqeralabs https://seqeralabs.github.io/helm-charts
 helm repo update
 helm install my-release seqeralabs/platform \
-  --version 0.37.0 \
+  --version 0.38.0 \
   --namespace my-namespace \
   --create-namespace \
   -f values.yaml

--- a/charts/platform/README.md
+++ b/charts/platform/README.md
@@ -96,7 +96,7 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | file://charts/pipeline-optimization | pipeline-optimization | 2.x.x |
 | file://charts/portal-web | portal-web | 0.6.x |
 | file://charts/studios | studios | 1.x.x |
-| file://charts/wave | wave | 0.5.x |
+| file://charts/wave | wave | 0.6.x |
 | oci://registry-1.docker.io/bitnamicharts | common | 2.x.x |
 
 ## Values

--- a/charts/platform/charts/agent-backend/CHANGELOG.md
+++ b/charts/platform/charts/agent-backend/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2026-07-17
+
+### Added
+
+- `ingress.extraHosts[].paths[].portName` as an alternative to `portNumber`, for referencing ALB
+  annotation-based actions (for example `portName: use-annotation`). Takes precedence over
+  `portNumber` when both are set.
+
 ## [1.2.1] - 2026-07-17
 
 ### Changed

--- a/charts/platform/charts/agent-backend/Chart.yaml
+++ b/charts/platform/charts/agent-backend/Chart.yaml
@@ -19,7 +19,7 @@ apiVersion: v2
 name: agent-backend
 description: Backend service for Seqera CLI AI capabilities
 type: application
-version: 1.2.1
+version: 1.3.0
 appVersion: "1.13.1"
 icon: https://raw.githubusercontent.com/seqeralabs/helm-charts/master/media/seqera-icon-light.svg
 maintainers:

--- a/charts/platform/charts/agent-backend/README.md
+++ b/charts/platform/charts/agent-backend/README.md
@@ -2,7 +2,7 @@
 
 Backend service for Seqera CLI AI capabilities
 
-![Version: 1.2.1](https://img.shields.io/badge/Version-1.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.13.1](https://img.shields.io/badge/AppVersion-1.13.1-informational?style=flat-square)
+![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.13.1](https://img.shields.io/badge/AppVersion-1.13.1-informational?style=flat-square)
 
 Some basic familiarity with Helm is assumed. If you are new to Helm, please refer to the [Helm documentation](https://helm.sh/docs/).
 We recommend reading through the `values.yaml` file to understand the configuration options available for the chart. Each entry is documented with `# --` comments describing its purpose and usage. Other annotations are used to automatically generate the README files and can be ignored:
@@ -51,13 +51,13 @@ To install the chart:
 
 1. Download the default values file:
    ```console
-   helm show values oci://public.cr.seqera.io/charts/agent-backend --version 1.2.1 > values.yaml
+   helm show values oci://public.cr.seqera.io/charts/agent-backend --version 1.3.0 > values.yaml
    ```
 2. Edit `values.yaml` to match your environment. We recommend removing entries whose defaults you don't need to override — this keeps your configuration file focused and easier to maintain across upgrades.
 3. Install the chart with the release name `my-release`:
    ```console
    helm install my-release oci://public.cr.seqera.io/charts/agent-backend \
-     --version 1.2.1 \
+     --version 1.3.0 \
      --namespace my-namespace \
      --create-namespace \
      -f values.yaml
@@ -73,7 +73,7 @@ Charts are also published to a traditional Helm repository. This can be useful i
 helm repo add seqeralabs https://seqeralabs.github.io/helm-charts
 helm repo update
 helm install my-release seqeralabs/agent-backend \
-  --version 1.2.1 \
+  --version 1.3.0 \
   --namespace my-namespace \
   --create-namespace \
   -f values.yaml
@@ -379,7 +379,7 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | ingress.path | string | `""` | Path for the main ingress rule. When empty, falls back to `global.ingress.path` |
 | ingress.defaultPathType | string | `""` | Default path type for the Ingress. When empty, falls back to `global.ingress.defaultPathType` |
 | ingress.defaultBackend | object | `{}` | Configure the default service for the ingress (evaluated as template) Important: make sure only one defaultBackend is defined across the k8s cluster: if the ingress doesn't reconcile successfully, 'describe ingress <name>' will report problems |
-| ingress.extraHosts | list | `[]` | Additional hosts you want to include. Evaluated as a template |
+| ingress.extraHosts | list | `[]` | Additional hosts you want to include. Evaluated as a template. Each path's backend takes either `portNumber` or `portName` (e.g. `use-annotation` to reference an ALB action defined via `ingress.annotations`). |
 | ingress.annotations | object | `{}` | Ingress annotations specific to your load balancer. Evaluated as a template |
 | ingress.extraLabels | object | `{}` | Additional labels for the ingress object. Evaluated as a template |
 | ingress.ingressClassName | string | `""` | Name of the ingress class (replaces the deprecated annotation `kubernetes.io/ingress.class`). When empty, falls back to `global.ingress.ingressClassName` |

--- a/charts/platform/charts/agent-backend/templates/ingress.yaml
+++ b/charts/platform/charts/agent-backend/templates/ingress.yaml
@@ -71,7 +71,11 @@ spec:
               service:
                 name: {{ tpl .serviceName $ | quote }}
                 port:
+      {{- if .portName }}
+                  name: {{ tpl .portName $ | quote }}
+      {{- else }}
                   number: {{ tpl (toString .portNumber) $ | int }}
+      {{- end }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/platform/charts/agent-backend/tests/ingress_test.yaml
+++ b/charts/platform/charts/agent-backend/tests/ingress_test.yaml
@@ -198,6 +198,23 @@ tests:
           path: spec.rules[1].http.paths[0].backend.service.port.number
           value: 7777
 
+  - it: should use portName instead of portNumber when provided in extraHosts
+    set:
+      ingress.enabled: true
+      ingress.extraHosts:
+        - host: redirect.example.com
+          paths:
+            - path: /*
+              serviceName: redirect-to-service
+              portName: use-annotation
+    asserts:
+      - equal:
+          path: spec.rules[1].http.paths[0].backend.service
+          value:
+            name: redirect-to-service
+            port:
+              name: use-annotation
+
   - it: should handle multiple extraHosts with different portNumber types
     set:
       ingress.enabled: true

--- a/charts/platform/charts/agent-backend/values.schema.json
+++ b/charts/platform/charts/agent-backend/values.schema.json
@@ -771,7 +771,7 @@
           "type": "boolean"
         },
         "extraHosts": {
-          "description": "Additional hosts you want to include. Evaluated as a template",
+          "description": "Additional hosts you want to include. Evaluated as a template.\nEach path's backend takes either `portNumber` or `portName` (e.g. `use-annotation`\nto reference an ALB action defined via `ingress.annotations`).",
           "items": {
             "required": []
           },

--- a/charts/platform/charts/agent-backend/values.yaml
+++ b/charts/platform/charts/agent-backend/values.yaml
@@ -740,7 +740,9 @@ ingress:
   #     port:
   #       number: '{{ .Values.frontend.service.http.port }}'
 
-  # -- Additional hosts you want to include. Evaluated as a template
+  # -- Additional hosts you want to include. Evaluated as a template.
+  # Each path's backend takes either `portNumber` or `portName` (e.g. `use-annotation`
+  # to reference an ALB action defined via `ingress.annotations`).
   # @section -- Ingress
   extraHosts: []
   # extraHosts:
@@ -756,6 +758,15 @@ ingress:
   #         pathType: Prefix  # Optional, defaults to defaultPathType
   #         serviceName: '{{ printf "%s-frontend" (include "common.names.fullname" .) }}'
   #         portNumber: '{{ .Values.frontend.service.http.port }}'
+  #   # Redirect an alternate host to the canonical domain via an ALB redirect action.
+  #   # Requires a matching action under ingress.annotations, for example:
+  #   #   alb.ingress.kubernetes.io/actions.redirect-to-service: >
+  #   #     {"Type":"redirect","RedirectConfig":{"Protocol":"HTTPS","Host":"{{ tpl .Values.global.agentBackendDomain . }}","Port":"443","Path":"/#{path}","Query":"#{query}","StatusCode":"HTTP_301"}}
+  #   - host: alternatedomain.example.com
+  #     paths:
+  #       - path: /*
+  #         serviceName: redirect-to-service   # must match the actions.<name> annotation
+  #         portName: use-annotation
 
   # -- Ingress annotations specific to your load balancer. Evaluated as a template
   # @section -- Ingress

--- a/charts/platform/charts/mcp/CHANGELOG.md
+++ b/charts/platform/charts/mcp/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] - 2026-07-17
+
+### Added
+
+- `ingress.extraHosts[].paths[].portName` as an alternative to `portNumber`, for referencing ALB
+  annotation-based actions (for example `portName: use-annotation`). Takes precedence over
+  `portNumber` when both are set.
+
 ## [0.6.0] - 2026-07-17
 
 ### Added

--- a/charts/platform/charts/mcp/Chart.yaml
+++ b/charts/platform/charts/mcp/Chart.yaml
@@ -22,7 +22,7 @@ description: |
   Wave container provisioning, bioinformatics data, and nf-core modules through intelligent
   RAG-based natural language interactions.
 type: application
-version: 0.6.0
+version: 0.7.0
 appVersion: "1.4.2"
 icon: https://raw.githubusercontent.com/seqeralabs/helm-charts/master/media/seqera-icon-light.svg
 maintainers:

--- a/charts/platform/charts/mcp/README.md
+++ b/charts/platform/charts/mcp/README.md
@@ -4,7 +4,7 @@ A Model Context Protocol (MCP) server that provides comprehensive access to the 
 Wave container provisioning, bioinformatics data, and nf-core modules through intelligent
 RAG-based natural language interactions.
 
-![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.4.2](https://img.shields.io/badge/AppVersion-1.4.2-informational?style=flat-square)
+![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.4.2](https://img.shields.io/badge/AppVersion-1.4.2-informational?style=flat-square)
 
 Some basic familiarity with Helm is assumed. If you are new to Helm, please refer to the [Helm documentation](https://helm.sh/docs/).
 We recommend reading through the `values.yaml` file to understand the configuration options available for the chart. Each entry is documented with `# --` comments describing its purpose and usage. Other annotations are used to automatically generate the README files and can be ignored:
@@ -45,13 +45,13 @@ To install the chart:
 
 1. Download the default values file:
    ```console
-   helm show values oci://public.cr.seqera.io/charts/mcp --version 0.6.0 > values.yaml
+   helm show values oci://public.cr.seqera.io/charts/mcp --version 0.7.0 > values.yaml
    ```
 2. Edit `values.yaml` to match your environment. We recommend removing entries whose defaults you don't need to override — this keeps your configuration file focused and easier to maintain across upgrades.
 3. Install the chart with the release name `my-release`:
    ```console
    helm install my-release oci://public.cr.seqera.io/charts/mcp \
-     --version 0.6.0 \
+     --version 0.7.0 \
      --namespace my-namespace \
      --create-namespace \
      -f values.yaml
@@ -67,7 +67,7 @@ Charts are also published to a traditional Helm repository. This can be useful i
 helm repo add seqeralabs https://seqeralabs.github.io/helm-charts
 helm repo update
 helm install my-release seqeralabs/mcp \
-  --version 0.6.0 \
+  --version 0.7.0 \
   --namespace my-namespace \
   --create-namespace \
   -f values.yaml
@@ -295,7 +295,7 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | ingress.path | string | `""` | Path for the main ingress rule. When empty, falls back to `global.ingress.path` |
 | ingress.defaultPathType | string | `""` | Default path type for the Ingress. When empty, falls back to `global.ingress.defaultPathType` |
 | ingress.defaultBackend | object | `{}` | Configure the default service for the ingress (evaluated as template) Important: make sure only one defaultBackend is defined across the k8s cluster: if the ingress doesn't reconcile successfully, 'describe ingress <name>' will report problems |
-| ingress.extraHosts | list | `[]` | Additional hosts you want to include. Evaluated as a template |
+| ingress.extraHosts | list | `[]` | Additional hosts you want to include. Evaluated as a template. Each path's backend takes either `portNumber` or `portName` (e.g. `use-annotation` to reference an ALB action defined via `ingress.annotations`). |
 | ingress.annotations | object | `{}` | Ingress annotations specific to your load balancer. Evaluated as a template |
 | ingress.extraLabels | object | `{}` | Additional labels for the ingress object. Evaluated as a template |
 | ingress.ingressClassName | string | `""` | Name of the ingress class (replaces the deprecated annotation `kubernetes.io/ingress.class`). When empty, falls back to `global.ingress.ingressClassName` |

--- a/charts/platform/charts/mcp/templates/ingress.yaml
+++ b/charts/platform/charts/mcp/templates/ingress.yaml
@@ -71,7 +71,11 @@ spec:
               service:
                 name: {{ tpl .serviceName $ | quote }}
                 port:
+      {{- if .portName }}
+                  name: {{ tpl .portName $ | quote }}
+      {{- else }}
                   number: {{ tpl (toString .portNumber) $ | int }}
+      {{- end }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/platform/charts/mcp/tests/ingress_test.yaml
+++ b/charts/platform/charts/mcp/tests/ingress_test.yaml
@@ -198,6 +198,23 @@ tests:
           path: spec.rules[1].http.paths[0].backend.service.port.number
           value: 7777
 
+  - it: should use portName instead of portNumber when provided in extraHosts
+    set:
+      ingress.enabled: true
+      ingress.extraHosts:
+        - host: redirect.example.com
+          paths:
+            - path: /*
+              serviceName: redirect-to-service
+              portName: use-annotation
+    asserts:
+      - equal:
+          path: spec.rules[1].http.paths[0].backend.service
+          value:
+            name: redirect-to-service
+            port:
+              name: use-annotation
+
   - it: should handle multiple extraHosts with different portNumber types
     set:
       ingress.enabled: true

--- a/charts/platform/charts/mcp/values.schema.json
+++ b/charts/platform/charts/mcp/values.schema.json
@@ -385,7 +385,7 @@
           "type": "boolean"
         },
         "extraHosts": {
-          "description": "Additional hosts you want to include. Evaluated as a template",
+          "description": "Additional hosts you want to include. Evaluated as a template.\nEach path's backend takes either `portNumber` or `portName` (e.g. `use-annotation`\nto reference an ALB action defined via `ingress.annotations`).",
           "items": {
             "required": []
           },

--- a/charts/platform/charts/mcp/values.yaml
+++ b/charts/platform/charts/mcp/values.yaml
@@ -535,7 +535,9 @@ ingress:
   #     port:
   #       number: '{{ .Values.frontend.service.http.port }}'
 
-  # -- Additional hosts you want to include. Evaluated as a template
+  # -- Additional hosts you want to include. Evaluated as a template.
+  # Each path's backend takes either `portNumber` or `portName` (e.g. `use-annotation`
+  # to reference an ALB action defined via `ingress.annotations`).
   # @section -- Ingress
   extraHosts: []
   # extraHosts:
@@ -551,6 +553,15 @@ ingress:
   #         pathType: Prefix  # Optional, defaults to defaultPathType
   #         serviceName: '{{ printf "%s-frontend" (include "common.names.fullname" .) }}'
   #         portNumber: '{{ .Values.frontend.service.http.port }}'
+  #   # Redirect an alternate host to the canonical domain via an ALB redirect action.
+  #   # Requires a matching action under ingress.annotations, for example:
+  #   #   alb.ingress.kubernetes.io/actions.redirect-to-service: >
+  #   #     {"Type":"redirect","RedirectConfig":{"Protocol":"HTTPS","Host":"{{ tpl .Values.global.mcpDomain . }}","Port":"443","Path":"/#{path}","Query":"#{query}","StatusCode":"HTTP_301"}}
+  #   - host: alternatedomain.example.com
+  #     paths:
+  #       - path: /*
+  #         serviceName: redirect-to-service   # must match the actions.<name> annotation
+  #         portName: use-annotation
 
   # -- Ingress annotations specific to your load balancer. Evaluated as a template
   # @section -- Ingress

--- a/charts/platform/charts/portal-web/CHANGELOG.md
+++ b/charts/platform/charts/portal-web/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this chart will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.6.0] - 2026-07-17
+
+### Added
+
+- `ingress.extraHosts[].paths[].portName` as an alternative to `portNumber`, for referencing ALB
+  annotation-based actions (for example `portName: use-annotation`). Takes precedence over
+  `portNumber` when both are set.
+
 ## [0.5.0] - 2026-07-17
 
 ### Added

--- a/charts/platform/charts/portal-web/Chart.yaml
+++ b/charts/platform/charts/portal-web/Chart.yaml
@@ -19,7 +19,7 @@ apiVersion: v2
 name: portal-web
 description: Portal web frontend for Seqera Platform
 type: application
-version: 0.5.0
+version: 0.6.0
 appVersion: "1.7.2"
 icon: https://raw.githubusercontent.com/seqeralabs/helm-charts/master/media/seqera-icon-light.svg
 maintainers:

--- a/charts/platform/charts/portal-web/README.md
+++ b/charts/platform/charts/portal-web/README.md
@@ -2,7 +2,7 @@
 
 Portal web frontend for Seqera Platform
 
-![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.7.2](https://img.shields.io/badge/AppVersion-1.7.2-informational?style=flat-square)
+![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.7.2](https://img.shields.io/badge/AppVersion-1.7.2-informational?style=flat-square)
 
 Some basic familiarity with Helm is assumed. If you are new to Helm, please refer to the [Helm documentation](https://helm.sh/docs/).
 We recommend reading through the `values.yaml` file to understand the configuration options available for the chart. Each entry is documented with `# --` comments describing its purpose and usage. Other annotations are used to automatically generate the README files and can be ignored:
@@ -38,13 +38,13 @@ To install the chart:
 
 1. Download the default values file:
    ```console
-   helm show values oci://public.cr.seqera.io/charts/portal-web --version 0.5.0 > values.yaml
+   helm show values oci://public.cr.seqera.io/charts/portal-web --version 0.6.0 > values.yaml
    ```
 2. Edit `values.yaml` to match your environment. We recommend removing entries whose defaults you don't need to override — this keeps your configuration file focused and easier to maintain across upgrades.
 3. Install the chart with the release name `my-release`:
    ```console
    helm install my-release oci://public.cr.seqera.io/charts/portal-web \
-     --version 0.5.0 \
+     --version 0.6.0 \
      --namespace my-namespace \
      --create-namespace \
      -f values.yaml
@@ -60,7 +60,7 @@ Charts are also published to a traditional Helm repository. This can be useful i
 helm repo add seqeralabs https://seqeralabs.github.io/helm-charts
 helm repo update
 helm install my-release seqeralabs/portal-web \
-  --version 0.5.0 \
+  --version 0.6.0 \
   --namespace my-namespace \
   --create-namespace \
   -f values.yaml
@@ -236,7 +236,7 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | ingress.path | string | `""` | Path for the main ingress rule. When empty, falls back to `global.ingress.path` |
 | ingress.defaultPathType | string | `""` | Default path type for the Ingress. When empty, falls back to `global.ingress.defaultPathType` |
 | ingress.defaultBackend | object | `{}` | Configure the default service for the ingress (evaluated as template) Important: make sure only one defaultBackend is defined across the k8s cluster: if the ingress doesn't reconcile successfully, 'describe ingress <name>' will report problems |
-| ingress.extraHosts | list | `[]` | Additional hosts you want to include. Evaluated as a template |
+| ingress.extraHosts | list | `[]` | Additional hosts you want to include. Evaluated as a template. Each path's backend takes either `portNumber` or `portName` (e.g. `use-annotation` to reference an ALB action defined via `ingress.annotations`). |
 | ingress.annotations | object | `{}` | Ingress annotations specific to your load balancer. Evaluated as a template |
 | ingress.extraLabels | object | `{}` | Additional labels for the ingress object. Evaluated as a template |
 | ingress.ingressClassName | string | `""` | Name of the ingress class (replaces the deprecated annotation `kubernetes.io/ingress.class`). When empty, falls back to `global.ingress.ingressClassName` |

--- a/charts/platform/charts/portal-web/templates/ingress.yaml
+++ b/charts/platform/charts/portal-web/templates/ingress.yaml
@@ -70,7 +70,11 @@ spec:
               service:
                 name: {{ tpl .serviceName $ | quote }}
                 port:
+      {{- if .portName }}
+                  name: {{ tpl .portName $ | quote }}
+      {{- else }}
                   number: {{ tpl (toString .portNumber) $ | int }}
+      {{- end }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/platform/charts/portal-web/tests/ingress_test.yaml
+++ b/charts/platform/charts/portal-web/tests/ingress_test.yaml
@@ -152,3 +152,34 @@ tests:
       - equal:
           path: spec.rules[1].http.paths[0].backend.service.port.number
           value: 7777
+
+  - it: should use portName instead of portNumber when provided in extraHosts
+    set:
+      ingress.enabled: true
+      ingress.extraHosts:
+        - host: ai.old.example.com
+          paths:
+            - path: /*
+              serviceName: redirect-to-service
+              portName: use-annotation
+    asserts:
+      - equal:
+          path: spec.rules[1].http.paths[0].backend.service
+          value:
+            name: redirect-to-service
+            port:
+              name: use-annotation
+
+  - it: should template portName in extraHosts
+    set:
+      ingress.enabled: true
+      ingress.extraHosts:
+        - host: ai.old.example.com
+          paths:
+            - path: /*
+              serviceName: redirect-to-service
+              portName: "{{ .Release.Name }}-port"
+    asserts:
+      - equal:
+          path: spec.rules[1].http.paths[0].backend.service.port.name
+          value: RELEASE-NAME-port

--- a/charts/platform/charts/portal-web/values.schema.json
+++ b/charts/platform/charts/portal-web/values.schema.json
@@ -386,7 +386,7 @@
           "type": "boolean"
         },
         "extraHosts": {
-          "description": "Additional hosts you want to include. Evaluated as a template",
+          "description": "Additional hosts you want to include. Evaluated as a template.\nEach path's backend takes either `portNumber` or `portName` (e.g. `use-annotation`\nto reference an ALB action defined via `ingress.annotations`).",
           "items": {
             "required": []
           },

--- a/charts/platform/charts/portal-web/values.yaml
+++ b/charts/platform/charts/portal-web/values.yaml
@@ -413,7 +413,9 @@ ingress:
   # @section -- Ingress
   defaultBackend: {}
 
-  # -- Additional hosts you want to include. Evaluated as a template
+  # -- Additional hosts you want to include. Evaluated as a template.
+  # Each path's backend takes either `portNumber` or `portName` (e.g. `use-annotation`
+  # to reference an ALB action defined via `ingress.annotations`).
   # @section -- Ingress
   extraHosts: []
   # extraHosts:
@@ -423,6 +425,15 @@ ingress:
   #         pathType: Prefix
   #         serviceName: '{{ include "common.names.fullname" . }}'
   #         portNumber: '{{ .Values.service.http.port }}'
+  #   # Redirect an alternate host to the canonical domain via an ALB redirect action.
+  #   # Requires a matching action under ingress.annotations, for example:
+  #   #   alb.ingress.kubernetes.io/actions.redirect-to-service: >
+  #   #     {"Type":"redirect","RedirectConfig":{"Protocol":"HTTPS","Host":"{{ tpl .Values.global.portalWebDomain . }}","Port":"443","Path":"/#{path}","Query":"#{query}","StatusCode":"HTTP_301"}}
+  #   - host: alternatedomain.example.com
+  #     paths:
+  #       - path: /*
+  #         serviceName: redirect-to-service   # must match the actions.<name> annotation
+  #         portName: use-annotation
 
   # -- Ingress annotations specific to your load balancer. Evaluated as a template
   # @section -- Ingress

--- a/charts/platform/charts/studios/CHANGELOG.md
+++ b/charts/platform/charts/studios/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.0] - 2026-07-17
+
+### Added
+
+- `ingress.extraHosts[].paths[].portName` as an alternative to `portNumber`, for referencing ALB
+  annotation-based actions (for example `portName: use-annotation`). Takes precedence over
+  `portNumber` when both are set.
+
 ## [1.6.0] - 2026-07-17
 
 ### Added

--- a/charts/platform/charts/studios/Chart.yaml
+++ b/charts/platform/charts/studios/Chart.yaml
@@ -21,7 +21,7 @@ name: studios
 description: Studios is a unified platform for interactive analysis
 sources:
   - https://github.com/seqeralabs/helm-charts/tree/main/seqera/charts/studios
-version: 1.6.0
+version: 1.7.0
 appVersion: "0.11.1"
 icon: https://raw.githubusercontent.com/seqeralabs/helm-charts/master/media/seqera-icon-light.svg
 maintainers:

--- a/charts/platform/charts/studios/README.md
+++ b/charts/platform/charts/studios/README.md
@@ -2,7 +2,7 @@
 
 Studios is a unified platform for interactive analysis
 
-![Version: 1.6.0](https://img.shields.io/badge/Version-1.6.0-informational?style=flat-square) ![AppVersion: 0.11.1](https://img.shields.io/badge/AppVersion-0.11.1-informational?style=flat-square)
+![Version: 1.7.0](https://img.shields.io/badge/Version-1.7.0-informational?style=flat-square) ![AppVersion: 0.11.1](https://img.shields.io/badge/AppVersion-0.11.1-informational?style=flat-square)
 
 Some basic familiarity with Helm is assumed. If you are new to Helm, please refer to the [Helm documentation](https://helm.sh/docs/).
 We recommend reading through the `values.yaml` file to understand the configuration options available for the chart. Each entry is documented with `# --` comments describing its purpose and usage. Other annotations are used to automatically generate the README files and can be ignored:
@@ -44,13 +44,13 @@ To install the chart:
 
 1. Download the default values file:
    ```console
-   helm show values oci://public.cr.seqera.io/charts/studios --version 1.6.0 > values.yaml
+   helm show values oci://public.cr.seqera.io/charts/studios --version 1.7.0 > values.yaml
    ```
 2. Edit `values.yaml` to match your environment. We recommend removing entries whose defaults you don't need to override — this keeps your configuration file focused and easier to maintain across upgrades.
 3. Install the chart with the release name `my-release`:
    ```console
    helm install my-release oci://public.cr.seqera.io/charts/studios \
-     --version 1.6.0 \
+     --version 1.7.0 \
      --namespace my-namespace \
      --create-namespace \
      -f values.yaml
@@ -66,7 +66,7 @@ Charts are also published to a traditional Helm repository. This can be useful i
 helm repo add seqeralabs https://seqeralabs.github.io/helm-charts
 helm repo update
 helm install my-release seqeralabs/studios \
-  --version 1.6.0 \
+  --version 1.7.0 \
   --namespace my-namespace \
   --create-namespace \
   -f values.yaml
@@ -324,7 +324,7 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | ingress.path | string | `""` | Path for the main ingress rule. When empty, falls back to `global.ingress.path` |
 | ingress.defaultPathType | string | `""` | Default path type for the Ingress. When empty, falls back to `global.ingress.defaultPathType` |
 | ingress.defaultBackend | object | `{}` | Configure the default service for the ingress (evaluated as template) Important: make sure only one defaultBackend is defined across the k8s cluster: if the ingress doesn't reconcile successfully, 'describe ingress <name>' will report problems |
-| ingress.extraHosts | list | `[]` | Additional hosts you want to include. Evaluated as a template |
+| ingress.extraHosts | list | `[]` | Additional hosts you want to include. Evaluated as a template. Each path's backend takes either `portNumber` or `portName` (e.g. `use-annotation` to reference an ALB action defined via `ingress.annotations`). |
 | ingress.annotations | object | `{}` | Ingress annotations specific to your load balancer. Evaluated as a template |
 | ingress.extraLabels | object | `{}` | Additional labels for the ingress object. Evaluated as a template |
 | ingress.ingressClassName | string | `""` | Name of the ingress class (replaces the deprecated annotation `kubernetes.io/ingress.class`). When empty, falls back to `global.ingress.ingressClassName` |

--- a/charts/platform/charts/studios/templates/ingress.yaml
+++ b/charts/platform/charts/studios/templates/ingress.yaml
@@ -72,7 +72,11 @@ spec:
               service:
                 name: {{ tpl .serviceName $ | quote }}
                 port:
+      {{- if .portName }}
+                  name: {{ tpl .portName $ | quote }}
+      {{- else }}
                   number: {{ tpl (toString .portNumber) $ | int }}
+      {{- end }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/platform/charts/studios/tests/ingress_test.yaml
+++ b/charts/platform/charts/studios/tests/ingress_test.yaml
@@ -554,6 +554,26 @@ tests:
           path: spec.rules[1].http.paths[0].backend.service.port.number
           value: 6666
 
+  - it: should use portName instead of portNumber in extraHosts
+    set:
+      global:
+        studiosDomain: 'studios.example.com'
+      ingress:
+        enabled: true
+        extraHosts:
+          - host: redirect.example.com
+            paths:
+              - path: /*
+                serviceName: redirect-to-service
+                portName: use-annotation
+    asserts:
+      - equal:
+          path: spec.rules[1].http.paths[0].backend.service
+          value:
+            name: redirect-to-service
+            port:
+              name: use-annotation
+
   - it: should handle multiple extraHosts with different portNumber types
     set:
       global:

--- a/charts/platform/charts/studios/values.schema.json
+++ b/charts/platform/charts/studios/values.schema.json
@@ -203,7 +203,7 @@
           "type": "boolean"
         },
         "extraHosts": {
-          "description": "Additional hosts you want to include. Evaluated as a template",
+          "description": "Additional hosts you want to include. Evaluated as a template.\nEach path's backend takes either `portNumber` or `portName` (e.g. `use-annotation`\nto reference an ALB action defined via `ingress.annotations`).",
           "items": {
             "required": []
           },

--- a/charts/platform/charts/studios/values.yaml
+++ b/charts/platform/charts/studios/values.yaml
@@ -653,7 +653,9 @@ ingress:
   #     port:
   #       number: '{{ .Values.frontend.service.http.port }}'
 
-  # -- Additional hosts you want to include. Evaluated as a template
+  # -- Additional hosts you want to include. Evaluated as a template.
+  # Each path's backend takes either `portNumber` or `portName` (e.g. `use-annotation`
+  # to reference an ALB action defined via `ingress.annotations`).
   # @section -- Ingress
   extraHosts: []
   # extraHosts:
@@ -669,6 +671,15 @@ ingress:
   #         pathType: Prefix  # Optional, defaults to defaultPathType
   #         serviceName: '{{ printf "%s-frontend" (include "common.names.fullname" .) }}'
   #         portNumber: '{{ .Values.frontend.service.http.port }}'
+  #   # Redirect an alternate host to the canonical domain via an ALB redirect action.
+  #   # Requires a matching action under ingress.annotations, for example:
+  #   #   alb.ingress.kubernetes.io/actions.redirect-to-service: >
+  #   #     {"Type":"redirect","RedirectConfig":{"Protocol":"HTTPS","Host":"{{ tpl .Values.global.studiosDomain . }}","Port":"443","Path":"/#{path}","Query":"#{query}","StatusCode":"HTTP_301"}}
+  #   - host: alternatedomain.example.com
+  #     paths:
+  #       - path: /*
+  #         serviceName: redirect-to-service   # must match the actions.<name> annotation
+  #         portName: use-annotation
 
   # -- Ingress annotations specific to your load balancer. Evaluated as a template
   # @section -- Ingress

--- a/charts/platform/charts/wave/CHANGELOG.md
+++ b/charts/platform/charts/wave/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2026-07-20
+
+### Fixed
+
+- `WAVE_SERVER_URL` in the ConfigMap is now derived from `global.waveDomain` instead of
+  `global.platformExternalDomain`, so it points at the Wave subdomain (for example
+  `https://wave.<platformExternalDomain>`) used for container pulls.
+- The Redis password Secret key now defaults to `REDIS_PASSWORD` (matching the key the chart's
+  Secret writes and the documented default for `redis.existingSecretKey`) instead of
+  `WAVE_REDIS_PASSWORD`. Previously the deployment's `secretKeyRef` pointed at `WAVE_REDIS_PASSWORD`
+  while the chart-managed Secret stored the value under `REDIS_PASSWORD`, so setting
+  `redis.password` inline caused the pod to fail to start with `CreateContainerConfigError`.
+
 ## [0.5.0] - 2026-07-17
 
 ### Added

--- a/charts/platform/charts/wave/CHANGELOG.md
+++ b/charts/platform/charts/wave/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-07-17
+
+### Added
+
+- `ingress.extraHosts[].paths[].portName` as an alternative to `portNumber`, for referencing ALB
+  annotation-based actions (for example `portName: use-annotation`). Takes precedence over
+  `portNumber` when both are set.
+
 ## [0.4.0] - 2026-07-17
 
 ### Added

--- a/charts/platform/charts/wave/CHANGELOG.md
+++ b/charts/platform/charts/wave/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.6.0] - 2026-07-20
+## [0.5.0] - 2026-07-20
+
+### Added
+
+- `ingress.extraHosts[].paths[].portName` as an alternative to `portNumber`, for referencing ALB
+  annotation-based actions (for example `portName: use-annotation`). Takes precedence over
+  `portNumber` when both are set.
 
 ### Fixed
 
@@ -17,14 +23,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `WAVE_REDIS_PASSWORD`. Previously the deployment's `secretKeyRef` pointed at `WAVE_REDIS_PASSWORD`
   while the chart-managed Secret stored the value under `REDIS_PASSWORD`, so setting
   `redis.password` inline caused the pod to fail to start with `CreateContainerConfigError`.
-
-## [0.5.0] - 2026-07-17
-
-### Added
-
-- `ingress.extraHosts[].paths[].portName` as an alternative to `portNumber`, for referencing ALB
-  annotation-based actions (for example `portName: use-annotation`). Takes precedence over
-  `portNumber` when both are set.
 
 ## [0.4.0] - 2026-07-17
 

--- a/charts/platform/charts/wave/Chart.yaml
+++ b/charts/platform/charts/wave/Chart.yaml
@@ -19,7 +19,7 @@ apiVersion: v2
 name: wave
 description: Wave
 type: application
-version: 0.4.0
+version: 0.5.0
 appVersion: "v1.35.0"
 icon: https://raw.githubusercontent.com/seqeralabs/helm-charts/master/media/seqera-icon-light.svg
 maintainers:

--- a/charts/platform/charts/wave/Chart.yaml
+++ b/charts/platform/charts/wave/Chart.yaml
@@ -19,7 +19,7 @@ apiVersion: v2
 name: wave
 description: Wave
 type: application
-version: 0.5.0
+version: 0.6.0
 appVersion: "v1.35.0"
 icon: https://raw.githubusercontent.com/seqeralabs/helm-charts/master/media/seqera-icon-light.svg
 maintainers:

--- a/charts/platform/charts/wave/Chart.yaml
+++ b/charts/platform/charts/wave/Chart.yaml
@@ -17,10 +17,10 @@
 
 apiVersion: v2
 name: wave
-description: Wave
+description: On-demand containers provisioning service
 type: application
-version: 0.6.0
-appVersion: "v1.35.0"
+version: 0.5.0
+appVersion: "v1.36.0"
 icon: https://raw.githubusercontent.com/seqeralabs/helm-charts/master/media/seqera-icon-light.svg
 maintainers:
   - name: Seqera Labs

--- a/charts/platform/charts/wave/README.md
+++ b/charts/platform/charts/wave/README.md
@@ -2,7 +2,7 @@
 
 Wave
 
-![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.35.0](https://img.shields.io/badge/AppVersion-v1.35.0-informational?style=flat-square)
+![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.35.0](https://img.shields.io/badge/AppVersion-v1.35.0-informational?style=flat-square)
 
 Some basic familiarity with Helm is assumed. If you are new to Helm, please refer to the [Helm documentation](https://helm.sh/docs/).
 We recommend reading through the `values.yaml` file to understand the configuration options available for the chart. Each entry is documented with `# --` comments describing its purpose and usage. Other annotations are used to automatically generate the README files and can be ignored:
@@ -39,13 +39,13 @@ To install the chart:
 
 1. Download the default values file:
    ```console
-   helm show values oci://public.cr.seqera.io/charts/wave --version 0.5.0 > values.yaml
+   helm show values oci://public.cr.seqera.io/charts/wave --version 0.6.0 > values.yaml
    ```
 2. Edit `values.yaml` to match your environment. We recommend removing entries whose defaults you don't need to override — this keeps your configuration file focused and easier to maintain across upgrades.
 3. Install the chart with the release name `my-release`:
    ```console
    helm install my-release oci://public.cr.seqera.io/charts/wave \
-     --version 0.5.0 \
+     --version 0.6.0 \
      --namespace my-namespace \
      --create-namespace \
      -f values.yaml
@@ -61,7 +61,7 @@ Charts are also published to a traditional Helm repository. This can be useful i
 helm repo add seqeralabs https://seqeralabs.github.io/helm-charts
 helm repo update
 helm install my-release seqeralabs/wave \
-  --version 0.5.0 \
+  --version 0.6.0 \
   --namespace my-namespace \
   --create-namespace \
   -f values.yaml

--- a/charts/platform/charts/wave/README.md
+++ b/charts/platform/charts/wave/README.md
@@ -2,7 +2,7 @@
 
 Wave
 
-![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.35.0](https://img.shields.io/badge/AppVersion-v1.35.0-informational?style=flat-square)
+![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.35.0](https://img.shields.io/badge/AppVersion-v1.35.0-informational?style=flat-square)
 
 Some basic familiarity with Helm is assumed. If you are new to Helm, please refer to the [Helm documentation](https://helm.sh/docs/).
 We recommend reading through the `values.yaml` file to understand the configuration options available for the chart. Each entry is documented with `# --` comments describing its purpose and usage. Other annotations are used to automatically generate the README files and can be ignored:
@@ -39,13 +39,13 @@ To install the chart:
 
 1. Download the default values file:
    ```console
-   helm show values oci://public.cr.seqera.io/charts/wave --version 0.4.0 > values.yaml
+   helm show values oci://public.cr.seqera.io/charts/wave --version 0.5.0 > values.yaml
    ```
 2. Edit `values.yaml` to match your environment. We recommend removing entries whose defaults you don't need to override — this keeps your configuration file focused and easier to maintain across upgrades.
 3. Install the chart with the release name `my-release`:
    ```console
    helm install my-release oci://public.cr.seqera.io/charts/wave \
-     --version 0.4.0 \
+     --version 0.5.0 \
      --namespace my-namespace \
      --create-namespace \
      -f values.yaml
@@ -61,7 +61,7 @@ Charts are also published to a traditional Helm repository. This can be useful i
 helm repo add seqeralabs https://seqeralabs.github.io/helm-charts
 helm repo update
 helm install my-release seqeralabs/wave \
-  --version 0.4.0 \
+  --version 0.5.0 \
   --namespace my-namespace \
   --create-namespace \
   -f values.yaml
@@ -306,7 +306,7 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | ingress.path | string | `""` | Path for the main ingress rule. When empty, falls back to `global.ingress.path` |
 | ingress.defaultPathType | string | `""` | Default path type for the Ingress. When empty, falls back to `global.ingress.defaultPathType` |
 | ingress.defaultBackend | object | `{}` | Configure the default service for the ingress (evaluated as template) Important: make sure only one defaultBackend is defined across the k8s cluster: if the ingress doesn't reconcile successfully, 'describe ingress <name>' will report problems |
-| ingress.extraHosts | list | `[]` | Additional hosts you want to include. Evaluated as a template |
+| ingress.extraHosts | list | `[]` | Additional hosts you want to include. Evaluated as a template. Each path's backend takes either `portNumber` or `portName` (e.g. `use-annotation` to reference an ALB action defined via `ingress.annotations`). |
 | ingress.annotations | object | `{}` | Ingress annotations specific to your load balancer. Evaluated as a template |
 | ingress.extraLabels | object | `{}` | Additional labels for the ingress object. Evaluated as a template |
 | ingress.ingressClassName | string | `""` | Name of the ingress class (replaces the deprecated annotation `kubernetes.io/ingress.class`). When empty, falls back to `global.ingress.ingressClassName` |

--- a/charts/platform/charts/wave/README.md
+++ b/charts/platform/charts/wave/README.md
@@ -1,8 +1,8 @@
 # wave
 
-Wave
+On-demand containers provisioning service
 
-![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.35.0](https://img.shields.io/badge/AppVersion-v1.35.0-informational?style=flat-square)
+![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.36.0](https://img.shields.io/badge/AppVersion-v1.36.0-informational?style=flat-square)
 
 Some basic familiarity with Helm is assumed. If you are new to Helm, please refer to the [Helm documentation](https://helm.sh/docs/).
 We recommend reading through the `values.yaml` file to understand the configuration options available for the chart. Each entry is documented with `# --` comments describing its purpose and usage. Other annotations are used to automatically generate the README files and can be ignored:
@@ -27,7 +27,7 @@ The required values to set in order to have a working installation are:
 
 The Helm chart comes with several requirement checks that will validate the provided configuration before proceeding with the installation.
 
-By default the chart selects the application images defined in the `appVersion` field of the `Chart.yaml` file, currently set as `v1.35.0`.
+By default the chart selects the application images defined in the `appVersion` field of the `Chart.yaml` file, currently set as `v1.36.0`.
 
 When a sensitive value is required (e.g. the database password, the Seqera license key), you can either provide it directly in the values file or reference an existing Kubernetes Secret containing the value. The key names to use in the provided Secret are specified in the values file comments.
 Sensitive values provided as plain text by the user are always stored in a Kubernetes Secret created by the chart. When an external Secret is used instead, the chart instructs the components to read the sensitive value from the external Secret directly, without further storing copies of the sensitive value in the chart-created Secret.
@@ -39,13 +39,13 @@ To install the chart:
 
 1. Download the default values file:
    ```console
-   helm show values oci://public.cr.seqera.io/charts/wave --version 0.6.0 > values.yaml
+   helm show values oci://public.cr.seqera.io/charts/wave --version 0.5.0 > values.yaml
    ```
 2. Edit `values.yaml` to match your environment. We recommend removing entries whose defaults you don't need to override — this keeps your configuration file focused and easier to maintain across upgrades.
 3. Install the chart with the release name `my-release`:
    ```console
    helm install my-release oci://public.cr.seqera.io/charts/wave \
-     --version 0.6.0 \
+     --version 0.5.0 \
      --namespace my-namespace \
      --create-namespace \
      -f values.yaml
@@ -61,7 +61,7 @@ Charts are also published to a traditional Helm repository. This can be useful i
 helm repo add seqeralabs https://seqeralabs.github.io/helm-charts
 helm repo update
 helm install my-release seqeralabs/wave \
-  --version 0.6.0 \
+  --version 0.5.0 \
   --namespace my-namespace \
   --create-namespace \
   -f values.yaml

--- a/charts/platform/charts/wave/templates/_helpers.tpl
+++ b/charts/platform/charts/wave/templates/_helpers.tpl
@@ -91,9 +91,9 @@ Build the Wave micronaut envs list: always ensure required environments are pres
 
 {{- define "wave.redis.existingSecret.secretKey" -}}
   {{- if (include "wave.redis.existingSecret" .) -}}
-    {{- printf "%s" (tpl .Values.redis.existingSecretKey .) | default "WAVE_REDIS_PASSWORD" -}}
+    {{- printf "%s" (tpl .Values.redis.existingSecretKey .) | default "REDIS_PASSWORD" -}}
   {{- else -}}
-    {{- printf "WAVE_REDIS_PASSWORD" -}}
+    {{- printf "REDIS_PASSWORD" -}}
   {{- end -}}
 {{- end -}}
 

--- a/charts/platform/charts/wave/templates/configmap.yaml
+++ b/charts/platform/charts/wave/templates/configmap.yaml
@@ -33,7 +33,7 @@ data:
   MICRONAUT_ENVIRONMENTS: {{ include "wave.micronautEnvs" . }}
   MICRONAUT_SERVER_PORT: {{ .Values.service.http.targetPort | quote }}
   TOWER_ENDPOINT_URL: '{{ printf "https://%s/api" .Values.global.platformExternalDomain | quote }}'
-  WAVE_SERVER_URL: {{ printf "https://%s" (tpl .Values.global.platformExternalDomain $) | quote }}
+  WAVE_SERVER_URL: {{ printf "https://%s" (tpl .Values.global.waveDomain $) | quote }}
 
   REDIS_URI: {{ include "wave.redis.uri" . | quote }}
   WAVE_DB_USER: {{ .Values.database.username | quote }}

--- a/charts/platform/charts/wave/templates/ingress.yaml
+++ b/charts/platform/charts/wave/templates/ingress.yaml
@@ -71,7 +71,11 @@ spec:
               service:
                 name: {{ tpl .serviceName $ | quote }}
                 port:
+      {{- if .portName }}
+                  name: {{ tpl .portName $ | quote }}
+      {{- else }}
                   number: {{ tpl (toString .portNumber) $ | int }}
+      {{- end }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/platform/charts/wave/tests/__snapshot__/configmap_test.yaml.snap
+++ b/charts/platform/charts/wave/tests/__snapshot__/configmap_test.yaml.snap
@@ -8,7 +8,7 @@ should render a ConfigMap with default values:
       TOWER_ENDPOINT_URL: '"https://example.com/api"'
       WAVE_DB_URI: jdbc:postgresql://db.example.com:5432/wavedb
       WAVE_DB_USER: waveuser
-      WAVE_SERVER_URL: https://example.com
+      WAVE_SERVER_URL: https://wave.example.com
     kind: ConfigMap
     metadata:
       annotations: {}

--- a/charts/platform/charts/wave/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/platform/charts/wave/tests/__snapshot__/deployment_test.yaml.snap
@@ -21,7 +21,7 @@ should render a Deployment with default values:
       template:
         metadata:
           annotations:
-            checksum/configmap: 253619a7171c2e26b76c97806e3bf7d1d826296faf074fe4a09a23f12d4b36f9
+            checksum/configmap: a3c4f3a56806ec40da3e4d11c9c13e1bb70d72758deac63d90d25a91bed4c4ff
             checksum/secret: d612594cf83ec8761d401b8770dc0f1773a5465202c0190a5bd356068e945bea
           labels:
             app.kubernetes.io/component: wave

--- a/charts/platform/charts/wave/tests/configmap_test.yaml
+++ b/charts/platform/charts/wave/tests/configmap_test.yaml
@@ -69,16 +69,16 @@ tests:
           path: data['TOWER_ENDPOINT_URL']
           value: '"https://prod.example.com/api"'
 
-  - it: should contain Wave server URL
+  - it: should contain Wave server URL derived from global.waveDomain
     set:
-      global.platformExternalDomain: prod.example.com
+      global.waveDomain: wave.prod.example.com
       database.host: db.example.com
       database.name: wavedb
       database.username: waveuser
     asserts:
       - equal:
           path: data.WAVE_SERVER_URL
-          value: "https://prod.example.com"
+          value: "https://wave.prod.example.com"
 
   - it: should contain Redis URI with default values
     set:

--- a/charts/platform/charts/wave/tests/deployment_test.yaml
+++ b/charts/platform/charts/wave/tests/deployment_test.yaml
@@ -360,7 +360,7 @@ tests:
             valueFrom:
               secretKeyRef:
                 name: release-name-wave
-                key: WAVE_REDIS_PASSWORD
+                key: REDIS_PASSWORD
 
   - it: should NOT include REDIS_PASSWORD in env when redis.password is not set
     template: deployment.yaml
@@ -413,7 +413,7 @@ tests:
             valueFrom:
               secretKeyRef:
                 name: my-redis-secret
-                key: WAVE_REDIS_PASSWORD
+                key: REDIS_PASSWORD
 
   - it: should render extraOptionsSpec under spec
     template: deployment.yaml

--- a/charts/platform/charts/wave/tests/ingress_test.yaml
+++ b/charts/platform/charts/wave/tests/ingress_test.yaml
@@ -190,6 +190,23 @@ tests:
           path: spec.rules[1].http.paths[0].backend.service.port.number
           value: 7777
 
+  - it: should use portName instead of portNumber when provided in extraHosts
+    set:
+      ingress.enabled: true
+      ingress.extraHosts:
+        - host: redirect.example.com
+          paths:
+            - path: /*
+              serviceName: redirect-to-service
+              portName: use-annotation
+    asserts:
+      - equal:
+          path: spec.rules[1].http.paths[0].backend.service
+          value:
+            name: redirect-to-service
+            port:
+              name: use-annotation
+
   - it: should handle multiple extraHosts with different portNumber types
     set:
       ingress.enabled: true

--- a/charts/platform/charts/wave/values.schema.json
+++ b/charts/platform/charts/wave/values.schema.json
@@ -425,7 +425,7 @@
           "type": "boolean"
         },
         "extraHosts": {
-          "description": "Additional hosts you want to include. Evaluated as a template",
+          "description": "Additional hosts you want to include. Evaluated as a template.\nEach path's backend takes either `portNumber` or `portName` (e.g. `use-annotation`\nto reference an ALB action defined via `ingress.annotations`).",
           "items": {
             "required": []
           },

--- a/charts/platform/charts/wave/values.yaml
+++ b/charts/platform/charts/wave/values.yaml
@@ -591,7 +591,9 @@ ingress:
   #     port:
   #       number: '{{ .Values.frontend.service.http.port }}'
 
-  # -- Additional hosts you want to include. Evaluated as a template
+  # -- Additional hosts you want to include. Evaluated as a template.
+  # Each path's backend takes either `portNumber` or `portName` (e.g. `use-annotation`
+  # to reference an ALB action defined via `ingress.annotations`).
   # @section -- Ingress
   extraHosts: []
   # extraHosts:
@@ -607,6 +609,15 @@ ingress:
   #         pathType: Prefix  # Optional, defaults to defaultPathType
   #         serviceName: '{{ printf "%s-frontend" (include "common.names.fullname" .) }}'
   #         portNumber: '{{ .Values.frontend.service.http.port }}'
+  #   # Redirect an alternate host to the canonical domain via an ALB redirect action.
+  #   # Requires a matching action under ingress.annotations, for example:
+  #   #   alb.ingress.kubernetes.io/actions.redirect-to-service: >
+  #   #     {"Type":"redirect","RedirectConfig":{"Protocol":"HTTPS","Host":"{{ tpl .Values.global.waveDomain . }}","Port":"443","Path":"/#{path}","Query":"#{query}","StatusCode":"HTTP_301"}}
+  #   - host: alternatedomain.example.com
+  #     paths:
+  #       - path: /*
+  #         serviceName: redirect-to-service   # must match the actions.<name> annotation
+  #         portName: use-annotation
 
   # -- Ingress annotations specific to your load balancer. Evaluated as a template
   # @section -- Ingress

--- a/charts/platform/templates/deployment-backend.yaml
+++ b/charts/platform/templates/deployment-backend.yaml
@@ -143,6 +143,14 @@ spec:
               value: "/var/cache/tower/"
             - name: NXF_PLUGINS_DIR
               value: "/var/cache/tower/plugins/"
+{{- if (index .Values "portal-web" "enabled") }}
+            - name: TOWER_AI_BASE_URL
+              value: {{ printf "https://%s" (tpl .Values.global.portalWebDomain $) | quote }}
+{{- end }}
+{{- if (index .Values "agent-backend" "enabled") }}
+            - name: TOWER_AGENT_BACKEND_URL
+              value: {{ printf "https://%s" (tpl .Values.global.agentBackendDomain $) | quote }}
+{{- end }}
 {{- with .Values.backend.extraEnvVars }}
             {{- include "seqera.envVars.render" (dict "value" . "context" $) | nindent 12 }}
 {{- end }}

--- a/charts/platform/templates/ingress.yaml
+++ b/charts/platform/templates/ingress.yaml
@@ -87,7 +87,11 @@ spec:
               service:
                 name: {{ tpl .serviceName $ | quote }}
                 port:
+      {{- if .portName }}
+                  name: {{ tpl .portName $ | quote }}
+      {{- else }}
                   number: {{ tpl (toString .portNumber) $ | int }}
+      {{- end }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/platform/tests/__snapshot__/deployment-backend_test.yaml.snap
+++ b/charts/platform/tests/__snapshot__/deployment-backend_test.yaml.snap
@@ -31,6 +31,10 @@ should produce a Deployment resource with minimal values:
             value: /var/cache/tower/
           - name: NXF_PLUGINS_DIR
             value: /var/cache/tower/plugins/
+          - name: TOWER_AI_BASE_URL
+            value: https://ai.example.com
+          - name: TOWER_AGENT_BACKEND_URL
+            value: https://ai-api.example.com
         envFrom:
           - configMapRef:
               name: release-name-platform-backend
@@ -272,6 +276,10 @@ should render the backend deployment with the correct checksums, labels and anno
                   value: /var/cache/tower/
                 - name: NXF_PLUGINS_DIR
                   value: /var/cache/tower/plugins/
+                - name: TOWER_AI_BASE_URL
+                  value: https://ai.example.com
+                - name: TOWER_AGENT_BACKEND_URL
+                  value: https://ai-api.example.com
               envFrom:
                 - configMapRef:
                     name: release-name-platform-backend

--- a/charts/platform/tests/deployment-backend_test.yaml
+++ b/charts/platform/tests/deployment-backend_test.yaml
@@ -301,6 +301,10 @@ tests:
         value: /var/cache/tower/
       - name: NXF_PLUGINS_DIR
         value: /var/cache/tower/plugins/
+      - name: TOWER_AI_BASE_URL
+        value: https://ai.example.com
+      - name: TOWER_AGENT_BACKEND_URL
+        value: https://ai-api.example.com
       - name: CUSTOM_ENV_VAR
         value: "custom-value"
       - name: STRING_VAR
@@ -331,6 +335,89 @@ tests:
           name: extra-env-vars-secret1
       - secretRef:
           name: extra-env-vars-secret2
+
+- it: should set AI/agent-backend URLs from domains when subcharts are enabled
+  template: deployment-backend.yaml
+  set:
+    global:
+      platformExternalDomain: platform.example.com
+    portal-web:
+      enabled: true
+    agent-backend:
+      enabled: true
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: TOWER_AI_BASE_URL
+        value: https://ai.platform.example.com
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: TOWER_AGENT_BACKEND_URL
+        value: https://ai-api.platform.example.com
+
+- it: should honour custom agentBackendDomain and portalWebDomain
+  template: deployment-backend.yaml
+  set:
+    global:
+      portalWebDomain: portal.example.com
+      agentBackendDomain: agent.example.com
+    portal-web:
+      enabled: true
+    agent-backend:
+      enabled: true
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: TOWER_AI_BASE_URL
+        value: https://portal.example.com
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: TOWER_AGENT_BACKEND_URL
+        value: https://agent.example.com
+
+- it: should not set AI/agent-backend URLs when subcharts are disabled
+  template: deployment-backend.yaml
+  set:
+    portal-web:
+      enabled: false
+    agent-backend:
+      enabled: false
+  asserts:
+  - notContains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: TOWER_AI_BASE_URL
+        value: https://ai.example.com
+  - notContains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: TOWER_AGENT_BACKEND_URL
+        value: https://ai-api.example.com
+
+- it: should set only TOWER_AI_BASE_URL when only portal-web is enabled
+  template: deployment-backend.yaml
+  set:
+    global:
+      platformExternalDomain: platform.example.com
+    portal-web:
+      enabled: true
+    agent-backend:
+      enabled: false
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: TOWER_AI_BASE_URL
+        value: https://ai.platform.example.com
+  - notContains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: TOWER_AGENT_BACKEND_URL
+        value: https://ai-api.platform.example.com
 
 - it: should render initContainers that wait for required services to be ready
   template: deployment-backend.yaml

--- a/charts/platform/tests/ingress_test.yaml
+++ b/charts/platform/tests/ingress_test.yaml
@@ -501,6 +501,27 @@ tests:
   - equal:
       path: spec.rules[1].http.paths[0].backend.service.port.number
       value: 6666
+
+- it: should use portName instead of portNumber in extraHosts
+  set:
+    ingress:
+      enabled: true
+      extraHosts:
+      - host: redirect.example.com
+        paths:
+        - path: /*
+          serviceName: redirect-to-service
+          portName: use-annotation
+    global:
+      platformExternalDomain: platform.example.com
+      contentDomain: ""
+  asserts:
+  - equal:
+      path: spec.rules[1].http.paths[0].backend.service
+      value:
+        name: redirect-to-service
+        port:
+          name: use-annotation
 - it: should handle multiple extraHosts with different portNumber types
   set:
     ingress:

--- a/charts/platform/values.schema.json
+++ b/charts/platform/values.schema.json
@@ -691,7 +691,7 @@
               "type": "boolean"
             },
             "extraHosts": {
-              "description": "Additional hosts you want to include. Evaluated as a template",
+              "description": "Additional hosts you want to include. Evaluated as a template.\nEach path's backend takes either `portNumber` or `portName` (e.g. `use-annotation`\nto reference an ALB action defined via `ingress.annotations`).",
               "items": {
                 "required": []
               },
@@ -3665,7 +3665,7 @@
           "type": "boolean"
         },
         "extraHosts": {
-          "description": "Additional hosts you want to include. Evaluated as a template",
+          "description": "Additional hosts you want to include. Evaluated as a template.\nEach path's backend takes either `portNumber` or `portName` (e.g. `use-annotation`\nto reference an ALB action defined via `ingress.annotations`).",
           "items": {
             "required": []
           },
@@ -4627,7 +4627,7 @@
               "type": "boolean"
             },
             "extraHosts": {
-              "description": "Additional hosts you want to include. Evaluated as a template",
+              "description": "Additional hosts you want to include. Evaluated as a template.\nEach path's backend takes either `portNumber` or `portName` (e.g. `use-annotation`\nto reference an ALB action defined via `ingress.annotations`).",
               "items": {
                 "required": []
               },
@@ -7200,7 +7200,7 @@
               "type": "boolean"
             },
             "extraHosts": {
-              "description": "Additional hosts you want to include. Evaluated as a template",
+              "description": "Additional hosts you want to include. Evaluated as a template.\nEach path's backend takes either `portNumber` or `portName` (e.g. `use-annotation`\nto reference an ALB action defined via `ingress.annotations`).",
               "items": {
                 "required": []
               },
@@ -7931,7 +7931,7 @@
               "type": "boolean"
             },
             "extraHosts": {
-              "description": "Additional hosts you want to include. Evaluated as a template",
+              "description": "Additional hosts you want to include. Evaluated as a template.\nEach path's backend takes either `portNumber` or `portName` (e.g. `use-annotation`\nto reference an ALB action defined via `ingress.annotations`).",
               "items": {
                 "required": []
               },
@@ -9306,7 +9306,7 @@
               "type": "boolean"
             },
             "extraHosts": {
-              "description": "Additional hosts you want to include. Evaluated as a template",
+              "description": "Additional hosts you want to include. Evaluated as a template.\nEach path's backend takes either `portNumber` or `portName` (e.g. `use-annotation`\nto reference an ALB action defined via `ingress.annotations`).",
               "items": {
                 "required": []
               },

--- a/charts/platform/values.schema.json
+++ b/charts/platform/values.schema.json
@@ -8917,7 +8917,7 @@
       "type": "object"
     },
     "wave": {
-      "description": "Wave",
+      "description": "On-demand containers provisioning service",
       "properties": {
         "_empty": {
           "default": "value",

--- a/charts/platform/values.yaml
+++ b/charts/platform/values.yaml
@@ -1623,7 +1623,9 @@ ingress:
   #     port:
   #       number: '{{ .Values.frontend.service.http.port }}'
 
-  # -- Additional hosts you want to include. Evaluated as a template
+  # -- Additional hosts you want to include. Evaluated as a template.
+  # Each path's backend takes either `portNumber` or `portName` (e.g. `use-annotation`
+  # to reference an ALB action defined via `ingress.annotations`).
   # @section -- Ingress
   extraHosts: []
   # extraHosts:
@@ -1639,6 +1641,15 @@ ingress:
   #         pathType: Prefix  # Optional, defaults to defaultPathType
   #         serviceName: '{{ printf "%s-frontend" (include "common.names.fullname" .) }}'
   #         portNumber: '{{ .Values.frontend.service.http.port }}'
+  #   # Redirect an alternate host to the canonical domain via an ALB redirect action.
+  #   # Requires a matching action under ingress.annotations, for example:
+  #   #   alb.ingress.kubernetes.io/actions.redirect-to-service: >
+  #   #     {"Type":"redirect","RedirectConfig":{"Protocol":"HTTPS","Host":"{{ tpl .Values.global.platformExternalDomain . }}","Port":"443","Path":"/#{path}","Query":"#{query}","StatusCode":"HTTP_301"}}
+  #   - host: alternatedomain.example.com
+  #     paths:
+  #       - path: /*
+  #         serviceName: redirect-to-service   # must match the actions.<name> annotation
+  #         portName: use-annotation
 
   # -- Ingress annotations specific to your load balancer. Evaluated as a template
   # @section -- Ingress


### PR DESCRIPTION
## What changed
Support `portName` in ingress extraHosts across all platform charts

```yaml
port:
  {{- if .portName }}
  name: {{ tpl .portName $ | quote }}
  {{- else }}
  number: {{ tpl (toString .portNumber) $ | int }}
  {{- end }}
```

## Why - motivation

After changing the portal-web domain to `ai.cloud.dev-seqera.io`, we want to add a redirect so the previous domain `ai.dev-seqera.io` redirects to the new domain.

To wire AWS Load Balancer Controller **annotation-based actions** (e.g. redirects, fixed-responses) onto the chart-managed ingress, the backend must reference the action via a named port `use-annotation` — the controller keys on that string to treat the backend as an action instead of a real Service/target group. The template previously only emitted `port.number`, so this wasn't expressible without dropping a raw `Ingress` into `extraDeploy`.

Example use (redirect an old host to the canonical domain):

```yaml
ingress:
  annotations:
    alb.ingress.kubernetes.io/actions.redirect-to-cloud: >
      {"Type":"redirect","RedirectConfig":{"Protocol":"HTTPS","Host":"ai.cloud.dev-seqera.io","Port":"443","Path":"/#{path}","Query":"#{query}","StatusCode":"HTTP_301"}}
  extraHosts:
    - host: ai.dev-seqera.io
      paths:
        - path: /*
          serviceName: redirect-to-cloud   # matches actions.<name>
          portName: use-annotation
```