### PR TITLE
fix: Fix WAVE_SERVER_URL env var in wave chart to use proper wave domain

### DIFF
--- a/charts/platform/CHANGELOG.md
+++ b/charts/platform/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bumped the `wave` subchart dependency to `0.6.x`, which fixes `WAVE_SERVER_URL` to be derived from
   `global.waveDomain` instead of `global.platformExternalDomain`, so it points at the Wave subdomain
   used for container pulls.
+- Picked up the `wave` subchart fix for the Redis password Secret key, which now defaults to
+  `REDIS_PASSWORD` (matching the chart-managed Secret) instead of `WAVE_REDIS_PASSWORD`; previously
+  setting `redis.password` inline caused the Wave pod to fail to start with
+  `CreateContainerConfigError`.
 
 ## [0.37.0] - 2026-07-17
 

--- a/charts/platform/CHANGELOG.md
+++ b/charts/platform/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `portal-web` subchart is enabled, and `TOWER_AGENT_BACKEND_URL` (to
   `https://<global.agentBackendDomain>`) when the `agent-backend` subchart is enabled.
 
+### Fixed
+
+- Bumped the `wave` subchart dependency to `0.6.x`, which fixes `WAVE_SERVER_URL` to be derived from
+  `global.waveDomain` instead of `global.platformExternalDomain`, so it points at the Wave subdomain
+  used for container pulls.
+
 ## [0.37.0] - 2026-07-17
 
 ### Added

--- a/charts/platform/Chart.lock
+++ b/charts/platform/Chart.lock
@@ -13,7 +13,7 @@ dependencies:
   version: 1.7.0
 - name: wave
   repository: file://charts/wave
-  version: 0.5.0
+  version: 0.6.0
 - name: mcp
   repository: file://charts/mcp
   version: 0.7.0
@@ -23,5 +23,5 @@ dependencies:
 - name: portal-web
   repository: file://charts/portal-web
   version: 0.6.0
-digest: sha256:c5e2d2fdf3dead48a2185dac462343774b44157b15beab47564562cb42d21b1d
-generated: "2026-07-17T18:33:04.245313+02:00"
+digest: sha256:f2b5d3fa81e3cc87cdae278b7438356b2737d28f526224cca083a705907b2b84
+generated: "2026-07-20T13:17:07.132824151+02:00"

--- a/charts/platform/Chart.yaml
+++ b/charts/platform/Chart.yaml
@@ -81,7 +81,7 @@ dependencies:
       - studios
     condition: studios.enabled
   - name: wave
-    version: "0.5.x"
+    version: "0.6.x"
     repository: "file://charts/wave"
     tags:
       - wave

--- a/charts/platform/README.md
+++ b/charts/platform/README.md
@@ -96,7 +96,7 @@ When upgrading between versions, please refer to the [CHANGELOG.md](CHANGELOG.md
 | file://charts/pipeline-optimization | pipeline-optimization | 2.x.x |
 | file://charts/portal-web | portal-web | 0.6.x |
 | file://charts/studios | studios | 1.x.x |
-| file://charts/wave | wave | 0.5.x |
+| file://charts/wave | wave | 0.6.x |
 | oci://registry-1.docker.io/bitnamicharts | common | 2.x.x |
 
 ## Values

--- a/charts/platform/charts/wave/CHANGELOG.md
+++ b/charts/platform/charts/wave/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `WAVE_SERVER_URL` in the ConfigMap is now derived from `global.waveDomain` instead of
   `global.platformExternalDomain`, so it points at the Wave subdomain (for example
   `https://wave.<platformExternalDomain>`) used for container pulls.
+- The Redis password Secret key now defaults to `REDIS_PASSWORD` (matching the key the chart's
+  Secret writes and the documented default for `redis.existingSecretKey`) instead of
+  `WAVE_REDIS_PASSWORD`. Previously the deployment's `secretKeyRef` pointed at `WAVE_REDIS_PASSWORD`
+  while the chart-managed Secret stored the value under `REDIS_PASSWORD`, so setting
+  `redis.password` inline caused the pod to fail to start with `CreateContainerConfigError`.
 
 ## [0.5.0] - 2026-07-17
 

--- a/charts/platform/charts/wave/CHANGELOG.md
+++ b/charts/platform/charts/wave/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2026-07-20
+
+### Fixed
+
+- `WAVE_SERVER_URL` in the ConfigMap is now derived from `global.waveDomain` instead of
+  `global.platformExternalDomain`, so it points at the Wave subdomain (for example
+  `https://wave.<platformExternalDomain>`) used for container pulls.
+
 ## [0.5.0] - 2026-07-17
 
 ### Added

--- a/charts/platform/charts/wave/Chart.yaml
+++ b/charts/platform/charts/wave/Chart.yaml
@@ -19,7 +19,7 @@ apiVersion: v2
 name: wave
 description: Wave
 type: application
-version: 0.5.0
+version: 0.6.0
 appVersion: "v1.35.0"
 icon: https://raw.githubusercontent.com/seqeralabs/helm-charts/master/media/seqera-icon-light.svg
 maintainers:

--- a/charts/platform/charts/wave/README.md
+++ b/charts/platform/charts/wave/README.md
@@ -2,7 +2,7 @@
 
 Wave
 
-![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.35.0](https://img.shields.io/badge/AppVersion-v1.35.0-informational?style=flat-square)
+![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.35.0](https://img.shields.io/badge/AppVersion-v1.35.0-informational?style=flat-square)
 
 Some basic familiarity with Helm is assumed. If you are new to Helm, please refer to the [Helm documentation](https://helm.sh/docs/).
 We recommend reading through the `values.yaml` file to understand the configuration options available for the chart. Each entry is documented with `# --` comments describing its purpose and usage. Other annotations are used to automatically generate the README files and can be ignored:
@@ -39,13 +39,13 @@ To install the chart:
 
 1. Download the default values file:
    ```console
-   helm show values oci://public.cr.seqera.io/charts/wave --version 0.5.0 > values.yaml
+   helm show values oci://public.cr.seqera.io/charts/wave --version 0.6.0 > values.yaml
    ```
 2. Edit `values.yaml` to match your environment. We recommend removing entries whose defaults you don't need to override — this keeps your configuration file focused and easier to maintain across upgrades.
 3. Install the chart with the release name `my-release`:
    ```console
    helm install my-release oci://public.cr.seqera.io/charts/wave \
-     --version 0.5.0 \
+     --version 0.6.0 \
      --namespace my-namespace \
      --create-namespace \
      -f values.yaml
@@ -61,7 +61,7 @@ Charts are also published to a traditional Helm repository. This can be useful i
 helm repo add seqeralabs https://seqeralabs.github.io/helm-charts
 helm repo update
 helm install my-release seqeralabs/wave \
-  --version 0.5.0 \
+  --version 0.6.0 \
   --namespace my-namespace \
   --create-namespace \
   -f values.yaml

--- a/charts/platform/charts/wave/templates/_helpers.tpl
+++ b/charts/platform/charts/wave/templates/_helpers.tpl
@@ -91,9 +91,9 @@ Build the Wave micronaut envs list: always ensure required environments are pres
 
 {{- define "wave.redis.existingSecret.secretKey" -}}
   {{- if (include "wave.redis.existingSecret" .) -}}
-    {{- printf "%s" (tpl .Values.redis.existingSecretKey .) | default "WAVE_REDIS_PASSWORD" -}}
+    {{- printf "%s" (tpl .Values.redis.existingSecretKey .) | default "REDIS_PASSWORD" -}}
   {{- else -}}
-    {{- printf "WAVE_REDIS_PASSWORD" -}}
+    {{- printf "REDIS_PASSWORD" -}}
   {{- end -}}
 {{- end -}}
 

--- a/charts/platform/charts/wave/templates/configmap.yaml
+++ b/charts/platform/charts/wave/templates/configmap.yaml
@@ -33,7 +33,7 @@ data:
   MICRONAUT_ENVIRONMENTS: {{ include "wave.micronautEnvs" . }}
   MICRONAUT_SERVER_PORT: {{ .Values.service.http.targetPort | quote }}
   TOWER_ENDPOINT_URL: '{{ printf "https://%s/api" .Values.global.platformExternalDomain | quote }}'
-  WAVE_SERVER_URL: {{ printf "https://%s" (tpl .Values.global.platformExternalDomain $) | quote }}
+  WAVE_SERVER_URL: {{ printf "https://%s" (tpl .Values.global.waveDomain $) | quote }}
 
   REDIS_URI: {{ include "wave.redis.uri" . | quote }}
   WAVE_DB_USER: {{ .Values.database.username | quote }}

--- a/charts/platform/charts/wave/tests/__snapshot__/configmap_test.yaml.snap
+++ b/charts/platform/charts/wave/tests/__snapshot__/configmap_test.yaml.snap
@@ -8,7 +8,7 @@ should render a ConfigMap with default values:
       TOWER_ENDPOINT_URL: '"https://example.com/api"'
       WAVE_DB_URI: jdbc:postgresql://db.example.com:5432/wavedb
       WAVE_DB_USER: waveuser
-      WAVE_SERVER_URL: https://example.com
+      WAVE_SERVER_URL: https://wave.example.com
     kind: ConfigMap
     metadata:
       annotations: {}

--- a/charts/platform/charts/wave/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/platform/charts/wave/tests/__snapshot__/deployment_test.yaml.snap
@@ -21,7 +21,7 @@ should render a Deployment with default values:
       template:
         metadata:
           annotations:
-            checksum/configmap: 253619a7171c2e26b76c97806e3bf7d1d826296faf074fe4a09a23f12d4b36f9
+            checksum/configmap: a3c4f3a56806ec40da3e4d11c9c13e1bb70d72758deac63d90d25a91bed4c4ff
             checksum/secret: d612594cf83ec8761d401b8770dc0f1773a5465202c0190a5bd356068e945bea
           labels:
             app.kubernetes.io/component: wave

--- a/charts/platform/charts/wave/tests/configmap_test.yaml
+++ b/charts/platform/charts/wave/tests/configmap_test.yaml
@@ -69,16 +69,16 @@ tests:
           path: data['TOWER_ENDPOINT_URL']
           value: '"https://prod.example.com/api"'
 
-  - it: should contain Wave server URL
+  - it: should contain Wave server URL derived from global.waveDomain
     set:
-      global.platformExternalDomain: prod.example.com
+      global.waveDomain: wave.prod.example.com
       database.host: db.example.com
       database.name: wavedb
       database.username: waveuser
     asserts:
       - equal:
           path: data.WAVE_SERVER_URL
-          value: "https://prod.example.com"
+          value: "https://wave.prod.example.com"
 
   - it: should contain Redis URI with default values
     set:

--- a/charts/platform/charts/wave/tests/deployment_test.yaml
+++ b/charts/platform/charts/wave/tests/deployment_test.yaml
@@ -360,7 +360,7 @@ tests:
             valueFrom:
               secretKeyRef:
                 name: release-name-wave
-                key: WAVE_REDIS_PASSWORD
+                key: REDIS_PASSWORD
 
   - it: should NOT include REDIS_PASSWORD in env when redis.password is not set
     template: deployment.yaml
@@ -413,7 +413,7 @@ tests:
             valueFrom:
               secretKeyRef:
                 name: my-redis-secret
-                key: WAVE_REDIS_PASSWORD
+                key: REDIS_PASSWORD
 
   - it: should render extraOptionsSpec under spec
     template: deployment.yaml


### PR DESCRIPTION
The wave server url env var `WAVE_SERVER_URL` in the wave chart configmap was pointing to the platform domain instead of wave own's domain. In the ingress we already use the correct domain.