### PR TITLE
fix: Fix redis password env var naming

### DIFF
--- a/charts/platform/CHANGELOG.md
+++ b/charts/platform/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bumped the `wave` subchart dependency to `0.6.x`, which fixes `WAVE_SERVER_URL` to be derived from
   `global.waveDomain` instead of `global.platformExternalDomain`, so it points at the Wave subdomain
   used for container pulls.
+- Picked up the `wave` subchart fix for the Redis password Secret key, which now defaults to
+  `REDIS_PASSWORD` (matching the chart-managed Secret) instead of `WAVE_REDIS_PASSWORD`; previously
+  setting `redis.password` inline caused the Wave pod to fail to start with
+  `CreateContainerConfigError`.
 
 ## [0.37.0] - 2026-07-17
 

--- a/charts/platform/charts/wave/CHANGELOG.md
+++ b/charts/platform/charts/wave/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `WAVE_SERVER_URL` in the ConfigMap is now derived from `global.waveDomain` instead of
   `global.platformExternalDomain`, so it points at the Wave subdomain (for example
   `https://wave.<platformExternalDomain>`) used for container pulls.
+- The Redis password Secret key now defaults to `REDIS_PASSWORD` (matching the key the chart's
+  Secret writes and the documented default for `redis.existingSecretKey`) instead of
+  `WAVE_REDIS_PASSWORD`. Previously the deployment's `secretKeyRef` pointed at `WAVE_REDIS_PASSWORD`
+  while the chart-managed Secret stored the value under `REDIS_PASSWORD`, so setting
+  `redis.password` inline caused the pod to fail to start with `CreateContainerConfigError`.
 
 ## [0.5.0] - 2026-07-17
 

--- a/charts/platform/charts/wave/templates/_helpers.tpl
+++ b/charts/platform/charts/wave/templates/_helpers.tpl
@@ -91,9 +91,9 @@ Build the Wave micronaut envs list: always ensure required environments are pres
 
 {{- define "wave.redis.existingSecret.secretKey" -}}
   {{- if (include "wave.redis.existingSecret" .) -}}
-    {{- printf "%s" (tpl .Values.redis.existingSecretKey .) | default "WAVE_REDIS_PASSWORD" -}}
+    {{- printf "%s" (tpl .Values.redis.existingSecretKey .) | default "REDIS_PASSWORD" -}}
   {{- else -}}
-    {{- printf "WAVE_REDIS_PASSWORD" -}}
+    {{- printf "REDIS_PASSWORD" -}}
   {{- end -}}
 {{- end -}}
 

--- a/charts/platform/charts/wave/tests/deployment_test.yaml
+++ b/charts/platform/charts/wave/tests/deployment_test.yaml
@@ -360,7 +360,7 @@ tests:
             valueFrom:
               secretKeyRef:
                 name: release-name-wave
-                key: WAVE_REDIS_PASSWORD
+                key: REDIS_PASSWORD
 
   - it: should NOT include REDIS_PASSWORD in env when redis.password is not set
     template: deployment.yaml
@@ -413,7 +413,7 @@ tests:
             valueFrom:
               secretKeyRef:
                 name: my-redis-secret
-                key: WAVE_REDIS_PASSWORD
+                key: REDIS_PASSWORD
 
   - it: should render extraOptionsSpec under spec
     template: deployment.yaml


### PR DESCRIPTION
The wave redis password env var was incorrectly defined as `WAVE_REDIS_PASSWORD` instead of `REDIS_PASSWORD` in some locations such as the wave chart helper script.